### PR TITLE
ZMQ_RECONNECT_IVL_MAX

### DIFF
--- a/zmq/core/constants.pyx
+++ b/zmq/core/constants.pyx
@@ -45,7 +45,7 @@ PUSH = ZMQ_PUSH
 UPSTREAM = ZMQ_UPSTREAM
 DOWNSTREAM = ZMQ_DOWNSTREAM
 # new in 2.1.1
-if ZMQ_XPUB != -1:
+if ZMQ_VERSION >= 20101:
     XPUB = ZMQ_XPUB
     XSUB = ZMQ_XSUB
     _optionals.extend(['XPUB','XSUB'])
@@ -78,7 +78,7 @@ int64_sockopts = [HWM, SWAP, AFFINITY, RATE, RECOVERY_IVL,
 int_sockopts = []
 
 # new sockopts in 2.1.0:
-if ZMQ_FD != -1:
+if ZMQ_VERSION >= 20100:
     FD = ZMQ_FD
     EVENTS = ZMQ_EVENTS
     TYPE = ZMQ_TYPE
@@ -89,11 +89,11 @@ if ZMQ_FD != -1:
     _optionals.extend('FD EVENTS TYPE LINGER RECONNECT_IVL BACKLOG'.split())
 
 # new in 2.1.1:
-if ZMQ_RECOVERY_IVL_MSEC != -1:
+if ZMQ_VERSION >= 20101:
     RECOVERY_IVL_MSEC = ZMQ_RECOVERY_IVL_MSEC
-    int64_sockopts.append(RECOVERY_IVL_MSEC)
-    _optionals.append('RECOVERY_IVL_MSEC')
-
+    RECONNECT_IVL_MAX = ZMQ_RECONNECT_IVL_MAX
+    int64_sockopts.extend([RECOVERY_IVL_MSEC, RECONNECT_IVL_MAX])
+    _optionals.extend('RECOVERY_IVL_MSEC RECONNECT_IVL_MAX'.split())
 
 #-----------------------------------------------------------------------------
 # Error handling

--- a/zmq/core/czmq.pxd
+++ b/zmq/core/czmq.pxd
@@ -45,6 +45,11 @@ cdef extern from "zmq.h" nogil:
 
     void _zmq_version "zmq_version"(int *major, int *minor, int *patch)
 
+    enum: ZMQ_VERSION_MAJOR
+    enum: ZMQ_VERSION_MINOR
+    enum: ZMQ_VERSION_PATCH
+    enum: ZMQ_VERSION
+    
     enum: ZMQ_HAUSNUMERO
     enum: ZMQ_ENOTSUP "ENOTSUP"
     enum: ZMQ_EPROTONOSUPPORT "EPROTONOSUPPORT"
@@ -123,6 +128,7 @@ cdef extern from "zmq.h" nogil:
     enum: ZMQ_RECONNECT_IVL # 18
     enum: ZMQ_BACKLOG # 19
     enum: ZMQ_RECOVERY_IVL_MSEC # 20
+    enum: ZMQ_RECONNECT_IVL_MAX # 20
 
     enum: ZMQ_NOBLOCK # 1
     enum: ZMQ_SNDMORE # 2

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -9,6 +9,7 @@
 #include "zmq.h"
 #define _missing (PyErr_SetString(PyExc_NotImplementedError, \
                 "Constant not available in current zeromq."), -1)
+// 2.1.0
 #ifndef ZMQ_FD
     #define ZMQ_FD (-1)
 #endif
@@ -27,6 +28,7 @@
 #ifndef ZMQ_BACKLOG
     #define ZMQ_BACKLOG (-1)
 #endif
+// 2.1.1
 #ifndef ZMQ_XPUB
     #define ZMQ_XPUB (-1)
 #endif
@@ -35,4 +37,7 @@
 #endif
 #ifndef ZMQ_RECOVERY_IVL_MSEC
     #define ZMQ_RECOVERY_IVL_MSEC (-1)
+#endif
+#ifndef ZMQ_RECONNECT_IVL_MAX
+    #define ZMQ_RECONNECT_IVL_MAX (-1)
 #endif


### PR DESCRIPTION
add newest constant, tweaked missing-constant behavior:

constants.pyx now checks ZMQ_VERSION, and includes all constants defined in the newest revision of that version.  The result is that pyzmq will have all constants defined for a given zeromq-x.y.z, but if your zeromq git branch is somewhat stale, then pyzmq may know about some newer constants than you have.  The result is that these constants will be defined, but their values will be `-1`.

This commit also adds ZMQ_VERSION\* to czmq.pxd
