### PR TITLE
Update an exception to refer to send_string() instead of send_unicode()

### DIFF
--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -566,7 +566,7 @@ cdef class Socket:
         _check_closed(self)
         
         if isinstance(data, unicode):
-            raise TypeError("unicode not allowed, use send_unicode")
+            raise TypeError("unicode not allowed, use send_string")
         
         if copy:
             # msg.bytes never returns the input data object


### PR DESCRIPTION
send_string() is preferred to send_unicode() as of 38d832ff7
