### PR TITLE
don't turn EINTR into KeyboardInterrupt

### DIFF
--- a/zmq/error.py
+++ b/zmq/error.py
@@ -118,8 +118,6 @@ def _check_rc(rc, errno=None):
             raise Again(errno)
         elif errno == ETERM:
             raise ContextTerminated(errno)
-        elif errno == EINTR:
-            raise KeyboardInterrupt
         else:
             raise ZMQError(errno)
 


### PR DESCRIPTION
This is redundant, and ends up doing the wrong thing when a signal handler is registered for SIGINT.
