### PR TITLE
bind_to_random_port fixes

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -185,6 +185,14 @@ class Socket(SocketBase, AttributeSetter):
         ZMQBindError
             if `max_tries` reached before successful bind
         """
+        if hasattr(constants, 'LAST_ENDPOINT') and min_port == 49152 and max_port == 65536:
+            # if LAST_ENDPOINT is supported, and min_port / max_port weren't specified,
+            # we can bind to port 0 and let the OS do the work
+            self.bind("%s:0" % addr)
+            url = self.last_endpoint.decode('ascii', 'replace')
+            _, port_s = url.rsplit(':', 1)
+            return int(port_s)
+        
         for i in range(max_tries):
             try:
                 port = random.randrange(min_port, max_port)

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -5,8 +5,9 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-import codecs
+import errno
 import random
+import sys
 import warnings
 
 import zmq
@@ -198,7 +199,12 @@ class Socket(SocketBase, AttributeSetter):
                 port = random.randrange(min_port, max_port)
                 self.bind('%s:%s' % (addr, port))
             except ZMQError as exception:
-                if not exception.errno == zmq.EADDRINUSE:
+                en = exception.errno
+                if en == zmq.EADDRINUSE:
+                    continue
+                elif sys.platform == 'win32' and en == errno.EACCES:
+                    continue
+                else:
                     raise
             else:
                 return port

--- a/zmq/utils/constant_names.py
+++ b/zmq/utils/constant_names.py
@@ -29,6 +29,8 @@ new_in = {
         'MAX_SOCKETS_DFLT',
         
         # socket opts
+        'IPV4ONLY',
+        'LAST_ENDPOINT',
         'ROUTER_BEHAVIOR',
         'ROUTER_MANDATORY',
         'FAIL_UNROUTABLE',


### PR DESCRIPTION
- use :0 in bind_to_random_port when LAST_ENDPOINT is available (libzmq ≥ 3.x)
- treat EACCESS on Windows the same as EADDRINUSE

closes #650