### PR TITLE
Zmqstream

### DIFF
--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -18,7 +18,7 @@
 import logging
 
 import zmq
-from zmq.core.socket import json, pickle, to_json
+from zmq.core.socket import json, pickle
 
 import ioloop
 try:
@@ -212,7 +212,7 @@ class ZMQStream(object):
         if json is None:
             raise ImportError('cjson, json or simplejson library is required.')
         else:
-            msg = to_json(obj)
+            msg = json.dumps(obj)
             return self.send(msg, flags=flags, callback=callback)
 
     def send_pyobj(self, obj, flags=0, protocol=-1, callback=None):


### PR DESCRIPTION
ZMQStream now provides complete socket interface, excluding recv methods and direct socket properties.

included:
all send_*
all bind*/connect
all get/setsockopt

excluded:
recv_*
socket_type (should this be included?)
context

Also included: socket.close() inside stream.close() is now a DelayedCallback, preventing it from blocking iostream's logging, at least for the error that caused stream.close() to be called.
