### PR TITLE
Stop building bdists for Python 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,16 @@ version 0.16 or later.
 
 For more detail on building pyzmq, see [our Wiki](https://github.com/zeromq/pyzmq/wiki/Building-and-Installing-PyZMQ).
 
-We build eggs and wheels for OS X and Windows, so you can get a binary on those platforms with either:
+We build wheels for OS X and Windows, so you can get a binary installer on those platforms with:
 
     pip install pyzmq
 
-or
-
-    easy_install pyzmq
-
 but compiling from source with `pip install pyzmq` should work in most environments.
+If the wheel doesn't work for some reason, or you want to force pyzmq to be compiled
+(this is often preferable if you already have libzmq installed and configured the way you want it),
+you can force installation with:
+
+    pip install --no-use-wheel pyzmq
 
 When compiling pyzmq (e.g. installing with pip on Linux),
 it is generally recommended that zeromq be installed separately,
@@ -69,7 +70,7 @@ via homebrew, apt, yum, etc:
 If this is not available, pyzmq will *try* to build libzmq as a Python Extension,
 though this is not guaranteed to work.
 
-To build pyzmq from the git repo (including release tags) requires Cython.
+Building pyzmq from the git repo (including release tags on GitHub) requires Cython.
 
 ## Old versions
 

--- a/tools/release_windows.bat
+++ b/tools/release_windows.bat
@@ -1,11 +1,11 @@
 @echo off
 REM build a pyzmq release on Windows
-REM 32+64b eggs on Python 27, 33, and wheels on 27, 33, 34
-REM that's 10 bdists
-REM requires Windows SDK 7.0 and 7.1
+REM 32+64b eggs on Python 27, and wheels on 27, 34
+REM that's 6 bdists
+REM requires Windows SDK 7.0 (for py2) and 7.1 (for py3)
 REM and Python installed in the locations: C:\Python34 (32b) and C:\Python34_64 (64b)
 
-REM run with cmd.exe /k tools/release_windows.bat
+REM run with cmd /k tools/release_windows.bat
 
 setlocal EnableDelayedExpansion
 
@@ -13,9 +13,10 @@ set SDKS=C:\Program Files\Microsoft SDKs\Windows
 set SDK7=%SDKS%\v7.0
 set SDK71=%SDKS%\v7.1
 set DISTUTILS_USE_SDK=1
-set UPLOAD=upload
+set UPLOAD=%~1
+set PYROOT=C:\
 
-for %%p in (34, 33, 27) do (
+for %%p in (34, 27) do (
   if "%%p"=="27" (
     set SDK=%SDK7%
   ) else (
@@ -35,8 +36,7 @@ for %%p in (34, 33, 27) do (
       set SUFFIX=
       set ARCH=/x86
     )
-    set PY=C:\Python%%p!SUFFIX!\Python
-    if not "%%p"=="27" set PY=!PY!
+    set PY=%PYROOT%\Python%%p!SUFFIX!\Python
     echo !PY! !SDK!
     !PY! -m pip install --upgrade setuptools pip wheel
     

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -32,11 +32,10 @@ repo = "git@github.com:zeromq/pyzmq"
 
 py_exes = {
     '2.7' : "/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7",
-    '3.3' : "/Library/Frameworks/Python.framework/Versions/3.3/bin/python3.3",
     '3.4' : "/Library/Frameworks/Python.framework/Versions/3.4/bin/python3.4",
     'pypy': "/usr/local/bin/pypy",
 }
-egg_pys = {'2.7', '3.3'}
+egg_pys = {'2.7'}
 
 tmp = "/tmp"
 env_root = os.path.join(tmp, 'envs')


### PR DESCRIPTION
Only wheels + eggs on 2.7, wheels on 3.4.

pyzmq-14.3 was the last version to ship 3.3 bdists.
