### PR TITLE
Source prefix of the libzmq library from pkg-config.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ def settings_from_prefix(prefix=None, bundle_libzmq_dylib=False):
         if not prefix:
             try:
                 p = Popen('pkg-config --variable=prefix --print-errors libzmq'.split(), stdout=PIPE, stderr=PIPE)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.ENOENT:
                     info("pkg-config not found")
                 else:
@@ -177,9 +177,9 @@ def settings_from_prefix(prefix=None, bundle_libzmq_dylib=False):
             if p is not None:
                 if p.wait():
                     info("Did not find libzmq via pkg-config:")
-                    info(p.stderr.read())
+                    info(p.stderr.read().decode())
                 else:
-                    prefix = p.stdout.readline().strip()
+                    prefix = p.stdout.readline().strip().decode()
                     info("Using zmq-prefix %s (found via pkg-config)." % prefix)
 
         settings['libraries'].append('zmq')


### PR DESCRIPTION
**tl;dr**: pyzmq does not make use of pkg-config to find the libzmq libraries. I think it should and this pull request adds that feature.

---

Our Jenkins slave fails to install pyzmq using a pip requirements file. We are creating isolated build environments using a different --prefix for different environments.

This is what happens is zeromq and pyzmq when trying to build it on RHEL5 (or actually CentOS5):
## Installing ZeroMQ 3.2.4 (passes)

```
[torsten.landschoff@build-rhel5 build]$ wget http://download.zeromq.org/zeromq-3.2.4.tar.gz
--22:37:07--  http://download.zeromq.org/zeromq-3.2.4.tar.gz
Resolving download.zeromq.org... 95.142.169.98
Connecting to download.zeromq.org|95.142.169.98|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2083123 (2.0M) [application/x-gzip]
Saving to: `zeromq-3.2.4.tar.gz'

100%[==================================================================================================================>] 2,083,123   1.15M/s   in 1.7s   

22:37:09 (1.15 MB/s) - `zeromq-3.2.4.tar.gz' saved [2083123/2083123]

[torsten.landschoff@build-rhel5 build]$ tar xzf zeromq-3.2.4.tar.gz 
[torsten.landschoff@build-rhel5 build]$ cd zeromq-3.2.4
[torsten.landschoff@build-rhel5 zeromq-3.2.4]$ ./configure --prefix=$HOME/opt
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
[...]
config.status: creating src/platform.hpp
config.status: executing depfiles commands
config.status: executing libtool commands
[torsten.landschoff@build-rhel5 zeromq-3.2.4]$ make -j2
Making all in src
make[1]: Entering directory `/home/torsten.landschoff/build/zeromq-3.2.4/src'
make  all-am
make[2]: Entering directory `/home/torsten.landschoff/build/zeromq-3.2.4/src'
[...]
  CXXLD  test_pair_ipc
  CXXLD  test_reqrep_ipc
  CXXLD  test_timeo
make[1]: Leaving directory `/home/torsten.landschoff/build/zeromq-3.2.4/tests'
make[1]: Entering directory `/home/torsten.landschoff/build/zeromq-3.2.4'
make[1]: Nothing to be done for `all-am'.
make[1]: Leaving directory `/home/torsten.landschoff/build/zeromq-3.2.4'

[torsten.landschoff@build-rhel5 zeromq-3.2.4]$ make install
Making install in src
make[1]: Entering directory `/home/torsten.landschoff/build/zeromq-3.2.4/src'
[...]
make[2]: Leaving directory `/home/torsten.landschoff/build/zeromq-3.2.4'
make[1]: Leaving directory `/home/torsten.landschoff/build/zeromq-3.2.4'
```
## ZeroMQ registers with pkg-config

After installation, pkg-config locates libzmq just fine:

```
[torsten.landschoff@build-rhel5 zeromq-3.2.4]$ export PKG_CONFIG_PATH=$HOME/opt/lib/pkgconfig
[torsten.landschoff@build-rhel5 zeromq-3.2.4]$ pkg-config --libs libzmq
-L/home/torsten.landschoff/opt/lib -lzmq  
```

Many open source libs (notably from freedesktop.org, the gnome project etc.) detect settings from pkg-config.
## pyzmq ignores installed libzmq, fails

Even though libzmq is available, pyzmq does not detect it ouf of the box and fails building the bundled version due to missing configure script:

```
[torsten.landschoff@build-rhel5 zeromq-3.2.4]$ cd ..

[torsten.landschoff@build-rhel5 build]$ pip install pyzmq
Downloading/unpacking pyzmq
  Downloading pyzmq-13.1.0.tar.gz (838kB): 838kB downloaded
  Running setup.py egg_info for package pyzmq

    no previously-included directories found matching 'docs/build'
[...]
    Configure: Autodetecting ZMQ settings...
        Custom ZMQ dir:
[...]
    Failed with default libzmq, trying again with /usr/local
    Configure: Autodetecting ZMQ settings...
        Custom ZMQ dir:       /usr/local
[...]
    Warning: Failed to build or run libzmq detection test.

    If you expected pyzmq to link against an installed libzmq, please check to make sure:

        * You have a C compiler installed
[...]
    Using bundled libzmq
    already have bundled/zeromq
    attempting ./configure to generate platform.hpp
    Warning: failed to configure libzmq:
    /bin/sh: ./configure: No such file or directory
[...]
bundled/zeromq/src/ip.cpp: In function ‘zmq::fd_t zmq::open_socket(int, int, int)’:

bundled/zeromq/src/ip.cpp:45: error: ‘SOCK_CLOEXEC’ was not declared in this scope

error: command 'gcc' failed with exit status 1
```
## Suggested patch fixes this

The patch of this pull request fixes this for me:

```
[torsten.landschoff@build-rhel5 build]$ pip install https://github.com/Bluehorn/pyzmq/archive/0b7769addc4ff1da77f453bf1273a71cb74d8844.zip
[...]
Installing collected packages: pyzmq
  Running setup.py install for pyzmq
    Using zmq-prefix /home/torsten.landschoff/opt (found via pkg-config).
    ************************************************
    gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/home/torsten.landschoff/opt/include -c build/temp.linux-x86_64-2.7/scratch/check_sys_un.c -o build/temp.linux-x86_64-2.7/scratch/check_sys_un.o
    gcc -pthread build/temp.linux-x86_64-2.7/scratch/check_sys_un.o -L/home/torsten.landschoff/opt/lib -Wl,-R/home/torsten.landschoff/opt/lib -o build/temp.linux-x86_64-2.7/scratch/check_sys_un
    Configure: Autodetecting ZMQ settings...
        Custom ZMQ dir:
    ************************************************
    cc -c /tmp/timer_createP9sooj.c -o build/temp.linux-x86_64-2.7/scratch/tmp/timer_createP9sooj.o
    cc build/temp.linux-x86_64-2.7/scratch/tmp/timer_createP9sooj.o -o build/temp.linux-x86_64-2.7/scratch/a.out
    build/temp.linux-x86_64-2.7/scratch/tmp/timer_createP9sooj.o: In function `main':
    timer_createP9sooj.c:(.text+0x15): undefined reference to `timer_create'
    collect2: ld returned 1 exit status
    gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/home/torsten.landschoff/opt/include -Izmq/utils -Izmq/backend/cython -Izmq/devices -c build/temp.linux-x86_64-2.7/scratch/vers.c -o build/temp.linux-x86_64-2.7/scratch/vers.o
    gcc -pthread build/temp.linux-x86_64-2.7/scratch/vers.o -L/home/torsten.landschoff/opt/lib -Wl,-R/home/torsten.landschoff/opt/lib -lzmq -lrt -o build/temp.linux-x86_64-2.7/scratch/vers
        ZMQ version detected: 3.2.4
    Warning: Detected ZMQ version: 3.2.4, but pyzmq targets ZMQ 4.0.1.
    Warning: libzmq features and fixes introduced after 3.2.4 will be unavailable.
Successfully installed pyzmq
Cleaning up...
```

Thanks for ZeroMQ and pyzmq. Looks like a great asset to me, albeit I am just starting to use it.
