### PR TITLE
some cert cleanup

### DIFF
--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -244,7 +244,7 @@ class Authenticator(object):
             if domain in self.certs:
                 # The certs dict stores keys in z85 format, convert binary key to z85 bytes
                 z85_client_key = z85.encode(client_key)
-                if z85_client_key in self.certs[domain] or self.certs[domain] == b'OK':
+                if self.certs[domain].get(z85_client_key):
                     allowed = True
                     reason = b"OK"
                 else:

--- a/zmq/auth/certs.py
+++ b/zmq/auth/certs.py
@@ -80,6 +80,8 @@ def load_certificate(filename):
     
     If the certificate file only contains the public key,
     secret_key will be None.
+
+    If there is no public key found in the file, ValueError will be raised.
     """
     public_key = None
     secret_key = None
@@ -98,6 +100,9 @@ def load_certificate(filename):
             if public_key and secret_key:
                 break
     
+    if public_key is None:
+        raise ValueError("No public key found in %s" % filename)
+
     return public_key, secret_key
 
 

--- a/zmq/auth/certs.py
+++ b/zmq/auth/certs.py
@@ -113,7 +113,7 @@ def load_certificates(directory='.'):
     for cert_file in cert_files:
         public_key, _ = load_certificate(cert_file)
         if public_key:
-            certs[public_key] = 'OK'
+            certs[public_key] = True
     return certs
 
 __all__ = ['create_certificates', 'load_certificate', 'load_certificates']

--- a/zmq/auth/certs.py
+++ b/zmq/auth/certs.py
@@ -38,6 +38,8 @@ def _write_key_file(key_filename, banner, public_key, secret_key=None, metadata=
         f.write(u('metadata\n'))
         if metadata:
             for k, v in metadata.items():
+                if isinstance(k, bytes):
+                    k = k.decode(encoding)
                 if isinstance(v, bytes):
                     v = v.decode(encoding)
                 f.write(u("    {0} = {1}\n").format(k, v))
@@ -80,7 +82,7 @@ def load_certificate(filename):
     
     If the certificate file only contains the public key,
     secret_key will be None.
-
+    
     If there is no public key found in the file, ValueError will be raised.
     """
     public_key = None
@@ -102,7 +104,7 @@ def load_certificate(filename):
     
     if public_key is None:
         raise ValueError("No public key found in %s" % filename)
-
+    
     return public_key, secret_key
 
 


### PR DESCRIPTION
- ValueError if load_certificate doesn't find a public key
- store allowed keys with bool, not "OK"
- cleanup some bytes/unicode in certs.py

closes #633