### PR TITLE
Context tracks its own sockets

### DIFF
--- a/zmq/core/context.pxd
+++ b/zmq/core/context.pxd
@@ -28,5 +28,6 @@ cdef class Context:
     """Manage the lifecycle of a 0MQ context."""
 
     cdef void *handle         # The C handle for the underlying zmq object.
-    cdef public object closed # bool property for a closed context.
+    cdef readonly object closed # bool property for a closed context.
+    cdef public set _sockets # collection of sockets created by this context
 

--- a/zmq/core/socket.pxd
+++ b/zmq/core/socket.pxd
@@ -34,11 +34,11 @@ cdef class Socket:
     """A 0MQ socket."""
 
     cdef void *handle           # The C handle for the underlying zmq object.
-    cdef public int socket_type # The 0MQ socket type - REQ,REP, etc.
+    cdef readonly int socket_type # The 0MQ socket type - REQ,REP, etc.
     # Hold on to a reference to the context to make sure it is not garbage
     # collected until the socket it done with it.
-    cdef public object context # The zmq Context object that owns this.
-    cdef public object closed   # bool property for a closed socket.
+    cdef readonly object context # The zmq Context object that owns this.
+    cdef readonly object closed   # bool property for a closed socket.
 
     # cpdef methods for direct-cython access:
     cpdef object send(self, object data, int flags=*, copy=*, track=*)

--- a/zmq/core/socket.pyx
+++ b/zmq/core/socket.pyx
@@ -181,6 +181,7 @@ cdef class Socket:
         if self.handle == NULL:
             raise ZMQError()
         self.closed = False
+        context._sockets.add(self)
 
     def __dealloc__(self):
         self.close()
@@ -202,6 +203,8 @@ cdef class Socket:
                 raise ZMQError()
             self.handle = NULL
             self.closed = True
+            if self in self.context._sockets:
+                self.context._sockets.remove(self)
 
     def setsockopt(self, int option, optval):
         """s.setsockopt(option, optval)

--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -52,23 +52,29 @@ class TestContext(BaseZMQTestCase):
     def test_fail_init(self):
         self.assertRaisesErrno(zmq.EINVAL, zmq.Context, 0)
     
-    def test_term_hang(self):
+    def test_term_cleanup(self):
         rep,req = self.create_bound_pair(zmq.XREP, zmq.XREQ)
+        self.assertTrue(req in self.context)
+        self.assertTrue(rep in self.context)
         req.setsockopt(zmq.LINGER, 0)
         req.send(asbytes('hello'), copy=False)
-        req.close()
-        rep.close()
         self.context.term()
+        self.assertTrue(req.closed)
+        self.assertTrue(rep.closed)
     
     def test_instance(self):
         ctx = zmq.Context.instance()
         c2 = zmq.Context.instance(io_threads=2)
         self.assertTrue(c2 is ctx)
-        c2.term()
+        ctx.term()
+        self.assertTrue(ctx.closed)
         c3 = zmq.Context.instance()
         c4 = zmq.Context.instance()
         self.assertFalse(c3 is c2)
         self.assertFalse(c3.closed)
         self.assertTrue(c3 is c4)
+        c3.term()
+        self.assertTrue(c3.closed)
+        
         
 

--- a/zmq/tests/test_log.py
+++ b/zmq/tests/test_log.py
@@ -41,7 +41,6 @@ class TestPubLog(BaseZMQTestCase):
     
     @property
     def logger(self):
-        # print dir(self)
         logger = logging.getLogger('zmqtest')
         logger.setLevel(logging.DEBUG)
         return logger
@@ -62,10 +61,9 @@ class TestPubLog(BaseZMQTestCase):
         ctx = self.context
         handler = handlers.PUBHandler(self.iface)
         self.assertFalse(handler.ctx is ctx)
-        self.sockets.append(handler.socket)
-        # handler.ctx.term()
+        self.terminate_context(handler.ctx)
+        
         handler = handlers.PUBHandler(self.iface, self.context)
-        self.sockets.append(handler.socket)
         self.assertTrue(handler.ctx is ctx)
         
         handler.setLevel(logging.DEBUG)
@@ -73,7 +71,6 @@ class TestPubLog(BaseZMQTestCase):
         logger.addHandler(handler)
         
         sub = ctx.socket(zmq.SUB)
-        self.sockets.append(sub)
         sub.connect(self.iface)
         sub.setsockopt(zmq.SUBSCRIBE, self.topic)
         import time; time.sleep(0.1)
@@ -110,7 +107,6 @@ class TestPubLog(BaseZMQTestCase):
         logger, handler, sub = self.connect_handler()
         handler.socket.bind(self.iface)
         sub2 = sub.context.socket(zmq.SUB)
-        self.sockets.append(sub2)
         sub2.connect(self.iface)
         sub2.setsockopt(zmq.SUBSCRIBE, asbytes(''))
         handler.root_topic = asbytes('twoonly')
@@ -120,8 +116,6 @@ class TestPubLog(BaseZMQTestCase):
         topic,msg2 = sub2.recv_multipart()
         self.assertEquals(topic, asbytes('twoonly.INFO'))
         self.assertEquals(msg2, asbytes(msg1+'\n'))
-        
-        
         
         logger.removeHandler(handler)
 

--- a/zmq/tests/test_monqueue.py
+++ b/zmq/tests/test_monqueue.py
@@ -55,14 +55,10 @@ class TestMonitoredQueue(BaseZMQTestCase):
         self.device.connect_mon("tcp://127.0.0.1:%i"%mport)
         time.sleep(.2)
         self.device.start()
-        self.sockets.extend([alice, bob, mon])
         return alice, bob, mon
         
     
     def teardown_device(self):
-        for socket in self.sockets:
-            socket.close()
-            del socket
         del self.device
         
     def test_reply(self):

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -41,14 +41,11 @@ except:
 class TestSocket(BaseZMQTestCase):
 
     def test_create(self):
-        ctx = zmq.Context()
-        s = ctx.socket(zmq.PUB)
+        s = self.context.socket(zmq.PUB)
         # Superluminal protocol not yet implemented
         self.assertRaisesErrno(zmq.EPROTONOSUPPORT, s.bind, 'ftl://a')
         self.assertRaisesErrno(zmq.EPROTONOSUPPORT, s.connect, 'ftl://a')
         self.assertRaisesErrno(zmq.EINVAL, s.bind, 'tcp://')
-        s.close()
-        del ctx
     
     def test_unicode_sockopts(self):
         """test setting/getting sockopts with unicode strings"""
@@ -104,7 +101,6 @@ class TestSocket(BaseZMQTestCase):
     def test_send_unicode(self):
         "test sending unicode objects"
         a,b = self.create_bound_pair(zmq.PAIR, zmq.PAIR)
-        self.sockets.extend([a,b])
         u = "çπ§"
         if str is not unicode:
             u = u.decode('utf8')
@@ -129,7 +125,6 @@ class TestSocket(BaseZMQTestCase):
         a = self.context.socket(zmq.XREQ)
         a.setsockopt(zmq.IDENTITY, asbytes("a"))
         b = self.context.socket(zmq.XREP)
-        self.sockets.extend([a,b])
         a.connect(iface)
         time.sleep(0.1)
         p1 = a.send(asbytes('something'), copy=False, track=True)
@@ -172,14 +167,15 @@ class TestSocket(BaseZMQTestCase):
         
 
     def test_close(self):
-        ctx = zmq.Context()
+        ctx = self.context
         s = ctx.socket(zmq.PUB)
+        self.assertTrue(s in ctx)
         s.close()
+        self.assertFalse(s in ctx)
         self.assertRaises(zmq.ZMQError, s.bind, asbytes(''))
         self.assertRaises(zmq.ZMQError, s.connect, asbytes(''))
         self.assertRaises(zmq.ZMQError, s.setsockopt, zmq.SUBSCRIBE, asbytes(''))
         self.assertRaises(zmq.ZMQError, s.send, asbytes('asdf'))
         self.assertRaises(zmq.ZMQError, s.recv)
-        del ctx
     
 

--- a/zmq/tests/test_zmqstream.py
+++ b/zmq/tests/test_zmqstream.py
@@ -26,22 +26,18 @@
 import sys
 import time
 
-from unittest import TestCase
-
 import zmq
 from zmq.eventloop import ioloop, zmqstream
 
-class TestZMQStream(TestCase):
+from zmq.tests import BaseZMQTestCase
+
+class TestZMQStream(BaseZMQTestCase):
     
     def setUp(self):
-        self.context = zmq.Context()
+        self.context = zmq.Context.instance()
         self.socket = self.context.socket(zmq.REP)
         self.loop = ioloop.IOLoop.instance()
         self.stream = zmqstream.ZMQStream(self.socket)
-    
-    def tearDown(self):
-        self.socket.close()
-        self.context.term()
     
     def test_callable_check(self):
         """Ensure callable check works (py3k)."""


### PR DESCRIPTION
Context keeps a set of its Sockets, and `Context.term()` closes all its sockets before calling ctx.term.

Test suite updated to use this functionality.

This better matches the official 0MQ C-API (http://zero.mq/c).
