### PR TITLE
Add TypeError handling to _check_rc function.

### DIFF
--- a/zmq/backend/cython/checkrc.pxd
+++ b/zmq/backend/cython/checkrc.pxd
@@ -11,13 +11,22 @@ cdef inline int _check_rc(int rc) except -1:
     PyErr_CheckSignals()
     if rc < 0:
         if errno == EAGAIN:
-            from zmq.error import Again
+            try:
+                from zmq.error import Again
+            except TypeError:
+                return 0
             raise Again(errno)
         elif errno == ZMQ_ETERM:
-            from zmq.error import ContextTerminated
+            try:
+                from zmq.error import ContextTerminated
+            except TypeError:
+                return 0
             raise ContextTerminated(errno)
         else:
-            from zmq.error import ZMQError
+            try:
+                from zmq.error import ZMQError
+            except TypeError:
+                return 0
             raise ZMQError(errno)
         # return -1
     return 0


### PR DESCRIPTION
I have experimented some problems at the end of a process that uses pyzmq with Python 3.4.0 (and Python 3.4.1 as well). The following Exception is raised on some occasions.

```
Exception ignored in: <bound method Socket.__del__ of <zmq.sugar.socket.Socket object at 0x1119908e8>>
Traceback (most recent call last):
  File "[...]/site-packages/zmq/sugar/socket.py", line 52, in __del__
  File "socket.pyx", line 277, in zmq.backend.cython.socket.Socket.close (zmq/backend/cython/socket.c:2985)
  File "checkrc.pxd", line 21, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:6007)
TypeError: 'NoneType' object is not callable
```

This exception is raised because the importation of zmq.error classes is impossible. This is yet fully known why it happens, but it is probably related to the garbage collector. This patch avoids TypeError by catching them if they happen during the importation, and simply returns 0 since this means that the process has ended anyway.

The other solution would be to import the exception at the beginning of the module, and check `if ZMQError is not None` before raising it.
