### PR TITLE
fix possible use of deallocated python object

### DIFF
--- a/zmq/backend/cython/utils.pyx
+++ b/zmq/backend/cython/utils.pyx
@@ -64,10 +64,11 @@ cdef class Stopwatch:
         self.watch = NULL
 
     def __dealloc__(self):
-        try:
-            self.stop()
-        except ZMQError:
-            pass
+        # copy of self.stop() we can't call object methods in dealloc as it
+        # might already be partially deleted
+        if self.watch:
+            zmq_stopwatch_stop(self.watch)
+            self.watch = NULL
 
     def start(self):
         """s.start()


### PR DESCRIPTION
 **dealloc** method might be called when the object is partially deleted, so
e.g. its methods must not be called. Fix this by copying the code of the
methods which require no python object internals.

Closes #458.
