### PR TITLE
Remove erroneous term(linger) from CFFI backend

### DIFF
--- a/zmq/backend/cffi/context.py
+++ b/zmq/backend/cffi/context.py
@@ -85,17 +85,9 @@ class Context(object):
         _check_rc(rc)
         return rc
 
-    def term(self, linger=None):
+    def term(self):
         if self.closed:
             return
-
-        sockets = self._sockets
-        self._sockets = set()
-        for s in sockets:
-            s = s()
-            if s and not s.closed:
-                if linger:
-                    s.setsockopt(LINGER, linger)
 
         C.zmq_ctx_destroy(self._zmq_ctx)
 


### PR DESCRIPTION
It doesn't make sense for term to take a linger arg, because the only time it can have an effect requires a violation of threadsafety.
