### PR TITLE
rollback bundled libzmq to 4.1.2

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -33,10 +33,10 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (4,1,4)
+bundled_version = (4,1,2)
 libzmq = "zeromq-%i.%i.%i.tar.gz" % (bundled_version)
 libzmq_url = "http://download.zeromq.org/" + libzmq
-libzmq_checksum = "sha256:e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378"
+libzmq_checksum = "sha256:f9162ead6d68521e5154d871bac304f88857308bb02366b81bb588497a345927"
 
 libsodium_version = (1,0,7)
 libsodium = "libsodium-%i.%i.%i.tar.gz" % (libsodium_version)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,7 +15,7 @@ This is a coarse summary of changes in pyzmq versions.  For a real changelog, co
 - FIX: handle multiple events in a single register call in :mod:`zmq.asyncio`
 - FIX: unicode/bytes bug in password prompt in :mod:`zmq.ssh` on Python 3
 - FIX: workaround gevent monkeypatches in garbage collection thread
-- update bundled libraries: libzmq-4.1.4, libsodium-1.0.7, minitornado from tornado-4.3.
+- update bundled libraries: libsodium-1.0.7, minitornado from tornado-4.3.
 - improved inspection by setting ``binding=True`` in cython compile options
 - add asyncio Authenticator implementation in :mod:`zmq.auth.asyncio`
 - workaround overflow bug in libzmq preventing receiving messages larger than ``MAX_INT``


### PR DESCRIPTION
both 4.1.3 and 4.1.4 cannot be built on Windows (for unrelated reasons), so 4.1.2 is the last working release of libzmq.