### PR TITLE
Do not attempt to grab the GIL when it is already held

### DIFF
--- a/zmq/core/context.pyx
+++ b/zmq/core/context.pyx
@@ -86,8 +86,7 @@ cdef class Context:
             self.max_sockets *= 2
             self._sockets = <void **>realloc(self._sockets, self.max_sockets*sizeof(void *))
             if self._sockets == NULL:
-                with gil:
-                    raise MemoryError("Could not reallocate _sockets array")
+                raise MemoryError("Could not reallocate _sockets array")
         
         self._sockets[self.n_sockets] = handle
         self.n_sockets += 1


### PR DESCRIPTION
Fixes build under Cython 0.14.1+
