### PR TITLE
Correct parameters in on_recv_stream callback

### DIFF
--- a/docs/source/eventloop.rst
+++ b/docs/source/eventloop.rst
@@ -117,7 +117,7 @@ it easier to use a single callback with multiple streams.
     s2.bind('tcp://localhost:54321')
     stream2 = ZMQStream(s2)
     
-    def echo(msg, stream):
+    def echo(stream, msg):
         stream.send_multipart(msg)
     
     stream1.on_recv_stream(echo)


### PR DESCRIPTION
As per http://zeromq.github.io/pyzmq/api/generated/zmq.eventloop.zmqstream.html#zmq.eventloop.zmqstream.ZMQStream.on_recv_stream
the signature is 

```
callback(stream, msg)
```

However the example gives

```
def echo(msg, stream):
    stream.send_multipart(msg)
```
