### PR TITLE
raise ENOTSOCK instead of ENOTSUP on closed sockets

### DIFF
--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -93,7 +93,7 @@ cdef inline _check_closed(Socket s):
     Does not do a deep check
     """
     if s._closed:
-        raise ZMQError(ENOTSUP)
+        raise ZMQError(ENOTSOCK)
 
 cdef inline _check_closed_deep(Socket s):
     """thorough check of whether the socket has been closed,

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -285,11 +285,11 @@ class TestSocket(BaseZMQTestCase):
         ctx = self.Context()
         s = ctx.socket(zmq.PUB)
         s.close()
-        self.assertRaises(zmq.ZMQError, s.bind, b'')
-        self.assertRaises(zmq.ZMQError, s.connect, b'')
-        self.assertRaises(zmq.ZMQError, s.setsockopt, zmq.SUBSCRIBE, b'')
-        self.assertRaises(zmq.ZMQError, s.send, b'asdf')
-        self.assertRaises(zmq.ZMQError, s.recv)
+        self.assertRaisesErrno(zmq.ENOTSOCK, s.bind, b'')
+        self.assertRaisesErrno(zmq.ENOTSOCK, s.connect, b'')
+        self.assertRaisesErrno(zmq.ENOTSOCK, s.setsockopt, zmq.SUBSCRIBE, b'')
+        self.assertRaisesErrno(zmq.ENOTSOCK, s.send, b'asdf')
+        self.assertRaisesErrno(zmq.ENOTSOCK, s.recv)
         del ctx
     
     def test_attr(self):


### PR DESCRIPTION
more consistent with underlying libzmq behavior

cffi backend already behaved this way, just change cython to match.

closes #523
