### PR TITLE
Include '*.pxi' files from Cython backend.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1139,7 +1139,7 @@ if pypy:
 
 
 package_data = {'zmq': ['*.pxd'],
-                'zmq.backend.cython': ['*.pxd'],
+                'zmq.backend.cython': ['*.pxd', '*.pxi'],
                 'zmq.backend.cffi': ['*.h', '*.c'],
                 'zmq.devices': ['*.pxd'],
                 'zmq.utils': ['*.pxd', '*.h', '*.json'],


### PR DESCRIPTION
When trying to write Cython code against pyzmq, I noticed that the *.pxi files don't get included in the distribution. It would be helpful to have them so that e.g. libzmq.pxd is a functional cython header.

This change just adds these files to package_data similar to how '*.pxd' files are included.