### PR TITLE
support ssh multiplexer in tunnels

### DIFF
--- a/zmq/ssh/tunnel.py
+++ b/zmq/ssh/tunnel.py
@@ -212,6 +212,16 @@ def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pas
         server, port = server.split(':')
         ssh += " -p %s" % port
     
+    cmd = "%s -O check %s" % (ssh, server)
+    (output, exitstatus) = pexpect.run(cmd, withexitstatus=True)
+    if not exitstatus:
+        pid = int(output[output.find("(pid=")+5:output.find(")")]) 
+        cmd = "%s -O forward -L 127.0.0.1:%i:%s:%i %s" % (
+            ssh, lport, remoteip, rport, server)
+        (output, exitstatus) = pexpect.run(cmd, withexitstatus=True)
+        if not exitstatus:
+            atexit.register(_stop_tunnel, cmd.replace("forward", "cancel", 1))
+            return pid
     cmd = "%s -f -S none -L 127.0.0.1:%i:%s:%i %s sleep %i" % (
         ssh, lport, remoteip, rport, server, timeout)
     tunnel = pexpect.spawn(cmd)
@@ -238,6 +248,9 @@ def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pas
             tunnel.sendline(password)
             failed = True
     
+def _stop_tunnel(cmd):
+    pexpect.run(cmd)
+
 def _split_server(server):
     if '@' in server:
         username,server = server.split('@', 1)


### PR DESCRIPTION
Currently openssh_tunnel overrides the user's ssh configuration to force multiplexing off with "-S none". That was to work around a bug in openssh (ipython/ipython#4720)

This patch uses the multiplex connection if one is available, while avoiding the problem with the "-f" bug.

Have done some minimal testing, with/without mux and with/without public key auth.
