### PR TITLE
add IOLoop.time

### DIFF
--- a/zmq/eventloop/ioloop.py
+++ b/zmq/eventloop/ioloop.py
@@ -452,6 +452,14 @@ class IOLoop(object):
         in sys.exc_info.
         """
         logging.error("Exception in callback %r", callback, exc_info=True)
+    
+    def time(self):
+        """This method will be added in tornado 3.0
+        
+        When 3.0 is closer to done, we will do a real upstream sync,
+        but this seems to be enough for now.
+        """
+        return time.time()
 
 
 class _Timeout(object):


### PR DESCRIPTION
the method is added in current tornado master, in the 3.0 refactor.

I will update IOLoop for real when tornado 3.0 is closer to release, but this
seems to be the main issue when using pyzmq IOLoop with tornado-dev.
