### PR TITLE
remove docstrings from pxds

### DIFF
--- a/zmq/backend/cython/context.pxd
+++ b/zmq/backend/cython/context.pxd
@@ -24,7 +24,6 @@
 #-----------------------------------------------------------------------------
 
 cdef class Context:
-    """Manage the lifecycle of a 0MQ context."""
 
     cdef object __weakref__     # enable weakref
     cdef void *handle           # The C handle for the underlying zmq object.

--- a/zmq/backend/cython/message.pxd
+++ b/zmq/backend/cython/message.pxd
@@ -32,14 +32,12 @@ from libzmq cimport zmq_msg_t, zmq_msg_data, zmq_msg_size
 #-----------------------------------------------------------------------------
 
 cdef class MessageTracker(object):
-    """A class for tracking if 0MQ is done using one or more messages."""
 
     cdef set events  # Message Event objects to track.
     cdef set peers   # Other Message or MessageTracker objects.
 
 
 cdef class Frame:
-    """A Message Frame class for non-copy send/recvs."""
 
     cdef zmq_msg_t zmq_msg
     cdef object _data      # The actual message data as a Python object.

--- a/zmq/backend/cython/socket.pxd
+++ b/zmq/backend/cython/socket.pxd
@@ -31,7 +31,6 @@ from context cimport Context
 
 
 cdef class Socket:
-    """A 0MQ socket."""
 
     cdef object __weakref__     # enable weakref
     cdef void *handle           # The C handle for the underlying zmq object.

--- a/zmq/backend/cython/stopwatch.pxd
+++ b/zmq/backend/cython/stopwatch.pxd
@@ -25,7 +25,5 @@
 
 
 cdef class Stopwatch:
-    """A simple stopwatch based on zmq_stopwatch_start/stop."""
-
     cdef void *watch # The C handle for the underlying zmq object
 


### PR DESCRIPTION
latest Cython doesn't allow docstrings in pxd class declarations.
