### PR TITLE
Better fix for cleanup on process termination.

### DIFF
--- a/zmq/core/context.pyx
+++ b/zmq/core/context.pyx
@@ -149,15 +149,13 @@ cdef class Context:
         This can be called to close the context by hand. If this is not called,
         the context will automatically be closed when it is garbage collected.
         """
-        global getpid
         cdef int rc
         cdef int i=-1
 
         # If this module has already been GC'ed (at process exit), the 
         # globally imported `getpid` function will be None. We reimport
         # it here in order to perform the PID check below.
-        if getpid is None:
-            from os import getpid
+        from os import getpid
 
         if self.handle != NULL and not self.closed and getpid() == self._pid:
             with nogil:


### PR DESCRIPTION
(This is a follow-up to https://github.com/zeromq/pyzmq/pull/265).

If `getpid` is None due to the module itself already being garbage
collected, it is reimported in order to be used in the cleanup logic.

This ensures that `zmq_term` is called when needed and still works
around missing global `getpid`.

Using the underlying C `getpid` functionality would require too much x-platform work that `os.getpid` already does for us. This lazy-import seems a little hackish but it should be an OK workaround for this corner case.
