### PR TITLE
Handle string input to z85

### DIFF
--- a/zmq/utils/z85.py
+++ b/zmq/utils/z85.py
@@ -42,9 +42,12 @@ def encode(rawbytes):
         return b''.join(encoded)
 
 def decode(z85bytes):
-    """decode Z85 bytes to raw bytes"""
+    """decode Z85 bytes to raw bytes, accepts ASCII string"""
     if PY3 and isinstance(z85bytes, str):
-        raise TypeError("Unicode-objects must be encoded to bytes")
+        try:
+            z85bytes = z85bytes.encode('ascii')
+        except UnicodeEncodeError:
+            raise ValueError('string argument should contain only ASCII characters')
 
     if len(z85bytes) % 5:
         raise ValueError("Z85 length must be multiple of 5, not %i" % len(z85bytes))

--- a/zmq/utils/z85.py
+++ b/zmq/utils/z85.py
@@ -44,7 +44,7 @@ def encode(rawbytes):
 def decode(z85bytes):
     """decode Z85 bytes to raw bytes"""
     if PY3 and isinstance(z85bytes, str):
-        z85bytes = z85bytes.encode('ascii')
+        raise TypeError("Unicode-objects must be encoded to bytes")
 
     if len(z85bytes) % 5:
         raise ValueError("Z85 length must be multiple of 5, not %i" % len(z85bytes))

--- a/zmq/utils/z85.py
+++ b/zmq/utils/z85.py
@@ -43,6 +43,9 @@ def encode(rawbytes):
 
 def decode(z85bytes):
     """decode Z85 bytes to raw bytes"""
+    if PY3 and isinstance(z85bytes, str):
+        z85bytes = z85bytes.encode('ascii')
+
     if len(z85bytes) % 5:
         raise ValueError("Z85 length must be multiple of 5, not %i" % len(z85bytes))
     


### PR DESCRIPTION
This fixes any confusion caused by passing a string in python 3 to the z85.decode function. Since python 3 treats strings differently from bytearrays, particularly in regards to doing list-type operations on them.

closes #815