### PR TITLE
use a random byte instead of byte literal

### DIFF
--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -440,7 +440,7 @@ class TestSocket(BaseZMQTestCase):
     @skip_if(platform.python_implementation() and os.environ.get('TRAVIS_PYTHON_VERSION'))
     def test_large_send(self):
         try:
-            buf = b'\1' * (2**31+1)
+            buf = os.urandom(1) * (2**31 + 1)
         except MemoryError:
             raise SkipTest()
         a, b = self.create_bound_pair()


### PR DESCRIPTION
avoids compiler optimization precomputing the literal, taking up 2GB of memory in compilation and .pyc