### PR TITLE
call signature in docstrings for Cython methods

### DIFF
--- a/zmq/core/context.pyx
+++ b/zmq/core/context.pyx
@@ -35,7 +35,9 @@ from constants import *
 
 
 cdef class Context:
-    """Manage the lifecycle of a 0MQ context.
+    """Context(io_threads=1)
+
+    Manage the lifecycle of a 0MQ context.
 
     This class no longer takes any flags or the number of application
     threads.
@@ -63,7 +65,9 @@ cdef class Context:
                 raise ZMQError()
 
     def term(self):
-        """Close or terminate the context.
+        """ctx.term()
+
+        Close or terminate the context.
 
         This can be called to close the context by hand. If this is not
         called, the context will automatically be closed when it is
@@ -78,7 +82,9 @@ cdef class Context:
             self.closed = True
 
     def socket(self, int socket_type):
-        """Create a Socket associated with this Context.
+        """ctx.socket(socket_type)
+
+        Create a Socket associated with this Context.
 
         Parameters
         ----------

--- a/zmq/core/device.pyx
+++ b/zmq/core/device.pyx
@@ -31,7 +31,9 @@ from zmq.core.socket cimport Socket as cSocket
 #-----------------------------------------------------------------------------
 
 def device(int device_type, cSocket isocket, cSocket osocket):
-    """Start a zeromq device.
+    """device(device_type, isocket, osocket)
+
+    Start a zeromq device.
 
     Parameters
     ----------

--- a/zmq/core/error.pyx
+++ b/zmq/core/error.pyx
@@ -26,7 +26,10 @@
 from czmq cimport zmq_strerror, zmq_errno
 
 def strerror(errnum):
-    """Return the error string given the error number."""
+    """strerror(errnum)
+
+    Return the error string given the error number.
+    """
     return zmq_strerror(errnum)
 
 

--- a/zmq/core/poll.pyx
+++ b/zmq/core/poll.pyx
@@ -35,7 +35,9 @@ from zmq.core.constants import POLLIN,POLLOUT, POLLERR
 #-----------------------------------------------------------------------------
 
 def _poll(sockets, long timeout=-1):
-    """Poll a set of 0MQ sockets, native file descs. or sockets.
+    """_poll(sockets, timeout=-1)
+
+    Poll a set of 0MQ sockets, native file descs. or sockets.
 
     Parameters
     ----------
@@ -103,13 +105,18 @@ def _poll(sockets, long timeout=-1):
 
 
 class Poller(object):
-    """An stateful poll interface that mirrors Python's built-in poll."""
+    """Poller()
+
+    A stateful poll interface that mirrors Python's built-in poll.
+    """
 
     def __init__(self):
         self.sockets = {}
 
     def register(self, socket, flags=POLLIN|POLLOUT):
-        """Register a 0MQ socket or native fd for I/O monitoring.
+        """p.register(socket, flags=POLLIN|POLLOUT)
+
+        Register a 0MQ socket or native fd for I/O monitoring.
 
         Parameters
         ----------
@@ -122,11 +129,16 @@ class Poller(object):
         self.sockets[socket] = flags
 
     def modify(self, socket, flags=POLLIN|POLLOUT):
-        """Modify the flags for an already registered 0MQ socket or native fd."""
+        """p.modify(socket, flags=POLLIN|POLLOUT)
+
+        Modify the flags for an already registered 0MQ socket or native fd.
+        """
         self.register(socket, flags)
 
     def unregister(self, socket):
-        """Remove a 0MQ socket or native fd for I/O monitoring.
+        """p.unregister(socket)
+
+        Remove a 0MQ socket or native fd for I/O monitoring.
 
         Parameters
         ----------
@@ -136,7 +148,9 @@ class Poller(object):
         del self.sockets[socket]
 
     def poll(self, timeout=None):
-        """Poll the registered 0MQ or native fds for I/O.
+        """p.poll(timeout=None)
+
+        Poll the registered 0MQ or native fds for I/O.
 
         Parameters
         ----------
@@ -156,7 +170,9 @@ class Poller(object):
 
 
 def select(rlist, wlist, xlist, timeout=None):
-    """Return the result of poll as a lists of sockets ready for r/w.
+    """select(rlist, wlist, xlist, timeout=None) -> (rlist, wlist, xlist)
+
+    Return the result of poll as a lists of sockets ready for r/w/exception.
 
     This has the same interface as Python's built-in :func:`select` function.
 

--- a/zmq/core/socket.pyx
+++ b/zmq/core/socket.pyx
@@ -72,9 +72,9 @@ from zmq.core.error import ZMQError, ZMQBindError
 
 
 cdef class Socket:
-    """A 0MQ socket.
+    """Socket(context, socket_type)
 
-    Socket(context, socket_type)
+    A 0MQ socket.
 
     Parameters
     ----------
@@ -98,7 +98,9 @@ cdef class Socket:
         self.close()
 
     def close(self):
-        """Close the socket.
+        """s.close()
+
+        Close the socket.
 
         This can be called to close the socket by hand. If this is not
         called, the socket will automatically be closed when it is
@@ -117,7 +119,9 @@ cdef class Socket:
             raise ZMQError(ENOTSUP)
 
     def setsockopt(self, int option, optval):
-        """Set socket options.
+        """s.setsockopt(option, optval)
+
+        Set socket options.
 
         See the 0MQ documentation for details on specific options.
 
@@ -160,7 +164,9 @@ cdef class Socket:
             raise ZMQError()
 
     def getsockopt(self, int option):
-        """Get the value of a socket option.
+        """s.getsockopt(option)
+
+        Get the value of a socket option.
 
         See the 0MQ documentation for details on specific options.
 
@@ -201,7 +207,9 @@ cdef class Socket:
         return result
     
     def setsockopt_unicode(self, int option, optval, encoding='utf-8'):
-        """Set socket options with a unicode object it is simply a wrapper 
+        """s.setsockopt_unicode(option, optval, encoding='utf-8')
+
+        Set socket options with a unicode object it is simply a wrapper
         for setsockopt to protect from encoding ambiguity.
 
         See the 0MQ documentation for details on specific options.
@@ -220,8 +228,10 @@ cdef class Socket:
             raise TypeError("unicode strings only")
         return self.setsockopt(option, optval.encode(encoding))
     
-    def getsockopt_unicode(self, int option,encoding='utf-8'):
-        """Get the value of a socket option.
+    def getsockopt_unicode(self, int option, encoding='utf-8'):
+        """s.getsockopt_unicode(option, encoding='utf-8')
+
+        Get the value of a socket option.
 
         See the 0MQ documentation for details on specific options.
 
@@ -241,7 +251,9 @@ cdef class Socket:
         return self.getsockopt(option).decode(encoding)
     
     def bind(self, addr):
-        """Bind the socket to an address.
+        """s.bind(addr)
+
+        Bind the socket to an address.
 
         This causes the socket to listen on a network port. Sockets on the
         other side of this connection will use :meth:`Sockiet.connect` to
@@ -267,7 +279,9 @@ cdef class Socket:
             raise ZMQError()
 
     def bind_to_random_port(self, addr, min_port=2000, max_port=20000, max_tries=100):
-        """Bind this socket to a random port in a range.
+        """s.bind_to_random_port(addr, min_port=2000, max_port=20000, max_tries=100)
+
+        Bind this socket to a random port in a range.
 
         Parameters
         ----------
@@ -296,7 +310,9 @@ cdef class Socket:
         raise ZMQBindError("Could not bind socket to random port.")
 
     def connect(self, addr):
-        """Connect to a remote 0MQ socket.
+        """s.connect(addr)
+
+        Connect to a remote 0MQ socket.
 
         Parameters
         ----------
@@ -321,8 +337,10 @@ cdef class Socket:
     # Sending and receiving messages
     #-------------------------------------------------------------------------
 
-    def send(self, object data, int flags=0, bool copy=True):
-        """Send a message on this socket.
+    def send(self, object data, int flags=0, copy=True):
+        """s.send(data, flags=0, copy=True)
+
+        Send a message on this socket.
 
         This queues the message to be sent by the IO thread at a later time.
 
@@ -406,7 +424,9 @@ cdef class Socket:
             raise ZMQError()
     
     def recv(self, int flags=0, copy=True):
-        """Receive a message.
+        """s.recv(flags=0, copy=True)
+
+        Receive a message.
 
         Parameters
         ----------
@@ -446,7 +466,9 @@ cdef class Socket:
         return msg
 
     def send_multipart(self, msg_parts, int flags=0, copy=True):
-        """Send a sequence of messages as a multipart message.
+        """s.send_multipart(msg_parts, flags=0, copy=True)
+
+        Send a sequence of messages as a multipart message.
 
         Parameters
         ----------
@@ -462,7 +484,9 @@ cdef class Socket:
         return self.send(msg_parts[-1], flags, copy=copy)
 
     def recv_multipart(self, int flags=0, copy=True):
-        """Receive a multipart message as a list of messages.
+        """s.recv_multipart(flags=0, copy=True)
+
+        Receive a multipart message as a list of messages.
 
         Parameters
         ----------
@@ -487,12 +511,17 @@ cdef class Socket:
         return parts
 
     def rcvmore(self):
-        """Are there more parts to a multipart message."""
+        """s.rcvmore()
+
+        Are there more parts to a multipart message.
+        """
         more = self.getsockopt(RCVMORE)
         return bool(more)
 
     def send_unicode(self, u, int flags=0, copy=False, encoding='utf-8'):
-        """Send a Python unicode object as a message with an encoding.
+        """s.send_unicode(u, flags=0, copy=False, encoding='utf-8')
+
+        Send a Python unicode object as a message with an encoding.
 
         Parameters
         ----------
@@ -507,8 +536,10 @@ cdef class Socket:
             raise TypeError("unicode/str objects only")
         return self.send(u.encode(encoding), flags=flags, copy=copy)
     
-    def recv_unicode(self, int flags=0,encoding='utf-8'):
-        """Receive a unicode string, as sent by send_unicode.
+    def recv_unicode(self, int flags=0, encoding='utf-8'):
+        """s.recv_unicode(flags=0, encoding='utf-8')
+
+        Receive a unicode string, as sent by send_unicode.
         
         Parameters
         ----------
@@ -526,7 +557,9 @@ cdef class Socket:
         return codecs.decode(msg.buffer, encoding)
     
     def send_pyobj(self, obj, flags=0, protocol=-1):
-        """Send a Python object as a message using pickle to serialize.
+        """s.send_pyobj(obj, flags=0, protocol=-1)
+
+        Send a Python object as a message using pickle to serialize.
 
         Parameters
         ----------
@@ -543,7 +576,9 @@ cdef class Socket:
         return self.send(msg, flags)
 
     def recv_pyobj(self, flags=0):
-        """Receive a Python object as a message using pickle to serialize.
+        """s.recv_pyobj(flags=0)
+
+        Receive a Python object as a message using pickle to serialize.
 
         Parameters
         ----------
@@ -559,7 +594,9 @@ cdef class Socket:
         return pickle.loads(s)
 
     def send_json(self, obj, flags=0):
-        """Send a Python object as a message using json to serialize.
+        """s.send_json(obj, flags=0)
+
+        Send a Python object as a message using json to serialize.
 
         Parameters
         ----------
@@ -575,7 +612,9 @@ cdef class Socket:
             return self.send(msg, flags)
 
     def recv_json(self, flags=0):
-        """Receive a Python object as a message using json to serialize.
+        """s.recv_json(flags=0)
+
+        Receive a Python object as a message using json to serialize.
 
         Parameters
         ----------

--- a/zmq/core/stopwatch.pyx
+++ b/zmq/core/stopwatch.pyx
@@ -32,7 +32,9 @@ from zmq.core.error import ZMQError
 #-----------------------------------------------------------------------------
 
 cdef class Stopwatch:
-    """A simple stopwatch based on zmq_stopwatch_start/stop.
+    """Stopwatch()
+
+    A simple stopwatch based on zmq_stopwatch_start/stop.
 
     This class should be used for benchmarking and timing ØMQ code.
     """
@@ -47,14 +49,20 @@ cdef class Stopwatch:
             pass
 
     def start(self):
-        """Start the stopwatch."""
+        """s.start()
+
+        Start the stopwatch.
+        """
         if self.watch == NULL:
             self.watch = zmq_stopwatch_start()
         else:
             raise ZMQError('Stopwatch is already runing.')
 
     def stop(self):
-        """Stop the stopwatch."""
+        """s.stop()
+
+        Stop the stopwatch.
+        """
         if self.watch == NULL:
             raise ZMQError('Must start the Stopwatch before calling stop.')
         else:
@@ -63,7 +71,10 @@ cdef class Stopwatch:
             return time
 
     def sleep(self, int seconds):
-        """Sleep for a number of seconds."""
+        """s.sleep(seconds)
+
+        Sleep for a number of seconds.
+        """
         zmq_sleep(seconds)
 
 

--- a/zmq/core/version.pyx
+++ b/zmq/core/version.pyx
@@ -33,12 +33,18 @@ __version__ = '2.0.9dev'
 
 
 def pyzmq_version():
-    """Return the version of pyzmq."""
+    """pyzmq_version()
+
+    Return the version of pyzmq.
+    """
     return __version__
 
 
 def zmq_version():
-    """Return the version of ZeroMQ itself."""
+    """zmq_version()
+
+    Return the version of ZeroMQ itself.
+    """
     cdef int major, minor, patch
     _zmq_version(&major, &minor, &patch)
     return '%i.%i.%i' % (major, minor, patch)

--- a/zmq/devices/monitoredqueue.pyx
+++ b/zmq/devices/monitoredqueue.pyx
@@ -46,7 +46,10 @@ from zmq.core import XREP, ZMQError
 
 def monitored_queue(Socket in_socket, Socket out_socket, Socket mon_socket,
                     str in_prefix='in', str out_prefix='out'):
-    """Start a monitored queue device.
+    """monitored_queue(in_socket, out_socket, mon_socket,
+                       in_prefix='in', out_prefix='out')
+
+    Start a monitored queue device.
 
     A monitored queue behaves just like a zmq QUEUE device as far as in_socket
     and out_socket are concerned, except that all messages *also* go out on


### PR DESCRIPTION
Introspection doesn't work for methods defined in Cython, so the call signature of methods should be
at the top of docstrings, following the model of numpy.

This commit adds this feature to all public methods.
