### PR TITLE
add version_info functions for getting [py]zmq versions as tuples

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,9 @@ dev
   remains threadsafe and 1:1 with libzmq.
 * :meth:`Socket.close` takes optional linger option, for setting linger prior
   to closing.
+* add :func:`zmq_version_info` and :func:`pyzmq_version_info` for getting libzmq
+  and pyzmq versions as tuples of numbers.  This helps with the fact that
+  version string comparison breaks down once versions get into double-digits.
 
 2.1.9
 =====

--- a/zmq/core/version.pyx
+++ b/zmq/core/version.pyx
@@ -42,17 +42,44 @@ def pyzmq_version():
     else:
         return __version__
 
+def pyzmq_version_info():
+    """pyzmq_version_info()
+    
+    Return the pyzmq version as a 3-tuple of numbers
+    
+    If pyzmq is a dev version, the patch-version will be `inf`.
+    
+    This helps comparison of version tuples in Python 3, where str-int
+    comparison is no longer legal for some reason.
+    """
+    import re
+    parts = re.findall('[0-9]+', __version__)
+    parts = [ int(p) for p in parts ]
+    if 'dev' in __version__:
+        parts.append(float('inf'))
+    return tuple(parts)
+
 
 def zmq_version():
     """zmq_version()
 
     Return the version of ZeroMQ itself as a string.
     """
+    return "%i.%i.%i" % zmq_version_info()
+
+def zmq_version_info():
+    """zmq_version()
+
+    Return the version of ZeroMQ itself as a 3-tuple of ints.
+    """
     cdef int major, minor, patch
     with nogil:
         _zmq_version(&major, &minor, &patch)
-    return '%i.%i.%i' % (major, minor, patch)
+    return (major, minor, patch)
 
 
-__all__ = ['zmq_version', 'pyzmq_version', '__version__', '__revision__']
+__all__ = ['zmq_version', 'zmq_version_info',
+           'pyzmq_version','pyzmq_version_info',
+           '__version__', '__revision__'
+]
 

--- a/zmq/tests/test_version.py
+++ b/zmq/tests/test_version.py
@@ -1,0 +1,69 @@
+#
+#    Copyright (c) 2011 Min Ragan-Kelley
+#
+#    This file is part of pyzmq.
+#
+#    pyzmq is free software; you can redistribute it and/or modify it under
+#    the terms of the Lesser GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    pyzmq is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    Lesser GNU General Public License for more details.
+#
+#    You should have received a copy of the Lesser GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from unittest import TestCase
+import zmq
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+class TestVersion(TestCase):
+
+    def test_pyzmq_version(self):
+        vs = zmq.pyzmq_version()
+        vs2 = zmq.__version__
+        self.assertTrue(isinstance(vs, str))
+        if zmq.__revision__:
+            self.assertEquals(vs, '@'.join(vs2, zmq.__revision__))
+        else:
+            self.assertEquals(vs, vs2)
+
+    def test_pyzmq_version_info(self):
+        version = zmq.core.version
+        save = version.__version__
+        try:
+            version.__version__ = '2.10dev'
+            info = zmq.pyzmq_version_info()
+            self.assertTrue(isinstance(info, tuple))
+            self.assertEquals(len(info), 3)
+            self.assertTrue(info > (2,10,99))
+            self.assertEquals(info, (2,10,float('inf')))
+            version.__version__ = '2.1.10'
+            info = zmq.pyzmq_version_info()
+            self.assertEquals(info, (2,1,10))
+            self.assertTrue(info > (2,1,9))
+        finally:
+            version.__version__ = save
+
+    def test_zmq_version_info(self):
+        info = zmq.zmq_version_info()
+        self.assertTrue(isinstance(info, tuple))
+        self.assertEquals(len(info), 3)
+        for item in info:
+            self.assertTrue(isinstance(item, int))
+
+    def test_zmq_version(self):
+        v = zmq.zmq_version()
+        self.assertTrue(isinstance(v, str))
+


### PR DESCRIPTION
This will help going forward as versions enter double-digits.

These aren't _critical_, but I think they will be useful so that user code doesn't have to deal with the fact that `'2.1.10' < '2.1.4'`.  @ellisonbg, if you okay this, I'll merge and cut 2.1.10 tomorrow.
