### PR TITLE
allow unicode addresses in cffi backend

### DIFF
--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -101,6 +101,8 @@ class Socket(object):
         self.close()
 
     def bind(self, address):
+        if isinstance(address, unicode):
+            address = address.encode('utf8')
         rc = C.zmq_bind(self._zmq_socket, address)
         if rc < 0:
             if IPC_PATH_MAX_LEN and C.zmq_errno() == errno_mod.ENAMETOOLONG:
@@ -116,14 +118,20 @@ class Socket(object):
                 _check_rc(rc)
 
     def unbind(self, address):
+        if isinstance(address, unicode):
+            address = address.encode('utf8')
         rc = C.zmq_unbind(self._zmq_socket, address)
         _check_rc(rc)
 
     def connect(self, address):
+        if isinstance(address, unicode):
+            address = address.encode('utf8')
         rc = C.zmq_connect(self._zmq_socket, address)
         _check_rc(rc)
 
     def disconnect(self, address):
+        if isinstance(address, unicode):
+            address = address.encode('utf8')
         rc = C.zmq_disconnect(self._zmq_socket, address)
         _check_rc(rc)
 

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -54,6 +54,14 @@ class TestSocket(BaseZMQTestCase):
         s.close()
         ctx.term()
 
+    def test_bind_unicode(self):
+        s = self.socket(zmq.PUB)
+        p = s.bind_to_random_port(unicode("tcp://*"))
+
+    def test_connect_unicode(self):
+        s = self.socket(zmq.PUB)
+        s.connect(unicode("tcp://127.0.0.1:5555"))
+
     def test_bind_to_random_port(self):
         # Check that bind_to_random_port do not hide usefull exception
         ctx = self.Context()


### PR DESCRIPTION
It seemed to work already, but I'm not sure why. This at least makes it explicit.
