### PR TITLE
Add fileno() method do Socket class

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -127,7 +127,15 @@ class Socket(SocketBase, AttributeSetter):
         ):
             keys.extend(collection)
         return keys
-    
+
+    #-------------------------------------------------------------------------
+    # File object interface fileno()
+    #-------------------------------------------------------------------------
+
+    def fileno(self):
+        return self.getsockopt(zmq.FD)
+
+
     #-------------------------------------------------------------------------
     # Getting/Setting options
     #-------------------------------------------------------------------------

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -434,6 +434,11 @@ class TestSocket(BaseZMQTestCase):
         rcvd = self.recv(b)
         self.assertEqual(rcvd, b'hi')
 
+    def test_socket_fileno(self):
+        p = self.socket(zmq.PUSH)
+        self.assertTrue(isinstance(p.fileno(), int))
+
+
 
 if have_gevent:
     import gevent


### PR DESCRIPTION
I was trying to use ZMQStream with tornado and noticed that the object passed to the event loop is a zmq socket class without a `fileno()` method. With this little path I got everything working as expected. Without I get:
```
TypeError: argument must be an int, or have a fileno() method.
```