### PR TITLE
buildutils uses reduce which was moved in Python 3

### DIFF
--- a/buildutils.py
+++ b/buildutils.py
@@ -30,6 +30,11 @@ try:
 except:
     from ConfigParser import ConfigParser
 
+try:
+    from functools import reduce
+except ImportError:
+    pass
+
 pjoin = os.path.join
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Tiny change
