### PR TITLE
Remove libzmq.dll location in LoadLibrary call

### DIFF
--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -27,7 +27,7 @@ import sys
 if sys.platform.startswith('win'):
     import os, ctypes
     here = os.path.dirname(__file__)
-    ctypes.cdll.LoadLibrary(os.path.join(here, 'libzmq.dll'))
+    ctypes.cdll.LoadLibrary('libzmq.dll')
 
 from zmq.utils import initthreads # initialize threads
 initthreads.init_threads()


### PR DESCRIPTION
Specifying the libzmq.dll location causes packaging issues when using pyInstaller. Remove the directory reference and delegate to LoadLibrary's search order defined here ( http://msdn.microsoft.com/en-us/library/ms684175(v=vs.85).aspx )
