### PR TITLE
Various fixes for hanging auth tests

### DIFF
--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -49,6 +49,7 @@ class Authenticator(object):
         self.zap_socket = self.context.socket(zmq.REP)
         self.zap_socket.linger = 1
         self.zap_socket.bind("inproc://zeromq.zap.01")
+        self.log.debug("Starting")
 
     def stop(self):
         """Close the ZAP socket"""
@@ -68,6 +69,7 @@ class Authenticator(object):
         """
         if self.blacklist:
             raise ValueError("Only use a whitelist or a blacklist, not both")
+        self.log.debug("Allowing %s", ','.join(addresses))
         self.whitelist.update(addresses)
 
     def deny(self, *addresses):
@@ -79,6 +81,7 @@ class Authenticator(object):
         """
         if self.whitelist:
             raise ValueError("Only use a whitelist or a blacklist, not both")
+        self.log.debug("Denying %s", ','.join(addresses))
         self.blacklist.update(addresses)
 
     def configure_plain(self, domain='*', passwords=None):
@@ -90,6 +93,7 @@ class Authenticator(object):
         """
         if passwords:
             self.passwords[domain] = passwords
+        self.log.debug("Configure plain: %s", domain)
 
     def configure_curve(self, domain='*', location=None):
         """Configure CURVE authentication for a given domain.
@@ -105,6 +109,7 @@ class Authenticator(object):
         """
         # If location is CURVE_ALLOW_ANY then allow all clients. Otherwise
         # treat location as a directory that holds the certificates.
+        self.log.debug("Configure curve: %s[%s]", domain, location)
         if location == CURVE_ALLOW_ANY:
             self.allow_any = True
         else:

--- a/zmq/tests/test_auth.py
+++ b/zmq/tests/test_auth.py
@@ -101,7 +101,8 @@ class TestThreadAuthentication(BaseAuthTestCase):
         port = server.bind_to_random_port(iface)
         client.connect("%s:%i" % (iface, port))
         msg = [b"Hello World"]
-        server.send_multipart(msg)
+        if server.poll(1000, zmq.POLLOUT):
+            server.send_multipart(msg)
         if client.poll(1000):
             rcvd_msg = client.recv_multipart()
             self.assertEqual(rcvd_msg, msg)

--- a/zmq/tests/test_auth.py
+++ b/zmq/tests/test_auth.py
@@ -245,20 +245,20 @@ def with_ioloop(method, expect_success=True):
     """decorator for running tests with an IOLoop"""
     def test_method(self):
         r = method(self)
-        
+
         loop = self.io_loop
         if expect_success:
             self.pullstream.on_recv(self.on_message_succeed)
         else:
             self.pullstream.on_recv(self.on_message_fail)
         
-        t = loop.time()
-        loop.add_callback(self.attempt_connection)
-        loop.add_callback(self.send_msg)
+        loop.call_later(1, self.attempt_connection)
+        loop.call_later(1.2, self.send_msg)
+        
         if expect_success:
-            loop.add_timeout(t + 1, self.on_test_timeout_fail)
+            loop.call_later(2, self.on_test_timeout_fail)
         else:
-            loop.add_timeout(t + 1, self.on_test_timeout_succeed)
+            loop.call_later(2, self.on_test_timeout_succeed)
         
         loop.start()
         if self.fail_msg:

--- a/zmq/tests/test_auth.py
+++ b/zmq/tests/test_auth.py
@@ -115,6 +115,8 @@ class TestThreadAuthentication(BaseAuthTestCase):
         # go through our authentication infrastructure at all.
         self.auth.stop()
         self.auth = None
+        # use a new context, so ZAP isn't inherited
+        self.context = self.Context()
         
         server = self.socket(zmq.PUSH)
         client = self.socket(zmq.PULL)


### PR DESCRIPTION
I understand how this should fix hangs in the threaded socket tests, but I don't understand how or where the IOLoop tests would have ever hung, so a sleep is the best I could come up with.

I cannot verify the fix, because the hangs do not appear to be reproducible on x86 systems.

closes #838