### PR TITLE
libzmq-4.1 changed default LINGER

### DIFF
--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -173,7 +173,6 @@ class TestSocket(BaseZMQTestCase):
         "test set/getsockopt roundtrip."
         p = self.context.socket(zmq.PUB)
         self.sockets.append(p)
-        self.assertEqual(p.getsockopt(zmq.LINGER), -1)
         p.setsockopt(zmq.LINGER, 11)
         self.assertEqual(p.getsockopt(zmq.LINGER), 11)
     


### PR DESCRIPTION
don't check that the default value is -1, because libzmq is an unreliable moving target.
