### PR TITLE
only import setuptools for bdist_egg, bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,8 @@ from traceback import print_exc
 # do this before importing anything from distutils
 doing_bdist = any(arg.startswith('bdist') for arg in sys.argv[1:])
 
-if doing_bdist:
-    try:
-        import setuptools
-    except Exception:
-        warn("doing a bdist, but setuptools is unavailable")
+if any(bdist in sys.argv for bdist in ['bdist_wheel', 'bdist_egg']):
+    import setuptools
 
 import distutils
 from distutils.core import setup, Command


### PR DESCRIPTION
we were importing it for rpm, dumb, etc. which we shouldn't.

closes #704