### PR TITLE
Fork detection before binding the socket.

### DIFF
--- a/zmq/utils/garbage.py
+++ b/zmq/utils/garbage.py
@@ -29,10 +29,11 @@ class GarbageCollectorThread(Thread):
         self.ready = Event()
     
     def run(self):
-        s = self.gc.context.socket(zmq.PULL)
-        s.linger = 0
+        # detect fork at begining of the thread
         if getpid is None or getpid() != self.pid:
             return
+        s = self.gc.context.socket(zmq.PULL)
+        s.linger = 0
         s.bind(self.gc.url)
 
         self.ready.set()


### PR DESCRIPTION
In case fork happens before s.bind, we will run into an address in use error.

This fix will alleviate the problem, but it is still less than ideal. -- what if a fork happens before s.bind? 
same applies to the detection before s.recv().

This is related to Issue #440 and Issue #439.
