### PR TITLE
change isalive to is_alive with paramiko issue shows up

### DIFF
--- a/zmq/ssh/tunnel.py
+++ b/zmq/ssh/tunnel.py
@@ -297,7 +297,7 @@ def paramiko_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pa
     return p
     
 def _shutdown_process(p):
-    if p.isalive():
+    if p.is_alive():
         p.terminate()
 
 def _paramiko_tunnel(lport, rport, server, remoteip, keyfile=None, password=None):


### PR DESCRIPTION
I'm not sure if you can replicate this error or not, but here is the issue on my machine:

Should isalive actually be is_alive (in ssh/tunnel.py line 300)? If we inspect the tunnel object
returned from Paramiko it has property is_alive. if you create a
virtualenv with just paramiko and pyzmq, and then run a basic hello
world client and server included (just run python hwserver.py and then
python hwclient.py you will need to change the ip addresses and ssh
tunnel to your own) we get the error:

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File
```

"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
atexit.py", line 24, in _run_exitfuncs
        func(_targs, *_kargs)
      File
"/Users/Tigger/Desktop/testing_pmq/lib/python2.7/site-packages/zmq/ssh/t
unnel.py", line 300, in _shutdown_process
        if p.isalive():
    AttributeError: 'Process' object has no attribute 'isalive'

```
This does not happen if we are using OpenSSH and pexpect.
```

Furthermore making the change does not seem to create any new errors if
a User is using OpenSSH/pexpect instead of paramiko.
