### PR TITLE
make monitor test more robust

### DIFF
--- a/zmq/tests/test_monitor.py
+++ b/zmq/tests/test_monitor.py
@@ -35,11 +35,13 @@ class TestSocketMonitor(BaseZMQTestCase):
         # test receive event for connect event
         s_rep.connect("tcp://127.0.0.1:6666")
         m = recv_monitor_message(s_event)
-        self.assertEqual(m['event'], zmq.EVENT_CONNECT_DELAYED)
-        self.assertEqual(m['endpoint'], b"tcp://127.0.0.1:6666")
-        # test receive event for connected event
-        m = recv_monitor_message(s_event)
+        if m['event'] == zmq.EVENT_CONNECT_DELAYED:
+            self.assertEqual(m['endpoint'], b"tcp://127.0.0.1:6666")
+            # test receive event for connected event
+            m = recv_monitor_message(s_event)
         self.assertEqual(m['event'], zmq.EVENT_CONNECTED)
+        self.assertEqual(m['endpoint'], b"tcp://127.0.0.1:6666")
+
 
     @skip_lt_4
     def test_monitor_connected(self):
@@ -56,8 +58,9 @@ class TestSocketMonitor(BaseZMQTestCase):
         # test receive event for connect event
         s_rep.connect("tcp://127.0.0.1:6667")
         m = recv_monitor_message(s_event)
-        self.assertEqual(m['event'], zmq.EVENT_CONNECT_DELAYED)
-        self.assertEqual(m['endpoint'], b"tcp://127.0.0.1:6667")
-        # test receive event for connected event
-        m = recv_monitor_message(s_event)
+        if m['event'] == zmq.EVENT_CONNECT_DELAYED:
+            self.assertEqual(m['endpoint'], b"tcp://127.0.0.1:6667")
+            # test receive event for connected event
+            m = recv_monitor_message(s_event)
         self.assertEqual(m['event'], zmq.EVENT_CONNECTED)
+        self.assertEqual(m['endpoint'], b"tcp://127.0.0.1:6667")


### PR DESCRIPTION
on freebsd the socket connect is not delayed and succeeds immediately
