### PR TITLE
tweak build checks

### DIFF
--- a/buildutils/detect.py
+++ b/buildutils/detect.py
@@ -113,6 +113,7 @@ def detect_zmq(basedir, compiler=None, **compiler_attrs):
     # check if we need to link against Realtime Extensions library
     if sys.platform.startswith('linux'):
         cc = ccompiler.new_compiler(compiler=compiler)
+        cc.output_dir = basedir
         if not cc.has_function('timer_create'):
             compiler_attrs['libraries'].append('rt')
             


### PR DESCRIPTION
- avoids linking against libzmq when checking for sys/un.h
  when zmq is unspecified and unavailable.
- avoids creating temp files outside build dir with `has_function` checks.
