### PR TITLE
Fixed byte size computation for numpy array

### DIFF
--- a/examples/serialization/serialsocket.py
+++ b/examples/serialization/serialsocket.py
@@ -57,7 +57,7 @@ def main():
     rep.bind('inproc://a')
     req.connect('inproc://a')
     A = numpy.ones((1024,1024))
-    print ("Array is %i bytes" % (len(A) * 8))
+    print ("Array is %i bytes" % (A.size * A.itemsize))
     
     # send/recv with pickle+zip
     req.send_zipped_pickle(A)


### PR DESCRIPTION
* `len(A)` returns the number of rows (which is 1024 in this case) while the total number of elements is to be retrieved with `A.size`
* the exact byte size of each element can be obtained with `A.itemsize` regardless of the actual `dtype` used for the array

with these changes the original size is correctly computed as 8388608 bytes which is exactly 8Mb