### PR TITLE
log send exceptions in zmqstream

### DIFF
--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -484,6 +484,7 @@ class ZMQStream(object):
         try:
             status = self.socket.send_multipart(msg, **kwargs)
         except zmq.ZMQError as e:
+            logging.error("SEND Error: %s", e)
             status = e
         if self._send_callback:
             callback = self._send_callback


### PR DESCRIPTION
Were swallowed silently, and passed to send callback if it is defined.
