### PR TITLE
Add verification of context state in Socket.__dealloc__.

### DIFF
--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -237,7 +237,7 @@ cdef class Socket:
         """
         if self.handle != NULL and not self._shadow and getpid() == self._pid:
             # during gc, self.context might be NULL
-            if self.context:
+            if self.context and not self.context.closed:
                 self.context._remove_socket(self.handle)
     
     @property


### PR DESCRIPTION
If the context is closed but not the deleted and `Socket.__dealloc__` is called by the garbage collector, an exception is thrown when executing the _check_rc function. This appears to happen only with Python 3.4.0 and 3.4.1.

```
Exception ignored in: <bound method Socket.__del__ of <zmq.sugar.socket.Socket object at 0x1119908e8>>
Traceback (most recent call last):
  File "[...]/site-packages/zmq/sugar/socket.py", line 52, in __del__
  File "socket.pyx", line 277, in zmq.backend.cython.socket.Socket.close (zmq/backend/cython/socket.c:2985)
  File "checkrc.pxd", line 21, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:6007)
TypeError: 'NoneType' object is not callable
```

This can be reproduced by executing this simple script which requires [scoop](https://scoop.googlecode.com).

```
#!/usr/bin/env python3 -m scoop -n 2
import scoop.futures
```
