### PR TITLE
Optimisation in socket.recv()

### DIFF
--- a/zmq/core/message.pxd
+++ b/zmq/core/message.pxd
@@ -50,5 +50,5 @@ cdef class Message:
 
     cdef Message fast_copy(self) # Create shallow copy of Message object.
     cdef object _getbuffer(self) # Construct self._buffer.
-    cdef object _copybytes(self) # Construct self._bytes.
 
+cdef object copy_zmq_msg_bytes(zmq_msg_t *zmq_msg) with gil

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -177,7 +177,7 @@ class TestMessage(BaseZMQTestCase):
             del s
     
     def test_tracker(self):
-        m = zmq.Message('asdf'.encode())
+        m = zmq.Message('asdf'.encode(), track=True)
         self.assertFalse(m.done)
         pm = zmq.MessageTracker(m)
         self.assertFalse(pm.done)
@@ -192,8 +192,8 @@ class TestMessage(BaseZMQTestCase):
         self.assertRaises(AttributeError, zmq.MessageTracker, m)
     
     def test_multi_tracker(self):
-        m = zmq.Message('asdf'.encode())
-        m2 = zmq.Message('whoda'.encode())
+        m = zmq.Message('asdf'.encode(), track=True)
+        m2 = zmq.Message('whoda'.encode(), track=True)
         mt = zmq.MessageTracker(m,m2)
         self.assertFalse(m.done)
         self.assertFalse(mt.done)

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -102,10 +102,10 @@ class TestSocket(BaseZMQTestCase):
         b = self.context.socket(zmq.XREP)
         self.sockets.extend([a,b])
         a.connect(iface)
-        p1 = a.send('something'.encode(), copy=False)
+        p1 = a.send('something'.encode(), copy=False, track=True)
         self.assert_(isinstance(p1, zmq.MessageTracker))
         self.assertFalse(p1.done)
-        p2 = a.send_multipart(list(map(str.encode, ['something', 'else'])), copy=False)
+        p2 = a.send_multipart(list(map(str.encode, ['something', 'else'])), copy=False, track=True)
         self.assert_(isinstance(p2, zmq.MessageTracker))
         self.assertEquals(p2.done, False)
         self.assertEquals(p1.done, False)
@@ -116,7 +116,7 @@ class TestSocket(BaseZMQTestCase):
         msg = b.recv_multipart()
         self.assertEquals(p2.done, True)
         self.assertEquals(msg, list(map(str.encode, ['a', 'something', 'else'])))
-        m = zmq.Message("again".encode())
+        m = zmq.Message("again".encode(), track=True)
         self.assertEquals(m.done, False)
         # print m.bytes
         p1 = a.send(m, copy=False)
@@ -138,7 +138,8 @@ class TestSocket(BaseZMQTestCase):
         # q.get()
         self.assertEquals(p1.done, True)
         self.assertEquals(p2.done, True)
-        
+        m = zmq.Message('something'.encode(), track=False)
+        self.assertRaises(AttributeError, a.send, m, copy=False, track=True)
         
 
     def test_close(self):


### PR DESCRIPTION
Currently the Message class is expensive to use, due to the MessageTracker which uses 3 Queue objects. This pulls in alot of stuff from threading. Passing a string into a copying send() operation will not create a Message object, but a recv() operation will always create a Message object. This change adds a "tracked" property to the Message class, and in the case of Socket.recv(copy=True), no tracking is done in the Message, which avoids the overhead of the Queues.

There are 2 other ways to achieve this, one (potentially simpler) one would be to implement a _recv_copy method in the Socket object, which wouldn't create a message object on recv(copy=True). The other is to subclass Message with a "TrackedMessage" class. The latter may well not be backwards compatible.

The performance difference is dramatic, a speedup of ~50% on a benchmark using recv_multipart calls to an XREP socket over a local interface.
