### PR TITLE
fix default value for copy in send_string

### DIFF
--- a/docs/source/morethanbindings.rst
+++ b/docs/source/morethanbindings.rst
@@ -72,7 +72,7 @@ behave just as you would expect:
 Default Options on the Context
 ******************************
 
-.. versionadded:: 2.1.12
+.. versionadded:: 2.1.11
 
 Just like setting socket options as attributes on Sockets, you can do the same on Contexts.
 This affects the default options of any *new* sockets created after the assignment.

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -270,7 +270,7 @@ class Socket(SocketBase, AttributeSetter):
     
         return parts
 
-    def send_string(self, u, flags=0, copy=False, encoding='utf-8'):
+    def send_string(self, u, flags=0, copy=True, encoding='utf-8'):
         """send a Python unicode string as a message with an encoding
     
         0MQ communicates with raw bytes, so you must encode/decode


### PR DESCRIPTION
should have been True, of course
