### PR TITLE
add missing web.py

### DIFF
--- a/zmq/web.py
+++ b/zmq/web.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 Brian Granger, Min Ragan-Kelley
+#
+#  This file is part of pyzmq
+#
+#  Distributed under the terms of the New BSD License.  The full license is in
+#  the file COPYING.BSD, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+raise ImportError('\n'.join([
+    "zmq.web is now maintained separately as zmqweb,",
+    "which can be found at https://github.com/ellisonbg/zmqweb"
+]))


### PR DESCRIPTION
Raises informative ImportError, pointing to new repo.

Was meant to be part of #286, but I forgot to add it.
