### PR TITLE
remove LABEL support, as it has been removed from libzmq

### DIFF
--- a/zmq/core/constants.pyx
+++ b/zmq/core/constants.pyx
@@ -116,9 +116,9 @@ else:
     MULTICAST_HOPS = ZMQ_MULTICAST_HOPS
     
     _optionals.extend(['MAXMSGSIZE', 'SNDHWM', 'RCVHWM', 'MULTICAST_HOPS',
-                        'RCVTIMEO', 'SNDTIMEO', 'RCVLABEL', 'SNDLABEL'])
+                        'RCVTIMEO', 'SNDTIMEO'])
     int64_sockopts.append(MAXMSGSIZE)
-    int_sockopts.extend([SNDHWM, RCVHWM, MULTICAST_HOPS, RCVTIMEO, SNDTIMEO, RCVLABEL])
+    int_sockopts.extend([SNDHWM, RCVHWM, MULTICAST_HOPS, RCVTIMEO, SNDTIMEO])
 
 if ZMQ_VERSION < 40000:
     # removed in 4.0.0

--- a/zmq/core/device.pyx
+++ b/zmq/core/device.pyx
@@ -55,7 +55,7 @@ def device(int device_type, cSocket isocket, cSocket osocket):
         raise ZMQError()
     return rc
 
-# inner loop inlined, to prevent duplication
+# inner loop inlined, to prevent code duplication for up/downstream
 cdef inline int _relay(void * insocket, void *outsocket, zmq_msg_t msg) nogil:
     cdef int more=0
     cdef int label=0
@@ -69,18 +69,19 @@ cdef inline int _relay(void * insocket, void *outsocket, zmq_msg_t msg) nogil:
         if (rc < 0):
             return -1
 
+        flags = 0
         rc = zmq_getsockopt(insocket, ZMQ_RCVMORE, &more, &flagsz)
         if (rc < 0):
             return -1
-        rc = zmq_getsockopt(insocket, ZMQ_RCVLABEL, &label, &flagsz)
-        if (rc < 0):
-            return -1
-        
-        flags = 0
         if more:
             flags = flags | ZMQ_SNDMORE
-        if label:
-            flags = flags | ZMQ_SNDLABEL
+        
+        # LABELs have been removed:
+        # rc = zmq_getsockopt(insocket, ZMQ_RCVLABEL, &label, &flagsz)
+        # if (rc < 0):
+        #     return -1
+        # if label:
+        #     flags = flags | ZMQ_SNDLABEL
         
         rc = zmq_sendmsg(outsocket, &msg, flags)
 

--- a/zmq/tests/__init__.py
+++ b/zmq/tests/__init__.py
@@ -41,7 +41,7 @@ except ImportError:
 #-----------------------------------------------------------------------------
 # Utilities
 #-----------------------------------------------------------------------------
-if zmq.zmq_version() >= '3.0.0':
+if zmq.zmq_version_info() >= (3,0,0):
     # keep NOBLOCK for tests
     zmq.NOBLOCK = zmq.DONTWAIT
 

--- a/zmq/tests/test_device.py
+++ b/zmq/tests/test_device.py
@@ -118,8 +118,7 @@ class TestDevice(BaseZMQTestCase):
 
     def test_labels(self):
         """test device support for SNDLABEL"""
-        if zmq.zmq_version() < '3.0.0':
-            raise SkipTest("Only for libzmq 3")
+        raise SkipTest("LABELs have been removed")
         dev = devices.ThreadDevice(zmq.QUEUE, zmq.XREP, -1)
         # select random port:
         binder = self.context.socket(zmq.XREQ)

--- a/zmq/tests/test_monqueue.py
+++ b/zmq/tests/test_monqueue.py
@@ -182,8 +182,6 @@ class TestMonitoredQueue(BaseZMQTestCase):
     
     def test_router_router(self):
         """test router-router MQ devices"""
-        if zmq.zmq_version() >= '4.0.0':
-            raise SkipTest("Only for libzmq < 4")
         dev = devices.ThreadMonitoredQueue(zmq.ROUTER, zmq.ROUTER, zmq.PUB, asbytes('in'), asbytes('out'))
         dev.setsockopt_in(zmq.LINGER, 0)
         dev.setsockopt_out(zmq.LINGER, 0)

--- a/zmq/tests/test_multipart.py
+++ b/zmq/tests/test_multipart.py
@@ -33,8 +33,6 @@ from zmq.tests import BaseZMQTestCase, SkipTest
 class TestMultipart(BaseZMQTestCase):
 
     def test_router_dealer(self):
-        if zmq.zmq_version() >= '4.0.0':
-            raise SkipTest("ROUTER/DEALER change in 4.0")
         router, dealer = self.create_bound_pair(zmq.ROUTER, zmq.DEALER)
 
         msg1 = asbytes('message1')


### PR DESCRIPTION
Leave some remnants commented out, as presumably it will return
more fully baked.  The prefix arg to send_multipart remains as well,
though it has no special function anymore, aside from prepending to the multipart message

(i.e. exactly what it did in libzmq-2.1, now that 3.0/3.1 are no longer different to 2.1 in this respect).

Not to be merged until the discussion regarding 3.0/3.1 release is resolved on zeromq-dev.
