### PR TITLE
add socket.[un]subscribe method(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - 'if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install -q -f travis-wheels-master/wheelhouse cython; fi'
   - 'if [[ ! -z "$ZMQ" && $ZMQ != bundled ]]; then wget https://github.com/zeromq/$ZMQ/archive/master.zip -O libzmq.zip && unzip libzmq.zip; fi'
   - 'if [[ ! -z "$ZMQ" && $ZMQ != bundled ]]; then sh -c "set -x; cd $ZMQ-master; sh autogen.sh; ./configure; make -j; sudo make install; sudo ldconfig"; fi'
-  - pip install -q -f file://travis-wheels-master/wheelhouse -r test-requirements.txt
+  - pip install -f file://travis-wheels-master/wheelhouse -r test-requirements.txt
 
 install:
   - 'if [[ ! -z "$ZMQ" && $ZMQ != bundled ]]; then export ZMQ=/usr/local; fi'

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -135,6 +135,42 @@ class Socket(SocketBase, AttributeSetter):
     setsockopt = SocketBase.set
     getsockopt = SocketBase.get
     
+    def __setattr__(self, key, value):
+        """override to allow setting zmq.[UN]SUBSCRIBE even though we have a subscribe method"""
+        _key = key.lower()
+        if _key in ('subscribe', 'unsubscribe'):
+            
+            if isinstance(value, unicode):
+                value = value.encode('utf8')
+            if _key == 'subscribe':
+                self.set(zmq.SUBSCRIBE, value)
+            else:
+                self.set(zmq.UNSUBSCRIBE, value)
+            return
+        super(Socket, self).__setattr__(key, value)
+    
+    def subscribe(self, topic):
+        """Subscribe to a topic
+
+        Only for SUB sockets.
+
+        .. versionadded:: 15.3
+        """
+        if isinstance(topic, unicode):
+            topic = topic.encode('utf8')
+        self.set(zmq.SUBSCRIBE, topic)
+    
+    def unsubscribe(self, topic):
+        """Unsubscribe from a topic
+
+        Only for SUB sockets.
+
+        .. versionadded:: 15.3
+        """
+        if isinstance(topic, unicode):
+            topic = topic.encode('utf8')
+        self.set(zmq.UNSUBSCRIBE, topic)
+    
     def set_string(self, option, optval, encoding='utf-8'):
         """set socket options with a unicode object
         


### PR DESCRIPTION
`Socket.verb = b'thing'` has bugged me for ages.

attr setters still work, for backward-compatibility