### PR TITLE
break out of the ioloop only after the iteration

### DIFF
--- a/zmq/eventloop/ioloop.py
+++ b/zmq/eventloop/ioloop.py
@@ -298,9 +298,10 @@ class IOLoop(object):
                         poll_timeout = min(seconds, poll_timeout)
                         break
 
-            if self._callbacks:
+            if self._callbacks or not self._running:
                 # If any callbacks or timeouts called add_callback,
                 # we don't want to wait in poll() before we run them.
+                # Also do not block if we are supposed to stop the loop.
                 poll_timeout = 0.0
 
             if self._blocking_signal_threshold is not None:


### PR DESCRIPTION
loop.add_timeout(0, loop.stop) will otherwise interrupt the loop
mid-flight (as opposed to the docstring) and handlers on the sockets
will never be called.

zmq/eventloop/ioloop.py: move the break to the end of the loop
zmq/tests/test_ioloop.py: add test for this
