### PR TITLE
Better error handling in Socket.bind_to_random_port

### DIFF
--- a/zmq/core/pysocket.py
+++ b/zmq/core/pysocket.py
@@ -141,8 +141,9 @@ def bind_to_random_port(self, addr, min_port=49152, max_port=65536, max_tries=10
         try:
             port = random.randrange(min_port, max_port)
             self.bind('%s:%s' % (addr, port))
-        except ZMQError:
-            pass
+        except ZMQError as exception:
+            if not exception.errno == zmq.EADDRINUSE:
+                raise exception
         else:
             return port
     raise ZMQBindError("Could not bind socket to random port.")

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -40,7 +40,22 @@ class TestSocket(BaseZMQTestCase):
         self.assertRaisesErrno(zmq.EINVAL, s.bind, 'tcp://')
         s.close()
         del ctx
-    
+
+    def test_bind_to_random_port(self):
+        # Check that bind_to_random_port do not hide usefull exception
+        ctx = self.Context()
+        c = ctx.socket(zmq.PUB)
+        # Invalid format
+        try:
+            c.bind_to_random_port('tcp:*')
+        except zmq.ZMQError as e:
+            self.assertEqual(e.errno, zmq.EINVAL)
+        # Invalid protocol
+        try:
+            c.bind_to_random_port('rand://*')
+        except zmq.ZMQError as e:
+            self.assertEqual(e.errno, zmq.EPROTONOSUPPORT)
+
     def test_unicode_sockopts(self):
         """test setting/getting sockopts with unicode strings"""
         topic = "tést"


### PR DESCRIPTION
Raise exception if errno is not EADDRINUSE.
