### PR TITLE
Fix for error during 0mq detection on OS X with non-default arch

### DIFF
--- a/buildutils.py
+++ b/buildutils.py
@@ -26,6 +26,7 @@ import sys
 import os
 import logging
 import pickle
+import platform
 from distutils import ccompiler
 from subprocess import Popen, PIPE
 
@@ -107,13 +108,18 @@ int main(){
         f.close()
 
     if sys.platform == 'darwin':
+        #use appropriate arch for comiler
+        if platform.architecture()[0]=='32bit':
+            cpreargs = ['-arch','i386']
+        else:
+            cpreargs = None
         # allow for missing UB arch, since it will still work:
-        preargs = ['-undefined', 'dynamic_lookup']
+        lpreargs = ['-undefined', 'dynamic_lookup']
     else:
-        preargs = None
+        lpreargs = None
 
-    objs = cc.compile([cfile])
-    cc.link_executable(objs, efile, extra_preargs=preargs)
+    objs = cc.compile([cfile],extra_preargs=cpreargs)
+    cc.link_executable(objs, efile, extra_preargs=lpreargs)
 
     result = Popen(efile, stdout=PIPE, stderr=PIPE)
     so, se = result.communicate()


### PR DESCRIPTION
When building pyzmq for Mac OS X 10.6 on a 64-bit Intel mac with a 32-bit (i386) install of python, I could not get pyzmq to get best the "configure" step.  This was because the detect_zmq function doesn't honor the architecture flag needed to compile for i386 when compiling the version detection test file.  This pull request adds the "-arch i386" to the compiler command line for the test version if the architecture is in fact 32-bit.
