### PR TITLE
Add warnings about setsockopt delayed effect.

### DIFF
--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -298,6 +298,13 @@ cdef class Socket:
         
         optval : int or bytes
             The value of the option to set.
+
+        Notes
+        -----
+        .. warning::
+
+            All options other than zmq.SUBSCRIBE, zmq.UNSUBSCRIBE and
+            zmq.LINGER only take effect for subsequent socket bind/connects.
         """
         cdef int64_t optval_int64_c
         cdef int optval_int_c

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -244,6 +244,12 @@ class Socket(SocketBase, AttributeSetter):
         """set the High Water Mark
         
         On libzmq ≥ 3, this sets both SNDHWM and RCVHWM
+
+
+        .. warning::
+
+            New values only take effect for subsequent socket
+            bind/connects.
         """
         major = zmq.zmq_version_info()[0]
         if major >= 3:


### PR DESCRIPTION
Adds two warnings about the fact that socket options (in particular, HWM) only takes effect on subsequent binds/connects, in places I would have seen it while trying to diagnose a problem I was having with memory usage.

This is mentioned in the [zeromq documentation](http://api.zeromq.org/2-1%3azmq-setsockopt) but nowhere in the guide, and is the source of [much confusion](http://stackoverflow.com/questions/8092473/zeromq-high-water-mark-doesnt-work). I figure adding it here can't hurt to repeat it as I don't see this behaviour changing.