### PR TITLE
when setup.py receives --debug it will put '_d' on the library name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ for idx, arg in enumerate(list(sys.argv)):
 
 # --- compiler settings -------------------------------------------------
 
-def bundled_settings():
+def bundled_settings(debug):
     """settings for linking extensions against bundled libzmq"""
     settings = {}
     settings['libraries'] = []
@@ -133,8 +133,12 @@ def bundled_settings():
         # link against libzmq in build dir:
         plat = distutils.util.get_platform()
         temp = 'temp.%s-%s' % (plat, sys.version[0:3])
-        settings['libraries'].append('libzmq')
-        settings['library_dirs'].append(pjoin('build', temp, 'Release', 'buildutils'))
+        if debug:
+            settings['libraries'].append('libzmq_d')
+            settings['library_dirs'].append(pjoin('build', temp, 'Debug', 'buildutils'))
+        else:
+            settings['libraries'].append('libzmq')
+            settings['library_dirs'].append(pjoin('build', temp, 'Release', 'buildutils'))
     
     return settings
 
@@ -264,7 +268,7 @@ class Configure(build_ext):
         cfg = self.config
         
         if cfg['libzmq_extension']:
-            settings = bundled_settings()
+            settings = bundled_settings(self.debug)
         else:
             settings = settings_from_prefix(cfg['zmq_prefix'], self.bundle_libzmq_dylib)
     


### PR DESCRIPTION
If I have a python compiled locally in [debug mode](https://docs.python.org/2/c-api/intro.html#debugging-builds) then I won't be able to compile the library since it says that the `libzmq` library was not found.

The problem is that the `libzmq_d.pyd` is created the linker doesn't know about this filename.
# Motivation

I wanted to use IPython with [Python Debug Builds](https://docs.python.org/2/c-api/intro.html#debugging-builds) and `pyzmq` is a dependency.
# Tests

I'm running Windows 7 - 64bits, Python 2.7.7.

[_Pytest_](http://pytest.org) was used to run the tests.

These _python 2_ versions were tested against:
#32 bits - debug

No failures.
#32 bits - release

`TestMonitoredQueue.test_router_router` failed:

```
____________________ TestMonitoredQueue.test_router_router ____________________

self = <tests.test_monqueue.TestMonitoredQueue testMethod=test_router_router>

    def test_router_router(self):
        """test router-router MQ devices"""
        dev = devices.ThreadMonitoredQueue(zmq.ROUTER, zmq.ROUTER, zmq.PUB, b'in', b'out')
        self.device = dev
        dev.setsockopt_in(zmq.LINGER, 0)
        dev.setsockopt_out(zmq.LINGER, 0)
        dev.setsockopt_mon(zmq.LINGER, 0)

        binder = self.context.socket(zmq.DEALER)
        porta = binder.bind_to_random_port('tcp://127.0.0.1')
        portb = binder.bind_to_random_port('tcp://127.0.0.1')
        binder.close()
        time.sleep(0.1)
        a = self.context.socket(zmq.DEALER)
        a.identity = b'a'
        b = self.context.socket(zmq.DEALER)
        b.identity = b'b'
        self.sockets.extend([a, b])

        a.connect('tcp://127.0.0.1:%i'%porta)
        dev.bind_in('tcp://127.0.0.1:%i'%porta)
        b.connect('tcp://127.0.0.1:%i'%portb)
        dev.bind_out('tcp://127.0.0.1:%i'%portb)
        dev.start()
        time.sleep(0.2)
        if zmq.zmq_version_info() >= (3,1,0):
            # flush erroneous poll state, due to LIBZMQ-280
            ping_msg = [ b'ping', b'pong' ]
            for s in (a,b):
                s.send_multipart(ping_msg)
                try:
                    s.recv(zmq.NOBLOCK)
                except zmq.ZMQError:
                    pass
        msg = [ b'hello', b'there' ]
        a.send_multipart([b'b']+msg)
>       bmsg = self.recv_multipart(b)

test_monqueue.py:203:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
f:\Shared\dist\12.0-win32\pyzmq-14.4.1\lib\site-packages\zmq\tests\__init__.py:169: in recv_multipart
    return self._select_recv(True, socket, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_monqueue.TestMonitoredQueue testMethod=test_router_router>
multipart = True, socket = <zmq.sugar.socket.Socket object at 0x02F4A148>
kwargs = {}, r = [], w = [], x = []

    def _select_recv(self, multipart, socket, **kwargs):
        """call recv[_multipart] in a way that raises if there is nothing to receive"""
        if zmq.zmq_version_info() >= (3,1,0):
            # zmq 3.1 has a bug, where poll can return false positives,
```

However, If I run this test alone it passes:

```
dist-12.0-win32 $ pytest test_monqueue.py -k test_router_router -v
test_monqueue.py::TestMonitoredQueue::test_router_router PASSED
```
#64 bits - debug

The same situation as "win32 release" happens
#64 bits - release

no failures
