### PR TITLE
retry interrupted system calls

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,13 @@ Changes in PyZMQ
 This is a coarse summary of changes in pyzmq versions.  For a real changelog, consult the
 `git log <https://github.com/zeromq/pyzmq/commits>`_
 
+14.7.0
+======
+
+- Following the `lead <https://www.python.org/dev/peps/pep-0475/>`_ of Python 3.5,
+  interrupted system calls will be retried.
+- Fixes for CFFI backend on Python 3 + support for PyPy 3.
+
 14.6.0
 ======
 

--- a/zmq/backend/cffi/_poll.py
+++ b/zmq/backend/cffi/_poll.py
@@ -4,11 +4,8 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
-from ._cffi import C, ffi, zmq_version_info
-
-from .constants import *
-
-from zmq.error import _check_rc
+from ._cffi import C, ffi
+from .utils import _retry_sys_call
 
 
 def _make_zmq_pollitem(socket, flags):
@@ -41,8 +38,7 @@ def zmq_poll(sockets, timeout):
     items = ffi.new('zmq_pollitem_t[]', cffi_pollitem_list)
     list_length = ffi.cast('int', len(cffi_pollitem_list))
     c_timeout = ffi.cast('long', timeout)
-    rc = C.zmq_poll(items, list_length, c_timeout)
-    _check_rc(rc)
+    _retry_sys_call(C.zmq_poll, items, list_length, c_timeout)
     result = []
     for index in range(len(items)):
         if not items[index].socket == ffi.NULL:

--- a/zmq/backend/cffi/devices.py
+++ b/zmq/backend/cffi/devices.py
@@ -4,13 +4,13 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
-from ._cffi import C, ffi, zmq_version_info
+from ._cffi import C, ffi
 from .socket import Socket
-from zmq.error import ZMQError, _check_rc
+from .utils import _retry_sys_call
+
 
 def device(device_type, frontend, backend):
-    rc = C.zmq_proxy(frontend._zmq_socket, backend._zmq_socket, ffi.NULL)
-    _check_rc(rc)
+    return proxy(frontend, backend)
 
 def proxy(frontend, backend, capture=None):
     if isinstance(capture, Socket):
@@ -18,7 +18,6 @@ def proxy(frontend, backend, capture=None):
     else:
         capture = ffi.NULL
 
-    rc = C.zmq_proxy(frontend._zmq_socket, backend._zmq_socket, capture)
-    _check_rc(rc)
+    _retry_sys_call(C.zmq_proxy, frontend._zmq_socket, backend._zmq_socket, capture)
 
 __all__ = ['device', 'proxy']

--- a/zmq/backend/cython/_device.pyx
+++ b/zmq/backend/cython/_device.pyx
@@ -25,7 +25,9 @@
 
 from libzmq cimport zmq_device, zmq_proxy, ZMQ_VERSION_MAJOR
 from zmq.backend.cython.socket cimport Socket as cSocket
-from zmq.backend.cython.checkrc cimport _check_rc, RETRY_SYS_CALL
+from zmq.backend.cython.checkrc cimport _check_rc
+
+from zmq.error import InterruptedSystemCall
 
 #-----------------------------------------------------------------------------
 # Basic device API
@@ -55,7 +57,11 @@ def device(int device_type, cSocket frontend, cSocket backend=None):
     while True:
         with nogil:
             rc = zmq_device(device_type, frontend.handle, backend.handle)
-        if _check_rc(rc) != RETRY_SYS_CALL:
+        try:
+            _check_rc(rc)
+        except InterruptedSystemCall:
+            continue
+        else:
             break
     return rc
 
@@ -85,7 +91,11 @@ def proxy(cSocket frontend, cSocket backend, cSocket capture=None):
     while True:
         with nogil:
             rc = zmq_proxy(frontend.handle, backend.handle, capture_handle)
-        if _check_rc(rc) != RETRY_SYS_CALL:
+        try:
+            _check_rc(rc)
+        except InterruptedSystemCall:
+            continue
+        else:
             break
     return rc
 

--- a/zmq/backend/cython/_poll.pyx
+++ b/zmq/backend/cython/_poll.pyx
@@ -31,7 +31,8 @@ from socket cimport Socket
 
 import sys
 
-from zmq.backend.cython.checkrc cimport _check_rc, RETRY_SYS_CALL
+from zmq.backend.cython.checkrc cimport _check_rc
+from zmq.error import InterruptedSystemCall
 
 #-----------------------------------------------------------------------------
 # Polling related methods
@@ -110,7 +111,11 @@ def zmq_poll(sockets, long timeout=-1):
         while True:
             with nogil:
                 rc = zmq_poll_c(pollitems, nsockets, timeout)
-            if _check_rc(rc) != RETRY_SYS_CALL:
+            try:
+                _check_rc(rc)
+            except InterruptedSystemCall:
+                continue
+            else:
                 break
     except Exception:
         free(pollitems)

--- a/zmq/backend/cython/checkrc.pxd
+++ b/zmq/backend/cython/checkrc.pxd
@@ -2,9 +2,6 @@ from libc.errno cimport EINTR, EAGAIN
 from cpython cimport PyErr_CheckSignals
 from libzmq cimport zmq_errno, ZMQ_ETERM
 
-cdef enum int:
-    SUCCESS = 0
-    RETRY_SYS_CALL = 1
 
 cdef inline int _check_rc(int rc) except -1:
     """internal utility for checking zmq return condition
@@ -15,8 +12,9 @@ cdef inline int _check_rc(int rc) except -1:
     PyErr_CheckSignals()
     if rc < 0:
         if errno == EINTR:
-            return RETRY_SYS_CALL
-        if errno == EAGAIN:
+            from zmq.error import InterruptedSystemCall
+            raise InterruptedSystemCall(errno)
+        elif errno == EAGAIN:
             from zmq.error import Again
             raise Again(errno)
         elif errno == ZMQ_ETERM:
@@ -25,4 +23,4 @@ cdef inline int _check_rc(int rc) except -1:
         else:
             from zmq.error import ZMQError
             raise ZMQError(errno)
-    return SUCCESS
+    return 0

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -189,7 +189,7 @@ cdef inline object _send_copy(void *handle, object msg, int flags=0):
             break
     _check_rc(rc2)
 
-cdef inline void _getsockopt(void *handle, int option, void *optval, size_t *sz):
+cdef inline object _getsockopt(void *handle, int option, void *optval, size_t *sz):
     """getsockopt, retrying interrupted calls
     
     checks rc, raising ZMQError on failure.
@@ -200,7 +200,7 @@ cdef inline void _getsockopt(void *handle, int option, void *optval, size_t *sz)
         if _check_rc(rc) != RETRY_SYS_CALL:
             break
 
-cdef inline void _setsockopt(void *handle, int option, void *optval, size_t sz):
+cdef inline object _setsockopt(void *handle, int option, void *optval, size_t sz):
     """setsockopt, retrying interrupted calls
     
     checks rc, raising ZMQError on failure.

--- a/zmq/tests/test_retry_eintr.py
+++ b/zmq/tests/test_retry_eintr.py
@@ -47,8 +47,7 @@ class TestEINTRSysCall(BaseZMQTestCase):
         pull = self.socket(zmq.PULL)
         pull.rcvtimeo = self.timeout_ms
         self.alarm()
-        with self.assertRaises(zmq.Again):
-            pull.recv()
+        self.assertRaises(zmq.Again, pull.recv)
         assert self.timer_fired
 
     @skip_if(not hasattr(zmq, 'SNDTIMEO'))
@@ -56,8 +55,7 @@ class TestEINTRSysCall(BaseZMQTestCase):
         push = self.socket(zmq.PUSH)
         push.sndtimeo = self.timeout_ms
         self.alarm()
-        with self.assertRaises(zmq.Again):
-            push.send(b('buf'))
+        self.assertRaises(zmq.Again, push.send, b('buf'))
         assert self.timer_fired
     
     def test_retry_poll(self):

--- a/zmq/tests/test_retry_eintr.py
+++ b/zmq/tests/test_retry_eintr.py
@@ -25,7 +25,6 @@ class TestEINTRSysCall(BaseZMQTestCase):
     timeout_ms = int(timeout * 1e3)
 
     @skip_if(not hasattr(signal, 'setitimer'), 'EINTR tests require setitimer')
-    @skip_pypy
     def alarm(self, t=None):
         """start a timer to fire only once
         

--- a/zmq/tests/test_retry_eintr.py
+++ b/zmq/tests/test_retry_eintr.py
@@ -1,0 +1,84 @@
+# -*- coding: utf8 -*-
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+import signal
+import time
+from threading import Thread
+
+import zmq
+from zmq.tests import (
+    BaseZMQTestCase, SkipTest, skip_pypy, skip_if
+)
+from zmq.utils.strtypes import b
+
+
+# Partially based on EINTRBaseTest from CPython 3.5 eintr_tester
+
+class TestEINTRSysCall(BaseZMQTestCase):
+    """ Base class for EINTR tests. """
+
+    # delay for initial signal delivery
+    signal_delay = 0.1
+    # timeout for tests. Must be > signal_delay
+    timeout = .25
+    timeout_ms = int(timeout * 1e3)
+
+    @skip_if(not hasattr(signal, 'setitimer'), 'EINTR tests require setitimer')
+    @skip_pypy
+    def alarm(self, t=None):
+        """start a timer to fire only once
+        
+        like signal.alarm, but with better resolution than integer seconds.
+        """
+        if t is None:
+            t = self.signal_delay
+        self.timer_fired = False
+        self.orig_handler = signal.signal(signal.SIGALRM, self.stop_timer)
+        # signal_period ignored, since only one timer event is allowed to fire
+        signal.setitimer(signal.ITIMER_REAL, t, 1000)
+    
+    def stop_timer(self, *args):
+        self.timer_fired = True
+        signal.setitimer(signal.ITIMER_REAL, 0, 0)
+        signal.signal(signal.SIGALRM, self.orig_handler)
+    
+    @skip_if(not hasattr(zmq, 'RCVTIMEO'))
+    def test_retry_recv(self):
+        pull = self.socket(zmq.PULL)
+        pull.rcvtimeo = self.timeout_ms
+        self.alarm()
+        with self.assertRaises(zmq.Again):
+            pull.recv()
+        assert self.timer_fired
+
+    @skip_if(not hasattr(zmq, 'SNDTIMEO'))
+    def test_retry_send(self):
+        push = self.socket(zmq.PUSH)
+        push.sndtimeo = self.timeout_ms
+        self.alarm()
+        with self.assertRaises(zmq.Again):
+            push.send(b('buf'))
+        assert self.timer_fired
+    
+    def test_retry_poll(self):
+        x, y = self.create_bound_pair()
+        poller = zmq.Poller()
+        poller.register(x, zmq.POLLIN)
+        self.alarm()
+        def send():
+            time.sleep(2 * self.signal_delay)
+            y.send(b('ping'))
+        t = Thread(target=send)
+        t.start()
+        evts = dict(poller.poll(2 * self.timeout_ms))
+        t.join()
+        assert x in evts
+        assert self.timer_fired
+        x.recv()
+    
+    def test_retry_getsockopt(self):
+        raise SkipTest("TODO: find a way to interrupt getsockopt")
+    
+    def test_retry_setsockopt(self):
+        raise SkipTest("TODO: find a way to interrupt setsockopt")

--- a/zmq/tests/test_retry_eintr.py
+++ b/zmq/tests/test_retry_eintr.py
@@ -74,6 +74,17 @@ class TestEINTRSysCall(BaseZMQTestCase):
         assert self.timer_fired
         x.recv()
     
+    def test_retry_term(self):
+        push = self.socket(zmq.PUSH)
+        push.linger = self.timeout_ms
+        push.connect('tcp://127.0.0.1:5555')
+        push.send(b('ping'))
+        time.sleep(0.1)
+        self.alarm()
+        self.context.destroy()
+        assert self.timer_fired
+        assert self.context.closed
+    
     def test_retry_getsockopt(self):
         raise SkipTest("TODO: find a way to interrupt getsockopt")
     


### PR DESCRIPTION
cc @flub

- cython backend only so far
- retry on EINTR for send,recv,poll,device
- are there other calls that should be retried?

TODO:

- [x] tests
- [x] cffi backend
- [x] determine if there are other calls that might need to be retried (e.g. get/setopt, msg/ctx operations)

closes #679