### PR TITLE
Fix Windows build for Python 2.7

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -33,10 +33,10 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (4,1,3)
+bundled_version = (4,1,2)
 libzmq = "zeromq-%i.%i.%i.tar.gz" % (bundled_version)
 libzmq_url = "http://download.zeromq.org/" + libzmq
-libzmq_checksum = "sha256:61b31c830db377777e417235a24d3660a4bcc3f40d303ee58df082fcd68bf411"
+libzmq_checksum = "sha256:f9162ead6d68521e5154d871bac304f88857308bb02366b81bb588497a345927"
 
 libsodium_version = (1,0,3)
 libsodium = "libsodium-%i.%i.%i.tar.gz" % (libsodium_version)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ import time
 import errno
 import platform
 from traceback import print_exc
+import setuptools
 
 # whether any kind of bdist is happening
 # do this before importing anything from distutils


### PR DESCRIPTION
- import setuptools in setup.py to take advantage of patches to
  distutils.find_vcvarsall

    Without this, `python setup.py install` fails due to the cryptic "Unable to find vcvarsall.bat". This isn't a problem with `pip install pyzmq` because pip monkeypatches setuptools in anyway.

- Revert bundled ZeroMQ version to 4.1.2 because of zeromq/libzmq#1630

   The packaged version of libzmq 4.1.3 contains an invalid version of the src/stdint.h file (one that doesn't actually exist in the git history anywhere). This is 100% a workaround, but its either that or patch the bundled libzmq, which seems more risky.