### PR TITLE
use import to load bundled libzmq in egg

### DIFF
--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -35,24 +35,15 @@ if bundled:
         _libzmq = ctypes.CDLL(bundled[0], mode=ctypes.RTLD_GLOBAL)
     del ctypes
 else:
-    import imp
     import zipimport
-    pkg_resources = None
-    ext_type = 0
-    ext_path = ''
     try:
         if isinstance(__loader__, zipimport.zipimporter):
             # a zipped pyzmq egg
-            import pkg_resources
-            for ext, _, ext_type in imp.get_suffixes():
-                if ext_type == imp.C_EXTENSION:
-                    ext_path = pkg_resources.resource_filename('zmq.libzmq', 'libzmq'+ext)
-                    imp.load_dynamic('zmq.libzmq', ext_path)
-                    break
+            from zmq import libzmq as _libzmq
     except (NameError, ImportError):
         pass
     finally:
-        del imp, zipimport, pkg_resources, ext_type, ext_path
+        del zipimport
 
 # init Python threads
 


### PR DESCRIPTION
use pkg_resources to load libzmq.{so,pyd}, which we could package pyzmq as a single egg file. it will make us we could deploy pyzmq on the fly.
