### PR TITLE
Use threading.Event instead of queue.Queue for tracking

### DIFF
--- a/zmq/core/message.pxd
+++ b/zmq/core/message.pxd
@@ -33,7 +33,7 @@ from czmq cimport zmq_msg_t
 cdef class MessageTracker(object):
     """A class for tracking if 0MQ is done using one or more messages."""
 
-    cdef set queues  # Message Queue objects to track.
+    cdef set events  # Message Event objects to track.
     cdef set peers   # Other Message or MessageTracker objects.
     
 
@@ -45,7 +45,7 @@ cdef class Message:
     cdef object _buffer    # A Python Buffer/View of the message contents
     cdef object _bytes     # A bytes/str copy of the message.
     cdef bool _failed_init # Flag to handle failed zmq_msg_init
-    cdef public object tracker_queue  # Queue for use with zmq_free_fn.
+    cdef public object tracker_event  # Event for use with zmq_free_fn.
     cdef public object tracker        # MessageTracker object.
 
     cdef Message fast_copy(self) # Create shallow copy of Message object.

--- a/zmq/core/socket.pyx
+++ b/zmq/core/socket.pyx
@@ -53,11 +53,6 @@ import random
 import struct
 import codecs
 
-try:    # 3.x
-    from queue import Queue, Empty
-except: # 2.x
-    from Queue import Queue, Empty
-
 from zmq.utils import jsonapi
 
 try:


### PR DESCRIPTION
This commit replaces Queues with Events for use in MessageTrackers.

The reason we used the Queue in the first place was that we thought we had to keep track of ØMQ's refcount on our buffers.  While figuring it out, we determined that we only need to track when the `free_fn` gets called, but we still used a Queue that only ever called put() once.  After recent discussion on an IPython Issue, I realized that the `threading.Event` object is much more appropriate for this case.

After tests, it appears that the initialization penalty that was the cause of making tracking optional is cut in half by using Events instead of Queues.

still passes all tests on 2.5 and 3.1.
