### PR TITLE
MinGW-related fixes

### DIFF
--- a/buildutils/__init__.py
+++ b/buildutils/__init__.py
@@ -7,3 +7,4 @@ from .msg import *
 from .config import *
 from .detect import *
 from .bundle import *
+from .misc import *

--- a/buildutils/detect.py
+++ b/buildutils/detect.py
@@ -20,13 +20,15 @@ from distutils import ccompiler
 from distutils.sysconfig import customize_compiler
 from subprocess import Popen, PIPE
 
+from .misc import customize_mingw
+
 pjoin = os.path.join
 
 #-----------------------------------------------------------------------------
 # Utility functions (adapted from h5py: http://h5py.googlecode.com)
 #-----------------------------------------------------------------------------
 
-def detect_zmq(basedir, **compiler_attrs):
+def detect_zmq(basedir, compiler=None, **compiler_attrs):
     """Compile, link & execute a test program, in empty directory `basedir`.
     
     The C compiler will be updated with any keywords given via setattr.
@@ -36,6 +38,8 @@ def detect_zmq(basedir, **compiler_attrs):
     
     basedir : path
         The location where the test program will be compiled and run
+    compiler : str
+        The distutils compiler key (e.g. 'unix', 'msvc', or 'mingw32')
     **compiler_attrs : dict
         Any extra compiler attributes, which will be set via ``setattr(cc)``.
     
@@ -50,9 +54,15 @@ def detect_zmq(basedir, **compiler_attrs):
         The compiler options used to compile the test function, e.g. `include_dirs`,
         `library_dirs`, `libs`, etc.
     """
-
-    cc = ccompiler.new_compiler()
-    customize_compiler(cc)
+    
+    if compiler is None or isinstance(compiler, str):
+        cc = ccompiler.new_compiler(compiler=compiler)
+        customize_compiler(cc)
+        if cc.compiler_type == 'mingw32':
+            customize_mingw(cc)
+    else:
+        cc = compiler
+    
     for name, val in compiler_attrs.items():
         setattr(cc, name, val)
 

--- a/buildutils/misc.py
+++ b/buildutils/misc.py
@@ -1,0 +1,21 @@
+"""misc build utility functions"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2012 Min Ragan-Kelley
+#
+#  This file is part of pyzmq
+#
+#  Distributed under the terms of the New BSD License.  The full license is in
+#  the file COPYING.BSD, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+def customize_mingw(cc):
+    # strip -mno-cygwin from mingw32 (Python Issue #12641)
+    for cmd in [cc.compiler, cc.compiler_cxx, cc.compiler_so, cc.linker_exe, cc.linker_so]:
+        if '-mno-cygwin' in cmd:
+            cmd.remove('-mno-cygwin')
+    
+    # remove problematic msvcr90
+    if 'msvcr90' in cc.dll_libraries:
+        cc.dll_libraries.remove('msvcr90')
+
+__all__ = ['customize_mingw']


### PR DESCRIPTION
adds some patches for MinGW support, and avoids some MSVC assumptions.

Still cannot build full pyzmq with bundled libzmq with MinGW yet.

Fixes titular MSVC assumption in #270, and applies patches suggested in #249.
