### PR TITLE
Allow OpenSSH to use non-default port

### DIFF
--- a/zmq/ssh/tunnel.py
+++ b/zmq/ssh/tunnel.py
@@ -201,8 +201,10 @@ def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pas
         raise ImportError("pexpect unavailable, use paramiko_tunnel")
     ssh="ssh "
     if keyfile:
-        ssh += "-i " + keyfile 
-    cmd = ssh + " -f -L 127.0.0.1:%i:%s:%i %s sleep %i"%(lport, remoteip, rport, server, timeout)
+        ssh += "-i " + keyfile
+    username, server, port = _split_server(server)
+    server = username + "@" + server 
+    cmd = ssh + " -f -L -p %i 127.0.0.1:%i:%s:%i %s sleep %i"%(port, lport, remoteip, rport, server, timeout)
     tunnel = pexpect.spawn(cmd)
     failed = False
     while True:


### PR DESCRIPTION
Currently tunnel_connection fails if server takes the form "address:port".  Opening a port other than 22 requires use of the -p option.

The change parses server, which takes the form "[user@]address[:port]" according to the documentation:
https://github.com/zeromq/pyzmq/blob/master/docs/source/ssh.rst
