### PR TITLE
Adds support for building libsodium on Windows.

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -36,7 +36,7 @@ bundled_version = (4,0,5)
 libzmq = "zeromq-%i.%i.%i.tar.gz" % (bundled_version)
 libzmq_url = "http://download.zeromq.org/" + libzmq
 
-libsodium_version = (1,0,0)
+libsodium_version = (1,0,2)
 libsodium = "libsodium-%i.%i.%i.tar.gz" % (libsodium_version)
 libsodium_url = "https://github.com/jedisct1/libsodium/releases/download/%i.%i.%i/" % libsodium_version + libsodium
 

--- a/buildutils/include_win32/stdint.h
+++ b/buildutils/include_win32/stdint.h
@@ -1,7 +1,7 @@
 #ifndef _stdint_h__
 #define _stdint_h__
 
-#include "../bundled/zeromq/src/stdint.hpp"
+#include "../../bundled/zeromq/src/stdint.hpp"
 
 #define UINT8_MAX 0xff
 #define UINT16_MAX 0xffff

--- a/buildutils/initlibsodium.c
+++ b/buildutils/initlibsodium.c
@@ -5,7 +5,7 @@ and used under the BSD license
 py3compat from http://wiki.python.org/moin/PortingExtensionModulesToPy3k
 
 Provide the init function that Python expects
-when we compile libzmq by pretending it is a Python extension.
+when we compile libsodium by pretending it is a Python extension.
 */
 #include "Python.h"
 
@@ -28,7 +28,7 @@ static struct PyModuleDef moduledef = {
 };
 
 PyMODINIT_FUNC
-PyInit_libzmq(void)
+PyInit_libsodium(void)
 {
     PyObject *module = PyModule_Create(&moduledef);
     return module;
@@ -37,7 +37,7 @@ PyInit_libzmq(void)
 #else // py2
 
 PyMODINIT_FUNC
-initlibzmq(void)
+initlibsodium(void)
 {
     (void) Py_InitModule("libsodium", Methods);
 }

--- a/patch/stdint.h
+++ b/patch/stdint.h
@@ -1,0 +1,11 @@
+#ifndef _stdint_h__
+#define _stdint_h__
+
+#include "../bundled/zeromq/src/stdint.hpp"
+
+#define UINT8_MAX 0xff
+#define UINT16_MAX 0xffff
+#define UINT32_MAX 0xffffffff
+#define UINT64_MAX 0xffffffffffffffffull
+
+#endif /* _stdint_h__ */

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -22,7 +22,7 @@
 
 // define fd type (from libzmq's fd.hpp)
 #ifdef _WIN32
-  #ifdef _MSC_VER && _MSC_VER <= 1400
+  #if defined(_MSC_VER) && _MSC_VER <= 1400
     #define ZMQ_FD_T UINT_PTR
   #else
     #define ZMQ_FD_T SOCKET


### PR DESCRIPTION
Libsodium compiles fine on Windows, even with VS2008 (for Python 2.7).  However, it requires a few tricks:
- VS2008 doesn't provide `<stdint.h>`, so we need to mock it (like libzmq already does);
- VS2008 doesn't support C99 `static inline` functions, but removing the `inline` when compiling it for PyZMQ seems to work fine;
- before version 1.0.1, libsodium uses the same `DLL_EXPORT` switch as libzmq, which prevented from compiling libsodium as a dependency of libzmq (since version 1.0.1, libsodium changed this macro to `SODIUM_DLL_EXPORT` and no longer conflicts with PyZMQ).