### PR TITLE
add ZMQVersionError for features that require libzmq newer than linked

### DIFF
--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -14,6 +14,7 @@ import logging
 import zmq
 from zmq.utils import z85
 from zmq.utils.strtypes import bytes, unicode, b, u
+from zmq.error import _check_version
 
 from .certs import load_certificates
 
@@ -32,8 +33,7 @@ class Authenticator(object):
     """
 
     def __init__(self, context=None, encoding='utf-8', log=None):
-        if zmq.zmq_version_info() < (4,0):
-            raise NotImplementedError("Security is only available in libzmq >= 4.0")
+        _check_version((4,0), "security")
         self.context = context or zmq.Context.instance()
         self.encoding = encoding
         self.allow_any = False

--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -24,7 +24,7 @@ from .message import Frame
 from .constants import *
 
 import zmq
-from zmq.error import ZMQError, _check_rc
+from zmq.error import ZMQError, _check_rc, _check_version
 from zmq.utils.strtypes import unicode
 
 
@@ -131,6 +131,7 @@ class Socket(object):
                 _check_rc(rc)
 
     def unbind(self, address):
+        _check_version((3,2), "unbind")
         if isinstance(address, unicode):
             address = address.encode('utf8')
         rc = C.zmq_unbind(self._zmq_socket, address)
@@ -143,6 +144,7 @@ class Socket(object):
         _check_rc(rc)
 
     def disconnect(self, address):
+        _check_version((3,2), "disconnect")
         if isinstance(address, unicode):
             address = address.encode('utf8')
         rc = C.zmq_disconnect(self._zmq_socket, address)
@@ -243,8 +245,8 @@ class Socket(object):
         events : int [default: zmq.EVENT_ALL]
             The zmq event bitmask for which events will be sent to the monitor.
         """
-        if zmq.zmq_version_info() < (3,2):
-            raise NotImplementedError("monitor requires libzmq >= 3.2, have %s" % zmq.zmq_version())
+        
+        _check_version((3,2), "monitor")
         if events < 0:
             events = zmq.EVENT_ALL
         rc = C.zmq_socket_monitor(self._zmq_socket, addr, events)

--- a/zmq/backend/cffi/utils.py
+++ b/zmq/backend/cffi/utils.py
@@ -12,7 +12,7 @@
 
 from ._cffi import ffi, C
 
-from zmq.error import ZMQError, _check_rc
+from zmq.error import ZMQError, _check_rc, _check_version
 
 def curve_keypair():
     """generate a Z85 keypair for use with zmq.CURVE security
@@ -24,6 +24,7 @@ def curve_keypair():
     (public, secret) : two bytestrings
         The public and private keypair as 40 byte z85-encoded bytestrings.
     """
+    _check_version((3,2), "monitor")
     public = ffi.new('char[64]')
     private = ffi.new('char[64]')
     rc = C.zmq_curve_keypair(public, private)

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -75,7 +75,7 @@ import zmq
 from zmq.backend.cython import constants
 from zmq.backend.cython.constants import *
 from zmq.backend.cython.checkrc cimport _check_rc
-from zmq.error import ZMQError, ZMQBindError
+from zmq.error import ZMQError, ZMQBindError, _check_version
 from zmq.utils.strtypes import bytes,unicode,basestring
 
 #-----------------------------------------------------------------------------
@@ -492,11 +492,8 @@ cdef class Socket:
         """
         cdef int rc
         cdef char* c_addr
-        
-        if ZMQ_VERSION_MAJOR < 3:
-            raise NotImplementedError("unbind requires libzmq >= 3.0, have %s" % zmq.zmq_version())
-        
 
+        _check_version((3,2), "unbind")
         _check_closed(self)
         if isinstance(addr, unicode):
             addr = addr.encode('utf-8')
@@ -527,9 +524,7 @@ cdef class Socket:
         cdef int rc
         cdef char* c_addr
         
-        if ZMQ_VERSION_MAJOR < 3:
-            raise NotImplementedError("disconnect requires libzmq >= 3.0, have %s" % zmq.zmq_version())
-
+        _check_version((3,2), "disconnect")
         _check_closed(self)
         if isinstance(addr, unicode):
             addr = addr.encode('utf-8')
@@ -547,6 +542,9 @@ cdef class Socket:
         Start publishing socket events on inproc.
         See libzmq docs for zmq_monitor for details.
         
+        While this function is available from libzmq 3.2,
+        pyzmq cannot parse monitor messages from libzmq prior to 4.0.
+        
         .. versionadded: libzmq-3.2
         .. versionadded: 14.0
         
@@ -560,9 +558,7 @@ cdef class Socket:
         cdef int rc, c_flags
         cdef char* c_addr
         
-        if zmq.zmq_version_info() < (3,2):
-            raise NotImplementedError("monitor requires libzmq >= 3.2, have %s" % zmq.zmq_version())
-        
+        _check_version((3,2), "monitor")
         if isinstance(addr, unicode):
             addr = addr.encode('utf-8')
         if not isinstance(addr, bytes):

--- a/zmq/backend/cython/utils.pyx
+++ b/zmq/backend/cython/utils.pyx
@@ -25,7 +25,7 @@
 
 from libzmq cimport zmq_stopwatch_start, zmq_stopwatch_stop, zmq_sleep, zmq_curve_keypair
 
-from zmq.error import ZMQError, _check_rc
+from zmq.error import ZMQError, _check_rc, _check_version
 
 #-----------------------------------------------------------------------------
 # Code
@@ -47,6 +47,7 @@ def curve_keypair():
     cdef int rc
     cdef char[64] public_key
     cdef char[64] secret_key
+    _check_version((4,0), "curve_keypair")
     rc = zmq_curve_keypair (public_key, secret_key)
     _check_rc(rc)
     return public_key, secret_key

--- a/zmq/error.py
+++ b/zmq/error.py
@@ -126,5 +126,48 @@ def _check_rc(rc, errno=None):
         else:
             raise ZMQError(errno)
 
+_zmq_version_info = None
+_zmq_version = None
 
-__all__ = ['ZMQBaseError', 'ZMQBindError', 'ZMQError', 'NotDone', 'ContextTerminated', 'Again']
+class ZMQVersionError(NotImplementedError):
+    def __init__(self, min_version, msg='Feature'):
+        global _zmq_version
+        if _zmq_version is None:
+            from zmq import zmq_version
+            _zmq_version = zmq_version()
+        self.msg = msg
+        self.min_version = min_version
+        self.version = _zmq_version
+    
+    def __repr__(self):
+        return "ZMQVersionError('%s')" % str(self)
+    
+    def __str__(self):
+        return "%s requires libzmq >= %s, have %s" % (self.msg, self.min_version, self.version)
+
+
+def _check_version(min_version_info, msg='Feature'):
+    """Check for libzmq
+    
+    raises ZMQVersionError if current zmq version is not at least min_version
+    
+    min_version_info is a tuple of integers, and will be compared against zmq.zmq_version_info().
+    """
+    global _zmq_version_info
+    if _zmq_version_info is None:
+        from zmq import zmq_version_info
+        _zmq_version_info = zmq_version_info()
+    if _zmq_version_info < min_version_info:
+        min_version = '.'.join(str(v) for v in min_version_info)
+        raise ZMQVersionError(min_version, msg)
+
+
+__all__ = [
+    'ZMQBaseError',
+    'ZMQBindError',
+    'ZMQError',
+    'NotDone',
+    'ContextTerminated',
+    'Again',
+    'ZMQVersionError',
+]

--- a/zmq/utils/monitor.py
+++ b/zmq/utils/monitor.py
@@ -12,9 +12,7 @@
 
 import struct
 import zmq
-
-# used to determine which version of the event message API is in use
-LIBZMQVERSION = zmq.zmq_version_info()
+from zmq.error import _check_version
 
 def parse_monitor_message(msg):
     """decode zmq_monitor event messages.
@@ -67,8 +65,7 @@ def recv_monitor_message(socket, flags=0):
     event : dict
         event description as dict with the keys `event`, `value`, and `endpoint`.
     """
-    if LIBZMQVERSION < (4,):
-        raise NotImplementedError("libzmq event API needs libzmq version >= 4.0, you have %s!" % zmq.zmq_version())
+    _check_version((4,0), 'libzmq event API')
     # will always return a list
     msg = socket.recv_multipart(flags)
     # 4.0-style event API


### PR DESCRIPTION
subclass of NotImplementedError for backward compatibility

should give better information when things don't work because of libzmq versions
