### PR TITLE
Fixes tornado < 3.0 ioloop "instance" test failure

### DIFF
--- a/zmq/tests/test_ioloop.py
+++ b/zmq/tests/test_ioloop.py
@@ -20,7 +20,7 @@ from zmq.tests import BaseZMQTestCase
 from zmq.eventloop import ioloop
 from zmq.eventloop.minitornado.ioloop import _Timeout
 try:
-    from tornado.ioloop import IOLoop as BaseIOLoop
+    from tornado.ioloop import PollIOLoop, IOLoop as BaseIOLoop
 except ImportError:
     from zmq.eventloop.minitornado.ioloop import IOLoop as BaseIOLoop
 


### PR DESCRIPTION
Older torando does not have PollIOLoop and pyzmq switches to minitornado. But the test fails since IOLoop is still successfully imported.
