### PR TITLE
Protect sockets from errors during gc in forked child

### DIFF
--- a/zmq/core/context.pxd
+++ b/zmq/core/context.pxd
@@ -30,6 +30,8 @@ cdef class Context:
     cdef void ** _sockets     # A C-array containg socket handles
     cdef size_t n_sockets         # the number of sockets
     cdef size_t max_sockets         # the size of the _sockets array
+    cdef int _pid # the pid of the process which created me (for fork safety)
+
     cdef public object closed # bool property for a closed context.
     # helpers for events on _sockets in Socket.__cinit__()/close()
     cdef inline void _add_socket(self, void* handle)

--- a/zmq/core/context.pyx
+++ b/zmq/core/context.pyx
@@ -27,6 +27,8 @@ from libc.stdlib cimport free, malloc, realloc
 
 from libzmq cimport *
 
+from os import getpid
+
 from error import ZMQError
 from zmq.core import constants
 from constants import *
@@ -67,6 +69,7 @@ cdef class Context:
         
         self.sockopts = {}
         self._attrs = {}
+        self._pid = getpid()
 
     def __del__(self):
         """deleting a Context should terminate it, without trying non-threadsafe destroy"""
@@ -149,7 +152,7 @@ cdef class Context:
         cdef int rc
         cdef int i=-1
 
-        if self.handle != NULL and not self.closed:
+        if self.handle != NULL and not self.closed and getpid() == self._pid:
             with nogil:
                 rc = zmq_term(self.handle)
             if rc != 0:

--- a/zmq/core/socket.pxd
+++ b/zmq/core/socket.pxd
@@ -40,6 +40,7 @@ cdef class Socket:
     cdef public Context context # The zmq Context object that owns this.
     cdef public bint _closed   # bool property for a closed socket.
     cdef dict _attrs   # dict needed for *non-sockopt* get/setattr in subclasses
+    cdef int _pid # the pid of the process which created me (for fork safety)
 
     # cpdef methods for direct-cython access:
     cpdef object send(self, object data, int flags=*, copy=*, track=*)


### PR DESCRIPTION
This simply prevents close/term from being called during gc in the forked process,
which would cause unavoidable asserts (mailbox.cpp:79) if fork is ever called
while there is a zmq socket in the process.

Actually trying to use the sockets/context after the fork will still produce the same error,
but there's no reason to protect people from themselves that much.
