### PR TITLE
Introduce decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ MANIFEST
 examples/security/public_keys
 examples/security/private_keys
 wheelhouse
+.coverage

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -11,6 +11,7 @@
 
     zmq
     zmq.devices
+    zmq.decorators
     zmq.green
     zmq.eventloop.ioloop
     zmq.eventloop.future

--- a/docs/source/api/zmq.decorators.rst
+++ b/docs/source/api/zmq.decorators.rst
@@ -1,0 +1,20 @@
+decorators
+===============================================================================
+
+
+Module: :mod:`decorators`
+----------------------------------------------------------------------
+
+.. automodule:: zmq.decorators
+
+.. currentmodule:: zmq.decorators
+
+
+Functions
+----------------------------------------------------------------------
+
+
+.. autofunction:: zmq.decorators.context
+
+.. autofunction:: zmq.decorators.socket
+

--- a/zmq/decorators/__init__.py
+++ b/zmq/decorators/__init__.py
@@ -1,0 +1,1 @@
+from zmq.decorators.sugar import *

--- a/zmq/decorators/base.py
+++ b/zmq/decorators/base.py
@@ -50,24 +50,27 @@ class ZDecoratorBase(object):
 
                 self.hook('preinit')
 
-                with self.target(*self.dec_args, **self.dec_kwargs) as obj:
-                    self.hook('postinit')
+                try:
+                    with self.target(*self.dec_args, **self.dec_kwargs) as obj:
+                        self.hook('postinit')
 
-                    if self.kwname and self.kwname not in self.wrap_kwargs:
-                        self.wrap_kwargs[self.kwname] = obj
-                    elif self.kwname and self.kwname in self.wrap_kwargs:
-                        raise TypeError(
-                            "{0}() got multiple values for"
-                            " argument '{1}'".format(
-                                func.__name__, self.kwname))
-                    else:
-                        self.wrap_args += (obj,)
+                        if self.kwname and self.kwname not in self.wrap_kwargs:
+                            self.wrap_kwargs[self.kwname] = obj
+                        elif self.kwname and self.kwname in self.wrap_kwargs:
+                            raise TypeError(
+                                "{0}() got multiple values for"
+                                " argument '{1}'".format(
+                                    func.__name__, self.kwname))
+                        else:
+                            self.wrap_args += (obj,)
 
-                    self.hook('preexec')
-                    func(*self.wrap_args, **self.wrap_kwargs)
-                    self.hook('postexec')
-
-                self.hook('cleanup')
+                        self.hook('preexec')
+                        func(*self.wrap_args, **self.wrap_kwargs)
+                        self.hook('postexec')
+                except:
+                    raise  # re-raise the exception
+                finally:
+                    self.hook('cleanup')
 
             return wrapper
 

--- a/zmq/decorators/base.py
+++ b/zmq/decorators/base.py
@@ -1,0 +1,62 @@
+from functools import wraps
+
+from zmq.utils.strtypes import basestring
+
+
+class ZDecoratorBase(object):
+
+    def __init__(self, target):
+        self.target = target
+
+    def __call__(self, *dec_args, **dec_kwargs):
+        self.kwname = None
+        self.dec_args = dec_args
+        self.dec_kwargs = dec_kwargs
+
+        self.pop_kwname()
+
+        def decorator(func):
+            @wraps(func)
+            def wrapper(*wrap_args, **wrap_kwargs):
+                self.wrap_args = wrap_args
+                self.wrap_kwargs = wrap_kwargs
+
+                self.hook('preinit')
+
+                with self.target(*self.dec_args, **self.dec_kwargs) as obj:
+                    self.hook('postinit')
+
+                    if self.kwname and self.kwname not in self.wrap_kwargs:
+                        self.wrap_kwargs[self.kwname] = obj
+                    elif self.kwname and self.kwname in self.wrap_kwargs:
+                        raise TypeError(
+                            "{0}() got multiple values for"
+                            " argument '{1}'".format(
+                                func.__name__, self.kwname))
+                    else:
+                        self.wrap_args = (obj,) + self.wrap_args
+
+                    self.hook('preexec')
+                    func(*self.wrap_args, **self.wrap_kwargs)
+                    self.hook('postexec')
+
+                self.hook('cleanup')
+
+            return wrapper
+
+        return decorator
+
+    def hook(self, func):
+        getattr(self, 'hook_{0}'.format(func), self.nop)()
+
+    @staticmethod
+    def nop(*args, **kwargs):
+        pass  # and save the world silently
+
+    def pop_kwname(self):
+        if isinstance(self.dec_kwargs.get('name'), basestring):
+            self.kwname = self.dec_kwargs.pop('name')
+        elif (len(self.dec_args) >= 1 and
+              isinstance(self.dec_args[0], basestring)):
+            self.kwname = self.dec_args[0]
+            self.dec_args = self.dec_args[1:]

--- a/zmq/decorators/base.py
+++ b/zmq/decorators/base.py
@@ -65,8 +65,9 @@ class ZDecoratorBase(object):
                             self.wrap_args += (obj,)
 
                         self.hook('preexec')
-                        func(*self.wrap_args, **self.wrap_kwargs)
+                        ret = func(*self.wrap_args, **self.wrap_kwargs)
                         self.hook('postexec')
+                        return ret
                 except:
                     raise  # re-raise the exception
                 finally:

--- a/zmq/decorators/base.py
+++ b/zmq/decorators/base.py
@@ -61,7 +61,7 @@ class ZDecoratorBase(object):
                             " argument '{1}'".format(
                                 func.__name__, self.kwname))
                     else:
-                        self.wrap_args = (obj,) + self.wrap_args
+                        self.wrap_args += (obj,)
 
                     self.hook('preexec')
                     func(*self.wrap_args, **self.wrap_kwargs)

--- a/zmq/decorators/base.py
+++ b/zmq/decorators/base.py
@@ -4,11 +4,38 @@ from zmq.utils.strtypes import basestring
 
 
 class ZDecoratorBase(object):
+    '''
+    The mini decorator factory
+    '''
 
     def __init__(self, target):
         self.target = target
 
     def __call__(self, *dec_args, **dec_kwargs):
+        '''
+        The main logic of decorator
+
+        Here is how those arguments works::
+
+            @out_decorator(*dec_args, *dec_kwargs)
+            def func(*wrap_args, **wrap_kwargs):
+                ...
+
+        And in the ``wrapper``, we simply create ``self.target`` instance via
+        ``with``::
+
+            with self.target(*dec_args, **dec_kwargs) as obj:
+                ...
+
+        Hooks
+            We also have hook functions for us to provide more custom logic.
+            Just inherit this class and define the following function.
+            - ``self.preinit``
+            - ``self.postinit``
+            - ``self.preexec``
+            - ``self.postexec``
+            - ``self.cleanup``
+        '''
         self.kwname = None
         self.dec_args = dec_args
         self.dec_kwargs = dec_kwargs

--- a/zmq/decorators/sugar.py
+++ b/zmq/decorators/sugar.py
@@ -1,0 +1,64 @@
+'''
+The decorators module for ``zmq.sugar``.
+'''
+
+__all__ = (
+    'context',
+    'socket'
+)
+
+
+import zmq
+
+from zmq.decorators.base import ZDecoratorBase
+
+
+def context(*args, **kwargs):
+    '''
+    .. versionadded:: 15.3.0
+
+    :param str name: the keyword argument passed to decorated function
+    '''
+    return ZDecoratorBase(zmq.Context)(*args, **kwargs)
+
+
+def socket(*args, **kwargs):
+    '''
+    .. versionadded:: 15.3.0
+
+    :param str name: the keyword argument passed to decorated function
+    '''
+    return _SocketDecorator(zmq.Socket)(*args, **kwargs)
+
+
+class _SocketDecorator(ZDecoratorBase):
+
+    def hook_preinit(self):
+        self.context_name = self.dec_kwargs.pop('context_name', 'context')
+        self.context = self._get_context()
+        self.dec_args = (self.context,) + self.dec_args
+
+    def _get_context(self):
+        '''
+        Find the ``zmq.Context`` from ``self.wrap_args`` and ``wrap_kwargs``
+
+        First, if there is an keyword argument named ``context`` and it is a
+        ``zmq.Context`` instance , we will take it.
+
+        Second, we check all the ``wrap_args``, take the first ``zmq.Context``
+        instance.
+
+        :raises TypeError: if any context instance can not be found
+        '''
+        if self.context_name in self.wrap_kwargs:
+            ctx = self.wrap_kwargs[self.context_name]
+
+            if isinstance(ctx, zmq.Context):
+                return ctx
+
+        for arg in self.wrap_args:
+            if not isinstance(arg, zmq.Context):
+                continue
+            return arg
+
+        raise TypeError('zmq.Context instance not found')

--- a/zmq/decorators/sugar.py
+++ b/zmq/decorators/sugar.py
@@ -10,6 +10,7 @@ __all__ = (
 
 import zmq
 
+from functools import partial
 from zmq.decorators.base import ZDecoratorBase
 
 
@@ -38,7 +39,7 @@ class _SocketDecorator(ZDecoratorBase):
     def hook_preinit(self):
         self.context_name = self.dec_kwargs.pop('context_name', 'context')
         self.context = self._get_context()
-        self.dec_args = (self.context,) + self.dec_args
+        self.target = partial(zmq.Socket, self.context)
 
     def _get_context(self):
         '''

--- a/zmq/decorators/sugar.py
+++ b/zmq/decorators/sugar.py
@@ -51,6 +51,8 @@ class _SocketDecorator(ZDecoratorBase):
         instance.
 
         Finally, we will provide default Context -- ``zmq.Context.instance``
+
+        :return: a ``zmq.Context`` instance
         '''
         if self.context_name in self.wrap_kwargs:
             ctx = self.wrap_kwargs[self.context_name]

--- a/zmq/decorators/sugar.py
+++ b/zmq/decorators/sugar.py
@@ -50,7 +50,7 @@ class _SocketDecorator(ZDecoratorBase):
         Second, we check all the ``wrap_args``, take the first ``zmq.Context``
         instance.
 
-        :raises TypeError: if any context instance can not be found
+        Finally, we will provide default Context -- ``zmq.Context.instance``
         '''
         if self.context_name in self.wrap_kwargs:
             ctx = self.wrap_kwargs[self.context_name]
@@ -63,4 +63,4 @@ class _SocketDecorator(ZDecoratorBase):
                 continue
             return arg
 
-        raise TypeError('zmq.Context instance not found')
+        return zmq.Context.instance()

--- a/zmq/decorators/sugar.py
+++ b/zmq/decorators/sugar.py
@@ -15,7 +15,7 @@ from zmq.decorators.base import ZDecoratorBase
 
 def context(*args, **kwargs):
     '''
-    .. versionadded:: 15.3.0
+    .. versionadded:: 15.3
 
     :param str name: the keyword argument passed to decorated function
     '''
@@ -24,9 +24,11 @@ def context(*args, **kwargs):
 
 def socket(*args, **kwargs):
     '''
-    .. versionadded:: 15.3.0
+    .. versionadded:: 15.3
 
     :param str name: the keyword argument passed to decorated function
+    :param str context_name: the keyword only argument to identify context
+                             object
     '''
     return _SocketDecorator(zmq.Socket)(*args, **kwargs)
 

--- a/zmq/tests/test_decorators.py
+++ b/zmq/tests/test_decorators.py
@@ -50,7 +50,7 @@ def test_ctx_keyword_miss(other_name):
 
 
 @raises(TypeError)
-def test_mulit_assign():
+def test_multi_assign():
     @context(name='ctx')
     def f(ctx):
         pass  # explosion
@@ -101,3 +101,56 @@ def test_skt_default_ctx(skt):
 @socket('myskt')
 def test_skt_type_miss(ctx, myskt):
     pass  # the socket type is missing
+
+
+@socket(zmq.PUSH)  # baz
+@socket(zmq.SUB)   # bar
+@socket(zmq.PUB)   # foo
+def test_multi_skts(foo, bar, baz):
+    assert isinstance(foo, zmq.Socket), foo
+    assert isinstance(bar, zmq.Socket), bar
+    assert isinstance(baz, zmq.Socket), baz
+
+    assert foo.context is zmq.Context.instance()
+    assert bar.context is zmq.Context.instance()
+    assert baz.context is zmq.Context.instance()
+
+    assert foo.type == zmq.PUB
+    assert bar.type == zmq.SUB
+    assert baz.type == zmq.PUSH
+
+
+@context()
+@socket(zmq.PUSH)  # baz
+@socket(zmq.SUB)   # bar
+@socket(zmq.PUB)   # foo
+def test_multi_skts_single_ctx(foo, bar, baz, ctx):
+    assert isinstance(foo, zmq.Socket), foo
+    assert isinstance(bar, zmq.Socket), bar
+    assert isinstance(baz, zmq.Socket), baz
+    assert isinstance(ctx, zmq.Context), ctx
+
+    assert foo.context is ctx
+    assert bar.context is ctx
+    assert baz.context is ctx
+
+    assert foo.type == zmq.PUB
+    assert bar.type == zmq.SUB
+    assert baz.type == zmq.PUSH
+
+
+@socket('foo', zmq.PUSH)
+@socket('bar', zmq.SUB)
+@socket('baz', zmq.PUB)
+def test_multi_skts_with_name(foo, bar, baz):
+    assert isinstance(foo, zmq.Socket), foo
+    assert isinstance(bar, zmq.Socket), bar
+    assert isinstance(baz, zmq.Socket), baz
+
+    assert foo.context is zmq.Context.instance()
+    assert bar.context is zmq.Context.instance()
+    assert baz.context is zmq.Context.instance()
+
+    assert foo.type == zmq.PUSH
+    assert bar.type == zmq.SUB
+    assert baz.type == zmq.PUB

--- a/zmq/tests/test_decorators.py
+++ b/zmq/tests/test_decorators.py
@@ -89,9 +89,9 @@ def test_ctx_reinit():
     foo_t.join()
     bar_t.join()
 
-    assert result['foo'] is not None
-    assert result['bar'] is not None
-    assert result['foo'] != result['bar']
+    assert result['foo'] is not None, result
+    assert result['bar'] is not None, result
+    assert result['foo'] != result['bar'], result
 
 
 @context()
@@ -152,9 +152,9 @@ def test_skt_reinit():
     foo_t.join()
     bar_t.join()
 
-    assert result['foo'] is not None
-    assert result['bar'] is not None
-    assert result['foo'] != result['bar']
+    assert result['foo'] is not None, result
+    assert result['bar'] is not None, resule
+    assert result['foo'] != result['bar'], result
 
 
 def test_ctx_skt_reinit():
@@ -180,12 +180,12 @@ def test_ctx_skt_reinit():
     foo_t.join()
     bar_t.join()
 
-    assert result['foo']['ctx'] is not None
-    assert result['foo']['skt'] is not None
-    assert result['bar']['ctx'] is not None
-    assert result['bar']['skt'] is not None
-    assert result['foo']['ctx'] != result['bar']['ctx']
-    assert result['foo']['skt'] != result['bar']['skt']
+    assert result['foo']['ctx'] is not None, result
+    assert result['foo']['skt'] is not None, result
+    assert result['bar']['ctx'] is not None, result
+    assert result['bar']['skt'] is not None, result
+    assert result['foo']['ctx'] != result['bar']['ctx'], result
+    assert result['foo']['skt'] != result['bar']['skt'], result
 
 
 @raises(TypeError)

--- a/zmq/tests/test_decorators.py
+++ b/zmq/tests/test_decorators.py
@@ -248,6 +248,15 @@ def test_multi_skts_with_name(foo, bar, baz):
     assert baz.type == zmq.PUB
 
 
+def test_func_return():
+    @context()
+    def f(ctx):
+        assert isinstance(ctx, zmq.Context), ctx
+        return 'something'
+
+    assert f() == 'something'
+
+
 class TestMethodDecorators():
     @context()
     @socket(zmq.PUB)

--- a/zmq/tests/test_decorators.py
+++ b/zmq/tests/test_decorators.py
@@ -1,0 +1,102 @@
+import zmq
+
+from nose.tools import raises
+from zmq.decorators import context, socket
+
+
+@context()
+def test_ctx(ctx):
+    assert isinstance(ctx, zmq.Context), ctx
+
+
+@context('myctx')
+def test_ctx_arg_naming(myctx):
+    assert isinstance(myctx, zmq.Context), myctx
+
+
+@context('ctx', 5)
+def test_ctx_args(ctx):
+    assert isinstance(ctx, zmq.Context), ctx
+    assert ctx.IO_THREADS == 5, ctx.IO_THREADS
+
+
+@context('ctx', io_threads=5)
+def test_ctx_arg_kwarg(ctx):
+    assert isinstance(ctx, zmq.Context), ctx
+    assert ctx.IO_THREADS == 5, ctx.IO_THREADS
+
+
+@context(name='myctx')
+def test_ctx_kw_naming(myctx):
+    assert isinstance(myctx, zmq.Context), myctx
+
+
+@context(name='ctx', io_threads=5)
+def test_ctx_kwargs(ctx):
+    assert isinstance(ctx, zmq.Context), ctx
+    assert ctx.IO_THREADS == 5, ctx.IO_THREADS
+
+
+@context(name='ctx', io_threads=5)
+def test_ctx_kwargs_default(ctx=None):
+    assert isinstance(ctx, zmq.Context), ctx
+    assert ctx.IO_THREADS == 5, ctx.IO_THREADS
+
+
+@raises(TypeError)
+@context(name='ctx')
+def test_ctx_keyword_miss(other_name):
+    pass  # the keyword ``ctx`` not found
+
+
+@raises(TypeError)
+def test_mulit_assign():
+    @context(name='ctx')
+    def f(ctx):
+        pass  # explosion
+    f('mock')
+
+
+@context()
+@socket(zmq.PUB)
+def test_ctx_skt(skt, ctx):
+    assert isinstance(skt, zmq.Socket), skt
+    assert isinstance(ctx, zmq.Context), ctx
+    assert skt.type == zmq.PUB
+
+
+@context()
+@socket('myskt', zmq.PUB)
+def test_skt_name(ctx, myskt):
+    assert isinstance(myskt, zmq.Socket), myskt
+    assert isinstance(ctx, zmq.Context), ctx
+    assert myskt.type == zmq.PUB
+
+
+@context()
+@socket(zmq.PUB, name='myskt')
+def test_skt_kwarg(ctx, myskt):
+    assert isinstance(myskt, zmq.Socket), myskt
+    assert isinstance(ctx, zmq.Context), ctx
+    assert myskt.type == zmq.PUB
+
+
+@context('ctx')
+@socket('skt', zmq.PUB, context_name='ctx')
+def test_ctx_skt(ctx, skt):
+    assert isinstance(skt, zmq.Socket), skt
+    assert isinstance(ctx, zmq.Context), ctx
+    assert skt.type == zmq.PUB
+
+
+@raises(TypeError)
+@socket(zmq.PUB)
+def test_ctx_miss(skt):
+    pass  # context not found
+
+
+@raises(TypeError)
+@context()
+@socket('myskt')
+def test_skt_type_miss(ctx, myskt):
+    pass  # the socket type is missing

--- a/zmq/tests/test_decorators.py
+++ b/zmq/tests/test_decorators.py
@@ -89,10 +89,11 @@ def test_ctx_skt(ctx, skt):
     assert skt.type == zmq.PUB
 
 
-@raises(TypeError)
 @socket(zmq.PUB)
-def test_ctx_miss(skt):
-    pass  # context not found
+def test_skt_default_ctx(skt):
+    assert isinstance(skt, zmq.Socket), skt
+    assert skt.context is zmq.Context.instance()
+    assert skt.type == zmq.PUB
 
 
 @raises(TypeError)

--- a/zmq/tests/test_imports.py
+++ b/zmq/tests/test_imports.py
@@ -7,11 +7,11 @@ from unittest import TestCase
 class TestImports(TestCase):
     """Test Imports - the quickest test to ensure that we haven't
     introduced version-incompatible syntax errors."""
-    
+
     def test_toplevel(self):
         """test toplevel import"""
         import zmq
-        
+
     def test_core(self):
         """test core imports"""
         from zmq import Context
@@ -21,25 +21,25 @@ class TestImports(TestCase):
         from zmq import constants
         from zmq import device, proxy
         from zmq import Stopwatch
-        from zmq import ( 
+        from zmq import (
             zmq_version,
             zmq_version_info,
             pyzmq_version,
             pyzmq_version_info,
         )
-    
+
     def test_devices(self):
         """test device imports"""
         import zmq.devices
         from zmq.devices import basedevice
         from zmq.devices import monitoredqueue
         from zmq.devices import monitoredqueuedevice
-    
+
     def test_log(self):
         """test log imports"""
         import zmq.log
         from zmq.log import handlers
-    
+
     def test_eventloop(self):
         """test eventloop imports"""
         import zmq.eventloop
@@ -47,16 +47,19 @@ class TestImports(TestCase):
         from zmq.eventloop import zmqstream
         from zmq.eventloop.minitornado.platform import auto
         from zmq.eventloop.minitornado import ioloop
-    
+
     def test_utils(self):
         """test util imports"""
         import zmq.utils
         from zmq.utils import strtypes
         from zmq.utils import jsonapi
-    
+
     def test_ssh(self):
         """test ssh imports"""
         from zmq.ssh import tunnel
-    
+
+    def test_decorators(self):
+        """test decorators imports"""
+        from zmq.decorators import context, socket
 
 


### PR DESCRIPTION
Hi, we already has the `zmq.Context` and `zmq.Socket` act as a context manager, but there is deep indentation when we use both. So we can use decorator for function to make the code beautiful.
 - `context`
 - `socket`

For example.
```python
import zmq
from zmq.decorators import context, socket

@context()
@socket(zmq.PUB)
def f(skt, ctx):
    skt.bind('...')
    ...
```

For more usage, there are test cases in this PR.

Also, i'm willing to change variables naming, coding style, or making more documentation, if that make everyone comfortable to merge this PR.  :smile: 