### PR TITLE
some travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - ZMQ=bundled
 before_install:
   - sudo apt-get install -qq libzmq3-dev
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install cffi --use-mirrors; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install cython --use-mirrors; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install -q --use-mirrors cffi; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install -q --use-mirrors cython; fi
 
 install:
   # uncomment this when travis ships Cython ≥ 0.16


### PR DESCRIPTION
- fix non-bundled zeromq
- start testing pypy, even though it doesn't work, and won't until travis starts shipping 2.0.
