### PR TITLE
Use a better range to bind to a random port on Windows

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -175,7 +175,7 @@ class Socket(SocketBase, AttributeSetter):
     
     getsockopt_unicode = getsockopt_string = get_string
     
-    def bind_to_random_port(self, addr, min_port=49152, max_port=65536, max_tries=100):
+    def bind_to_random_port(self, addr, min_port=32768, max_port=49151, max_tries=100):
         """bind this socket to a random port in a range
 
         Parameters


### PR DESCRIPTION
This PR is motivated by spyder-ide/spyder#1880, where a user mentioned that the current range of ports is also used by Windows Vista/7/8 to create dynamics connections.

This new range avoids the current (and frequent) failures some users observe when starting IPython kernels on this OS.