### PR TITLE
remove some obsolete libzmq-compat with dead dev branches

### DIFF
--- a/zmq/core/constants.pyx
+++ b/zmq/core/constants.pyx
@@ -45,29 +45,24 @@ PUB = ZMQ_PUB
 SUB = ZMQ_SUB
 REQ = ZMQ_REQ
 REP = ZMQ_REP
-XREQ = ZMQ_XREQ
-XREP = ZMQ_XREP
+DEALER = ZMQ_DEALER
+ROUTER = ZMQ_ROUTER
 PULL = ZMQ_PULL
 PUSH = ZMQ_PUSH
 XPUB = ZMQ_XPUB
 XSUB = ZMQ_XSUB
 
-if ZMQ_DEALER == -1:
-    DEALER = XREQ
-else:
-    DEALER = ZMQ_DEALER
-if ZMQ_ROUTER == -1:
-    ROUTER = XREP
-else:
-    ROUTER = ZMQ_ROUTER
-
 if ZMQ_VERSION < 30000:
-    UPSTREAM = ZMQ_UPSTREAM
-    DOWNSTREAM = ZMQ_DOWNSTREAM
-    _optionals.extend(['UPSTREAM','DOWNSTREAM'])
+    # keep deprecated aliases
+    XREQ = DEALER
+    XREP = ROUTER
+    UPSTREAM = PULL
+    DOWNSTREAM = PUSH
+    _optionals.extend(['XREQ','XREP','UPSTREAM','DOWNSTREAM'])
 
 # socket options
 AFFINITY = ZMQ_AFFINITY
+IDENTITY = ZMQ_IDENTITY
 SUBSCRIBE = ZMQ_SUBSCRIBE
 UNSUBSCRIBE = ZMQ_UNSUBSCRIBE
 RATE = ZMQ_RATE
@@ -86,7 +81,7 @@ FORWARDER = ZMQ_FORWARDER
 QUEUE = ZMQ_QUEUE
 
 # collections of sockopts, based on type:
-bytes_sockopts = [SUBSCRIBE, UNSUBSCRIBE]
+bytes_sockopts = [IDENTITY, SUBSCRIBE, UNSUBSCRIBE]
 int64_sockopts = [AFFINITY]
 int_sockopts = [RECONNECT_IVL_MAX]
 
@@ -140,19 +135,6 @@ else:
         IPV4ONLY,
         FAIL_UNROUTABLE,
     ])
-
-if ZMQ_VERSION < 40000:
-    # removed in 4.0.0
-    IDENTITY = ZMQ_IDENTITY
-    bytes_sockopts.append(IDENTITY)
-    _optionals.append('IDENTITY')
-else:
-    # new in 4.0.0
-    RCVCMD = ZMQ_RCVCMD
-    SNDCMD = ZMQ_SNDCMD # flag, not a sockopt
-    int_sockopts.append(RCVCMD)
-    _optionals.append('RCVCMD')
-    
 
 
 FD = ZMQ_FD
@@ -222,13 +204,12 @@ __all__ = [
     'XSUB',
     'REQ',
     'REP',
-    'XREQ',
     'DEALER',
-    'XREP',
     'ROUTER',
     'PULL',
     'PUSH',
     'AFFINITY',
+    'IDENTITY',
     'SUBSCRIBE',
     'UNSUBSCRIBE',
     'RATE',

--- a/zmq/core/libzmq.pxd
+++ b/zmq/core/libzmq.pxd
@@ -74,7 +74,6 @@ cdef extern from "zmq.h" nogil:
     enum: ZMQ_EFSM "EFSM"
     enum: ZMQ_ENOCOMPATPROTO "ENOCOMPATPROTO"
     enum: ZMQ_ETERM "ETERM"
-    enum: ZMQ_ECANTROUTE "ECANTROUTE"
     enum: ZMQ_EMTHREAD "EMTHREAD"
     
     enum: errno
@@ -110,16 +109,12 @@ cdef extern from "zmq.h" nogil:
     enum: ZMQ_SUB # 2
     enum: ZMQ_REQ # 3
     enum: ZMQ_REP # 4
-    enum: ZMQ_XREQ # 5
-    enum: ZMQ_DEALER # 5 or 12
-    enum: ZMQ_XREP # 6
-    enum: ZMQ_ROUTER # 6 or 11 or 13
+    enum: ZMQ_DEALER # 5
+    enum: ZMQ_ROUTER # 6
     enum: ZMQ_PULL # 7
     enum: ZMQ_PUSH # 8
     enum: ZMQ_XPUB # 9
     enum: ZMQ_XSUB # 10
-    enum: ZMQ_UPSTREAM # 7
-    enum: ZMQ_DOWNSTREAM # 8
 
     enum: ZMQ_HWM # 1
     enum: ZMQ_SWAP # 3
@@ -147,8 +142,6 @@ cdef extern from "zmq.h" nogil:
     enum: ZMQ_MULTICAST_HOPS # 25
     enum: ZMQ_RCVTIMEO # 27
     enum: ZMQ_SNDTIMEO # 28
-    enum: ZMQ_RCVLABEL # 29
-    enum: ZMQ_RCVCMD # 30
     enum: ZMQ_IPV4ONLY # 31
     enum: ZMQ_LAST_ENDPOINT # 32
     enum: ZMQ_FAIL_UNROUTABLE # 33
@@ -156,8 +149,6 @@ cdef extern from "zmq.h" nogil:
     enum: ZMQ_NOBLOCK # 1
     enum: ZMQ_DONTWAIT # 1
     enum: ZMQ_SNDMORE # 2
-    enum: ZMQ_SNDLABEL # 4
-    enum: ZMQ_SNDCMD # 8
 
     void *zmq_socket (void *context, int type)
     int zmq_close (void *s)

--- a/zmq/tests/test_device.py
+++ b/zmq/tests/test_device.py
@@ -106,29 +106,3 @@ class TestDevice(BaseZMQTestCase):
         del dev
         req.close()
 
-    def test_labels(self):
-        """test device support for SNDLABEL"""
-        raise SkipTest("LABELs have been removed")
-        dev = devices.ThreadDevice(zmq.QUEUE, zmq.XREP, -1)
-        # select random port:
-        binder = self.context.socket(zmq.XREQ)
-        port = binder.bind_to_random_port('tcp://127.0.0.1')
-        binder.close()
-        time.sleep(0.1)
-        req = self.context.socket(zmq.REQ)
-        req.connect('tcp://127.0.0.1:%i'%port)
-        dev.bind_in('tcp://127.0.0.1:%i'%port)
-        dev.start()
-        time.sleep(.25)
-        msg = b'hello'
-        req.send(msg, zmq.SNDLABEL)
-        req.send(msg, zmq.SNDMORE)
-        req.send(msg)
-        
-        self.assertEquals(msg, self.recv(req))
-        self.assertTrue(req.rcvlabel)
-        self.assertEquals(msg, self.recv(req))
-        self.assertTrue(req.rcvmore)
-        self.assertEquals(msg, self.recv(req))
-        del dev
-        req.close()

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -50,12 +50,6 @@
 #ifndef ZMQ_DONTWAIT
     #define ZMQ_DONTWAIT (-1)
 #endif
-#ifndef ZMQ_RCVLABEL
-    #define ZMQ_RCVLABEL (-1)
-#endif
-#ifndef ZMQ_SNDLABEL
-    #define ZMQ_SNDLABEL (-1)
-#endif
 #ifndef ZMQ_IPV4ONLY
     #define ZMQ_IPV4ONLY (-1)
 #endif
@@ -79,13 +73,6 @@
 #endif
 #ifndef ZMQ_MSG_SHARED
     #define ZMQ_MSG_SHARED (-1)
-#endif
-
-#ifndef ZMQ_UPSTREAM
-    #define ZMQ_UPSTREAM (-1)
-#endif
-#ifndef ZMQ_DOWNSTREAM
-    #define ZMQ_DOWNSTREAM (-1)
 #endif
 
 #ifndef ZMQ_HWM
@@ -116,33 +103,6 @@
     #define ZMQ_QUEUE 3
 #endif
 
-
-// new in 4.0.0
-#ifndef ECANTROUTE
-    #define ECANTROUTE (-1)
-#endif
-
-#ifndef ZMQ_RCVCMD
-    #define ZMQ_RCVCMD (-1)
-#endif
-#ifndef ZMQ_SNDCMD
-    #define ZMQ_SNDCMD (-1)
-#endif
-
-// removed in 4.0.0
-#ifndef ZMQ_XREQ
-    #define ZMQ_XREQ (-1)
-#endif
-#ifndef ZMQ_XREP
-    #define ZMQ_XREP (-1)
-#endif
-#ifndef ZMQ_DEALER
-    #define ZMQ_DEALER (-1)
-#endif
-
-#ifndef ZMQ_IDENTITY
-    #define ZMQ_IDENTITY (-1)
-#endif
 
 // define fd type (from libzmq's fd.hpp)
 #ifdef _WIN32


### PR DESCRIPTION
- CMD, LABEL removed
- handle deprecated aliases explicitly rather than implicitly
- don't handle deprecations in dead 4.0-dev branch
