### PR TITLE
fix inappropriate use of Py_ssize_t

### DIFF
--- a/zmq/backend/cython/context.pyx
+++ b/zmq/backend/cython/context.pyx
@@ -55,7 +55,7 @@ cdef class Context:
     def __init__(self, io_threads=1, shadow=0):
         pass
     
-    def __cinit__(self, int io_threads=1, Py_ssize_t shadow=0, **kwargs):
+    def __cinit__(self, int io_threads=1, size_t shadow=0, **kwargs):
         self.handle = NULL
         self._sockets = NULL
         if shadow:
@@ -141,7 +141,7 @@ cdef class Context:
     @property
     def underlying(self):
         """The address of the underlying libzmq context"""
-        return <Py_ssize_t> self.handle
+        return <size_t> self.handle
     
     # backward-compat, though nobody is using it
     _handle = underlying

--- a/zmq/backend/cython/rebuffer.pyx
+++ b/zmq/backend/cython/rebuffer.pyx
@@ -92,7 +92,7 @@ def print_view_info(obj):
 
     if mode == 3:
         PyObject_GetBuffer(obj, &view, flags)
-        print <Py_ssize_t>view.buf, view.len, view.format, view.ndim,
+        print <size_t>view.buf, view.len, view.format, view.ndim,
         if view.ndim:
             if view.shape:
                 print view.shape[0],

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -247,7 +247,7 @@ cdef class Socket:
     @property
     def underlying(self):
         """The address of the underlying libzmq socket"""
-        return <Py_ssize_t> self.handle
+        return <size_t> self.handle
     
     @property
     def closed(self):


### PR DESCRIPTION
`Py_ssize_t != size_t`, so casting `void*` to `Py_ssize_t` could result in OverflowErrors due to negative pointers.

closes #533
