### PR TITLE
Remove unhelpful GIL releases

### DIFF
--- a/zmq/backend/cython/message.pxd
+++ b/zmq/backend/cython/message.pxd
@@ -58,9 +58,8 @@ cdef inline object copy_zmq_msg_bytes(zmq_msg_t *zmq_msg):
     """ Copy the data from a zmq_msg_t """
     cdef char *data_c = NULL
     cdef Py_ssize_t data_len_c
-    with nogil:
-        data_c = <char *>zmq_msg_data(zmq_msg)
-        data_len_c = zmq_msg_size(zmq_msg)
+    data_c = <char *>zmq_msg_data(zmq_msg)
+    data_len_c = zmq_msg_size(zmq_msg)
     return PyBytes_FromStringAndSize(data_c, data_len_c)
 
 

--- a/zmq/backend/cython/message.pyx
+++ b/zmq/backend/cython/message.pyx
@@ -121,8 +121,7 @@ cdef class Frame:
             raise TypeError("Unicode objects not allowed. Only: str/bytes, buffer interfaces.")
 
         if data is None:
-            with nogil:
-                rc = zmq_msg_init(&self.zmq_msg)
+            rc = zmq_msg_init(&self.zmq_msg)
             _check_rc(rc)
             self._failed_init = False
             return
@@ -133,8 +132,7 @@ cdef class Frame:
         # object to take over the ref counting of data properly.
         hint = (data, self.tracker_event)
         Py_INCREF(hint)
-        with nogil:
-            rc = zmq_msg_init_data(
+        rc = zmq_msg_init_data(
                 &self.zmq_msg, <void *>data_c, data_len_c, 
                 <zmq_free_fn *>free_python_msg, <void *>hint
             )
@@ -160,9 +158,8 @@ cdef class Frame:
     
     def __getbuffer__(self, Py_buffer* buffer, int flags):
         # new-style (memoryview) buffer interface
-        with nogil:
-            buffer.buf = zmq_msg_data(&self.zmq_msg)
-            buffer.len = zmq_msg_size(&self.zmq_msg)
+        buffer.buf = zmq_msg_data(&self.zmq_msg)
+        buffer.len = zmq_msg_size(&self.zmq_msg)
         
         buffer.obj = self
         buffer.readonly = 1
@@ -177,8 +174,7 @@ cdef class Frame:
     def __getsegcount__(self, Py_ssize_t *lenp):
         # required for getreadbuffer
         if lenp != NULL:
-            with nogil:
-                lenp[0] = zmq_msg_size(&self.zmq_msg)
+            lenp[0] = zmq_msg_size(&self.zmq_msg)
         return 1
     
     def __getreadbuffer__(self, Py_ssize_t idx, void **p):
@@ -189,9 +185,8 @@ cdef class Frame:
             raise SystemError("accessing non-existent buffer segment")
         # read-only, because we don't want to allow
         # editing of the message in-place
-        with nogil:
-            data_c = <char *>zmq_msg_data(&self.zmq_msg)
-            data_len_c = zmq_msg_size(&self.zmq_msg)
+        data_c = <char *>zmq_msg_data(&self.zmq_msg)
+        data_len_c = zmq_msg_size(&self.zmq_msg)
         if p != NULL:
             p[0] = <void*>data_c
         return data_len_c
@@ -214,8 +209,7 @@ cdef class Frame:
         new_msg = Frame()
         # This does not copy the contents, but just increases the ref-count 
         # of the zmq_msg by one.
-        with nogil:
-            zmq_msg_copy(&new_msg.zmq_msg, &self.zmq_msg)
+        zmq_msg_copy(&new_msg.zmq_msg, &self.zmq_msg)
         # Copy the ref to data so the copy won't create a copy when str is
         # called.
         if self._data is not None:
@@ -234,8 +228,7 @@ cdef class Frame:
     def __len__(self):
         """Return the length of the message in bytes."""
         cdef size_t sz
-        with nogil:
-            sz = zmq_msg_size(&self.zmq_msg)
+        sz = zmq_msg_size(&self.zmq_msg)
         return sz
         # return <int>zmq_msg_size(&self.zmq_msg)
 

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -170,8 +170,7 @@ cdef inline object _send_copy(void *handle, object msg, int flags=0):
     # Copy the msg before sending. This avoids any complications with
     # the GIL, etc.
     # If zmq_msg_init_* fails we must not call zmq_msg_close (Bus Error)
-    with nogil:
-        rc = zmq_msg_init_size(&data, msg_c_len)
+    rc = zmq_msg_init_size(&data, msg_c_len)
 
     _check_rc(rc)
 
@@ -212,8 +211,7 @@ cdef class Socket:
         self.handle = NULL
         self.context = context
         self.socket_type = socket_type
-        with nogil:
-            self.handle = zmq_socket(<void *>c_handle, socket_type)
+        self.handle = zmq_socket(<void *>c_handle, socket_type)
         if self.handle == NULL:
             raise ZMQError()
         self._closed = False
@@ -306,8 +304,7 @@ cdef class Socket:
                 raise TypeError('expected bytes, got: %r' % optval)
             optval_c = PyBytes_AsString(optval)
             sz = PyBytes_Size(optval)
-            with nogil:
-                rc = zmq_setsockopt(
+            rc = zmq_setsockopt(
                     self.handle, option,
                     optval_c, sz
                 )
@@ -315,8 +312,7 @@ cdef class Socket:
             if not isinstance(optval, int):
                 raise TypeError('expected int, got: %r' % optval)
             optval_int64_c = optval
-            with nogil:
-                rc = zmq_setsockopt(
+            rc = zmq_setsockopt(
                     self.handle, option,
                     &optval_int64_c, sizeof(int64_t)
                 )
@@ -329,8 +325,7 @@ cdef class Socket:
             if not isinstance(optval, int):
                 raise TypeError('expected int, got: %r' % optval)
             optval_int_c = optval
-            with nogil:
-                rc = zmq_setsockopt(
+            rc = zmq_setsockopt(
                     self.handle, option,
                     &optval_int_c, sizeof(int)
                 )
@@ -368,20 +363,17 @@ cdef class Socket:
 
         if option in zmq.constants.bytes_sockopts:
             sz = 255
-            with nogil:
-                rc = zmq_getsockopt(self.handle, option, <void *>identity_str_c, &sz)
+            rc = zmq_getsockopt(self.handle, option, <void *>identity_str_c, &sz)
             _check_rc(rc)
             result = PyBytes_FromStringAndSize(<char *>identity_str_c, sz)
         elif option in zmq.constants.int64_sockopts:
             sz = sizeof(int64_t)
-            with nogil:
-                rc = zmq_getsockopt(self.handle, option, <void *>&optval_int64_c, &sz)
+            rc = zmq_getsockopt(self.handle, option, <void *>&optval_int64_c, &sz)
             _check_rc(rc)
             result = optval_int64_c
         elif option == ZMQ_FD:
             sz = sizeof(fd_t)
-            with nogil:
-                rc = zmq_getsockopt(self.handle, option, <void *>&optval_fd_c, &sz)
+            rc = zmq_getsockopt(self.handle, option, <void *>&optval_fd_c, &sz)
             _check_rc(rc)
             result = optval_fd_c
         else:
@@ -391,8 +383,7 @@ cdef class Socket:
             # sockopts will still raise just the same, but it will be libzmq doing
             # the raising.
             sz = sizeof(int)
-            with nogil:
-                rc = zmq_getsockopt(self.handle, option, <void *>&optval_int_c, &sz)
+            rc = zmq_getsockopt(self.handle, option, <void *>&optval_int_c, &sz)
             _check_rc(rc)
             result = optval_int_c
 

--- a/zmq/backend/cython/stopwatch.pyx
+++ b/zmq/backend/cython/stopwatch.pyx
@@ -54,8 +54,7 @@ cdef class Stopwatch:
         Start the stopwatch.
         """
         if self.watch == NULL:
-            with nogil:
-                self.watch = zmq_stopwatch_start()
+            self.watch = zmq_stopwatch_start()
         else:
             raise ZMQError('Stopwatch is already runing.')
 
@@ -73,8 +72,7 @@ cdef class Stopwatch:
         if self.watch == NULL:
             raise ZMQError('Must start the Stopwatch before calling stop.')
         else:
-            with nogil:
-                time = zmq_stopwatch_stop(self.watch)
+            time = zmq_stopwatch_stop(self.watch)
             self.watch = NULL
             return time
 

--- a/zmq/devices/monitoredqueue.pyx
+++ b/zmq/devices/monitoredqueue.pyx
@@ -87,17 +87,14 @@ def monitored_queue(Socket in_socket, Socket out_socket, Socket mon_socket,
     
     # build zmq_msg objects from str prefixes
     asbuffer_r(in_prefix, <void **>&msg_c, &msg_c_len)
-    with nogil:
-        rc = zmq_msg_init_size(&in_msg, msg_c_len)
+    rc = zmq_msg_init_size(&in_msg, msg_c_len)
     _check_rc(rc)
     
-    with nogil:
-        memcpy(zmq_msg_data(&in_msg), msg_c, zmq_msg_size(&in_msg))
+    memcpy(zmq_msg_data(&in_msg), msg_c, zmq_msg_size(&in_msg))
     
     asbuffer_r(out_prefix, <void **>&msg_c, &msg_c_len)
     
-    with nogil:
-        rc = zmq_msg_init_size(&out_msg, msg_c_len)
+    rc = zmq_msg_init_size(&out_msg, msg_c_len)
     _check_rc(rc)
     
     with nogil:


### PR DESCRIPTION
We used to release the GIL on all libzmq API calls, but many of these calls are not blocking. Since there is a finite cost to GIL transactions, I have removed the GIL releases that are not on blocking calls.

Simple testing shows a notable improvement in performance for multithreaded apps (simultaneous `while True: send/recv` threads).
