### PR TITLE
make meta property test not fail silently

### DIFF
--- a/zmq/tests/test_security.py
+++ b/zmq/tests/test_security.py
@@ -84,7 +84,7 @@ class TestSecurity(BaseZMQTestCase):
                     self.assertEqual(frame.get('Hello'), 'World')
                     self.assertEqual(frame['Socket-Type'], 'DEALER')
         except zmq.ZMQVersionError as e:
-            print('error %s' % e
+            print('error %s' % e)
             pass
 
         self.assertEqual(recvd, msg)


### PR DESCRIPTION
It took me some time to figure out why the test does not fail, until I noticed it actually fails.
