### PR TITLE
buffer

### DIFF
--- a/zmq/core/message.pyx
+++ b/zmq/core/message.pyx
@@ -30,7 +30,7 @@ cdef extern from "pyversion_compat.h":
 from cpython cimport PyBytes_FromStringAndSize
 from cpython cimport Py_DECREF, Py_INCREF
 
-from buffers cimport asbuffer_r, frombuffer_r, viewfromobject_r
+from buffers cimport asbuffer_r, viewfromobject_r
 
 cdef extern from "Python.h":
     ctypedef int Py_ssize_t
@@ -272,9 +272,7 @@ cdef class Message:
     # buffer interface code adapted from petsc4py by Lisandro Dalcin, a BSD project
     
     def __getbuffer__(self, Py_buffer* buffer, int flags):
-        """newstyle (memoryview) interface"""
-        # cdef char *data_c = NULL
-        # cdef Py_ssize_t data_len_c
+        # new-style (memoryview) buffer interface
         with nogil:
             buffer.buf = zmq_msg_data(&self.zmq_msg)
             buffer.len = zmq_msg_size(&self.zmq_msg)
@@ -290,14 +288,14 @@ cdef class Message:
         buffer.internal = NULL
     
     def __getsegcount__(self, Py_ssize_t *lenp):
-        """required for getreadbuffer"""
+        # required for getreadbuffer
         if lenp != NULL:
             with nogil:
                 lenp[0] = zmq_msg_size(&self.zmq_msg)
         return 1
     
     def __getreadbuffer__(self, Py_ssize_t idx, void **p):
-        """oldstyle (buffer) interface"""
+        # old-style (buffer) interface
         cdef char *data_c = NULL
         cdef Py_ssize_t data_len_c
         if idx != 0:

--- a/zmq/core/socket.pyx
+++ b/zmq/core/socket.pyx
@@ -32,7 +32,7 @@ from cpython cimport PyBytes_FromStringAndSize
 from cpython cimport PyBytes_AsString, PyBytes_Size
 from cpython cimport Py_DECREF, Py_INCREF
 
-from buffers cimport asbuffer_r, frombuffer_r, viewfromobject_r
+from buffers cimport asbuffer_r, viewfromobject_r
 
 from czmq cimport *
 from message cimport Message, copy_zmq_msg_bytes

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -286,7 +286,7 @@ class TestMessage(BaseZMQTestCase):
     
     def test_noncopying_recv(self):
         """check for clobbering message buffers"""
-        null = b'\0'*64
+        null = asbytes('\0'*64)
         sa,sb = self.create_bound_pair(zmq.PAIR, zmq.PAIR)
         for i in range(32):
             # try a few times
@@ -297,10 +297,14 @@ class TestMessage(BaseZMQTestCase):
             buf = m.buffer
             del m
             for i in range(5):
-                ff='\xff'*(40 + i*10)
+                ff=asbytes('\xff'*(40 + i*10))
                 sb.send(ff, copy=False)
                 m2 = sa.recv(copy=False)
-                self.assertEquals(bytes(buf), null)
+                if view.__name__ == 'buffer':
+                    b = bytes(buf)
+                else:
+                    b = buf.tobytes()
+                self.assertEquals(b, null)
                 self.assertEquals(mb, null)
                 self.assertEquals(m2.bytes, ff)
 


### PR DESCRIPTION
- Messages now provide (both) buffer interfaces
- Fix an issue where buffers created by zmq (recv(copy=False)) could be deallocated prematurely, as in:
  
    msg = s.recv(copy=False)
    buf = msg.buffer
    del msg # dealloc

messages received later may overwrite `buf`.

Test included and passed
