### PR TITLE
add explicit poll interval in zmq.green.Poller

### DIFF
--- a/zmq/green/poll.py
+++ b/zmq/green/poll.py
@@ -11,6 +11,7 @@ class _Poller(_original_Poller):
     Ensures that the greened Poller below is used in calls to
     :meth:`zmq.core.Poller.poll`.
     """
+    _gevent_bug_timeout = 1.33 # minimum poll interval, for working around gevent bug
 
     def _get_descriptors(self):
         """Returns three elements tuple with socket descriptors ready
@@ -73,7 +74,16 @@ class _Poller(_original_Poller):
                     return events
 
                 # wait for activity on sockets in a green way
-                select.select(rlist, wlist, xlist)
+                # set a minimum poll frequency,
+                # because gevent < 1.0 cannot be trusted to catch edge-triggered FD events
+                _bug_timeout = gevent.Timeout.start_new(self._gevent_bug_timeout)
+                try:
+                    select.select(rlist, wlist, xlist)
+                except gevent.Timeout as t:
+                    if t is not _bug_timeout:
+                        raise
+                finally:
+                    _bug_timeout.cancel()
 
         except gevent.Timeout as t:
             if t is not tout:

--- a/zmq/tests/test_device.py
+++ b/zmq/tests/test_device.py
@@ -148,10 +148,10 @@ if have_gevent:
             g = gevent.spawn(zmq.green.device, zmq.QUEUE, rep, rep)
             req.connect('tcp://127.0.0.1:%i' % port)
             req.send(b'hi')
-            timeout = gevent.Timeout(1)
+            timeout = gevent.Timeout(3)
             timeout.start()
             receiver = gevent.spawn(req.recv)
-            self.assertEqual(receiver.get(1), b'hi')
+            self.assertEqual(receiver.get(2), b'hi')
             timeout.cancel()
-            g.kill()
+            g.kill(block=True)
             


### PR DESCRIPTION
workaround same gevent FD bug in the sockets

closes #370
