### PR TITLE
updates setup.py to use pkgconfig to get the libdir and includedir instead of the prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ def check_pkgconfig():
                 zmq_config['include_dirs'].append(tok[2:])
             if tok.startswith("-l"):
                 zmq_config['libraries'].append(tok[2:])
-        info(zmq_config)
+        info("Settings obtained from pkg-config: %r" % zmq_config)
 
     return zmq_config
 

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ def check_pkgconfig():
 
     if pcfg is not None:
         output, _ = pcfg.communicate()
+        output = output.decode('utf8', 'replace')
         bits = output.strip().split()
         zmq_config = {'library_dirs':[], 'include_dirs':[], 'libraries':[]}
         for tok in bits:


### PR DESCRIPTION
Update calls out to pkg-config in a slightly more systematic way to first check if zmq is present, then get the libdir, includedir, and library name (a little ugly; based off the flags to reduce the number of calls) instead of trying to derive this information from the prefix. Tested with OS 10.10, Ubuntu trusty, with both packaged (homebrew/apt) and locally built versions of zeromq, with and without pkg-config present.