### PR TITLE
Set ready exiting from the scope early

### DIFF
--- a/zmq/utils/garbage.py
+++ b/zmq/utils/garbage.py
@@ -31,12 +31,14 @@ class GarbageCollectorThread(Thread):
     def run(self):
         # detect fork at begining of the thread
         if getpid is None or getpid() != self.pid:
+            self.ready.set()
             return
-        s = self.gc.context.socket(zmq.PULL)
-        s.linger = 0
-        s.bind(self.gc.url)
-
-        self.ready.set()
+        try:
+            s = self.gc.context.socket(zmq.PULL)
+            s.linger = 0
+            s.bind(self.gc.url)
+        finally:
+            self.ready.set()
         
         while True:
             # detect fork


### PR DESCRIPTION
so that the main thread won't deadlock on self.ready if bad things happen.

This is related to the deadlock after the 'address in use error' in forked children. The intent of this patch is that although forked subprocesses would still see 'address in use error' at bind, they will set self.ready so that the error in the gc thread is ignored and the main thread can continue. 
