### PR TITLE
install the zmq eventloop in tornado's eventloop

### DIFF
--- a/zmq/eventloop/ioloop.py
+++ b/zmq/eventloop/ioloop.py
@@ -26,7 +26,7 @@ import traceback
 from zmq.eventloop import stack_context
 from zmq.utils.strtypes import asbytes
 
-def install_zmq_eventloop():
+def install():
     """Install the zmq eventloop as the tornado eventloop.
     """
     import tornado.ioloop


### PR DESCRIPTION
Hi,

this is a very simple method for _installing_ pyzmq's eventloop within the tornado package. Not tested, but should work ;)

Daniel
