### PR TITLE
Fix for an Exception raised when processes exit.

### DIFF
--- a/zmq/core/context.pyx
+++ b/zmq/core/context.pyx
@@ -152,6 +152,13 @@ cdef class Context:
         cdef int rc
         cdef int i=-1
 
+        # If this module has already been GC'ed (at process exit), the 
+        # globally imported `getpid` function will be None. There really
+        # isn't anything to do at that point, so just bail out of this
+        # function.
+        if getpid is None:
+            return
+
         if self.handle != NULL and not self.closed and getpid() == self._pid:
             with nogil:
                 rc = zmq_term(self.handle)


### PR DESCRIPTION
Depending on how an application imports modules, if the reference counts
can lead to `zmq.core.context` getting garbage collected upon process
termination _before_ the `Context.__dealloc__` method is called.

The problem is that `__dealloc__` calls `getpid` which was imported by
`zmq.core.context`. At least, it tries to call it, but since the module
was GC'ed, is is `None` and you get the following exception.

```
Exception TypeError: "'NoneType' object is not callable" in <zmq.core.context.Context object at 0x28ce140> ignored
```

This change bails out of the typical `term()` function that is called on
`__dealloc__` if `getpid is None`.
