### PR TITLE
Fix client traceback formatting, pep8, dont use bare except

### DIFF
--- a/zmq/rpc/simplerpc.py
+++ b/zmq/rpc/simplerpc.py
@@ -386,7 +386,6 @@ class RPCServiceProxy(RPCServiceProxyBase):
         msg_id, msg_list = self._build_msg(method, args, kwargs)
         self.socket.send_multipart(msg_list)
         msg_list = self.socket.recv_multipart()
-        from pdb import set_trace; set_trace()
         msg_id = msg_list[0]
         status = msg_list[1]
         if status == b'SUCCESS':


### PR DESCRIPTION
There was an issue with the formatting of tracebacks in the client. It was not showing the formatted remote traceback, only the local traceback and a brief description of the traceback. 

I also found a few pep8 violations and the use of bare except.
