### PR TITLE
Missing library on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -354,6 +354,8 @@ class Configure(Command):
             ext.include_dirs.append(pjoin(bundledir, 'uuid'))
             ext.include_dirs.append(bundledir)
             ext.sources.extend(glob(pjoin(bundledir, 'uuid', '*.c')))
+
+            ext.libraries.append('rt')
         
         # insert the extension:
         self.distribution.ext_modules.insert(0, ext)


### PR DESCRIPTION
When compiling on Linux, I get the following error:

``` python
OSError: .../python2.6/site-packages/zmq/libzmq.so: undefined symbol: clock_gettime
```

This symbol is defined in `librt.so`. This patch adds the missing library.
