### PR TITLE
Be defensive against too long ipc socket path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ def settings_from_prefix(zmq=None):
            'libraries'      : ['zmq'],
            'include_dirs'   : [],
            'library_dirs'   : [],
+           'define_macros'  : [('PYZMQ_POSIX', 1)],
         }
     
         # add pthread on freebsd

--- a/zmq/core/error.pyx
+++ b/zmq/core/error.pyx
@@ -63,9 +63,11 @@ class ZMQError(ZMQBaseError):
     error : int
         The ZMQ errno or None.  If None, then ``zmq_errno()`` is called and
         used.
+    msg : string
+        Description of the error or None.
     """
 
-    def __init__(self, error=None):
+    def __init__(self, error=None, msg=None):
         """Wrap an errno style error.
 
         Parameters
@@ -73,6 +75,8 @@ class ZMQError(ZMQBaseError):
         error : int
             The ZMQ errno or None.  If None, then ``zmq_errno()`` is called and
             used.
+        msg : string
+            Description of the error or None.
         """
         cdef int errno
         if error is None:
@@ -80,11 +84,17 @@ class ZMQError(ZMQBaseError):
                 errno = zmq_errno()
             error = errno
         if type(error) == int:
-            self.strerror = strerror(error)
             self.errno = error
+            if msg is None:
+                self.strerror = strerror(error)
+            else:
+                self.strerror = msg
         else:
-            self.strerror = str(error)
             self.errno = None
+            if msg is None:
+                self.strerror = str(error)
+            else:
+                self.strerror = msg
         # flush signals, because there could be a SIGINT
         # waiting to pounce, resulting in uncaught exceptions.
         # Doing this here means getting SIGINT during a blocking

--- a/zmq/utils/ipc.h
+++ b/zmq/utils/ipc.h
@@ -1,0 +1,21 @@
+/*
+
+Platform-independant detection of IPC path max length
+
+Copyright (c) 2012 Godefroid Chapelle
+
+Distributed under the terms of the New BSD License.  The full license is in
+the file COPYING.BSD, distributed as part of this software.
+ */
+
+#if defined(PYZMQ_POSIX)
+#include "sys/un.h"
+int get_ipc_path_max_len(void) {
+    struct sockaddr_un *dummy;
+    return sizeof(dummy->sun_path) - 1;
+}
+#else
+int get_ipc_path_max_len(void) {
+    return 0;
+}
+#endif


### PR DESCRIPTION
ipc socket path cannot be longer than what is declared by `sys/un.h sockaddr_un.sun_path`.
(If it is, libzmq complains with a terse `file name too long`.)

The patch checks for length and raises a developer friendly exception.

PS: I am not a Cython expert, so I'd be pleased to get comments regarding style
