### PR TITLE
explicitly check rc==-1 for exceptional conditions

### DIFF
--- a/zmq/backend/cython/checkrc.pxd
+++ b/zmq/backend/cython/checkrc.pxd
@@ -10,7 +10,7 @@ cdef inline int _check_rc(int rc) except -1:
     """
     cdef int errno = zmq_errno()
     PyErr_CheckSignals()
-    if rc < 0:
+    if rc == -1: # if rc < -1, it's a bug in libzmq. Should we warn?
         if errno == EINTR:
             from zmq.error import InterruptedSystemCall
             raise InterruptedSystemCall(errno)

--- a/zmq/error.py
+++ b/zmq/error.py
@@ -120,7 +120,7 @@ def _check_rc(rc, errno=None):
     
     and raising the appropriate Exception class
     """
-    if rc < 0:
+    if rc == -1:
         if errno is None:
             from zmq.backend import zmq_errno
             errno = zmq_errno()

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 import copy
+import os
+import platform
 import time
 import warnings
 
@@ -434,6 +436,8 @@ class TestSocket(BaseZMQTestCase):
         rcvd = self.recv(b)
         self.assertEqual(rcvd, b'hi')
     
+    # Travis can't handle how much memory PyPy uses on this test
+    @skip_if(platform.python_implementation() and os.environ.get('TRAVIS_PYTHON_VERSION'))
     def test_large_send(self):
         try:
             buf = b'\1' * (2**31+1)

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -433,6 +433,16 @@ class TestSocket(BaseZMQTestCase):
         a.send(b'hi')
         rcvd = self.recv(b)
         self.assertEqual(rcvd, b'hi')
+    
+    def test_large_send(self):
+        try:
+            buf = b'\1' * (2**31+1)
+        except MemoryError:
+            raise SkipTest()
+        a, b = self.create_bound_pair()
+        a.send(buf, copy=False)
+        rcvd = b.recv()
+        assert rcvd == buf
 
 
 if have_gevent:


### PR DESCRIPTION
workaround overflow error in libzmq when sending or receiving messages larger than INT_MAX, in which case the signed-integer rc will have a negative value.

Any other negative value is a bug in libzmq. Since the only known cases of this are actually *successful* operations overflowing INT_MAX, we are now treating those as success, which may be a hazard.