### PR TITLE
adjust del/gc behavior

### DIFF
--- a/zmq/core/context.pyx
+++ b/zmq/core/context.pyx
@@ -77,6 +77,8 @@ cdef class Context:
         cdef int rc
         if self._sockets != NULL:
             free(self._sockets)
+            self._sockets = NULL
+            self.n_sockets = 0
         self.term()
     
     cdef inline void _add_socket(self, void* handle):


### PR DESCRIPTION
`__del__` appears to never be called from Cython, so put all close logic in `__dealloc__`.

Previously, this could segfault, but a check for whether the Context has been cleaned up seems to resolve that issue.

Also, the GIL is never released around zmq_close calls, which are non-blocking anyway.

closes #211
