### PR TITLE
Allocate a buffer for zmq_getsockopt to write to

### DIFF
--- a/zmq/tests/test_cffi_backend.py
+++ b/zmq/tests/test_cffi_backend.py
@@ -67,7 +67,7 @@ class TestCFFIBackend(TestCase):
         assert ret == 0
 
         option_len = ffi.new('size_t*', 3)
-        option = ffi.new('char*')
+        option = ffi.new('char[3]')
         ret = C.zmq_getsockopt(socket,
                             IDENTITY,
                             ffi.cast('void*', option),


### PR DESCRIPTION
We can't just create a pointer, we need enough space to write the value.

Spotted with a pydebug build of cpython.