### PR TITLE
cffi: fix linger in Socket.close() and Context.destroy()

### DIFF
--- a/zmq/backend/cffi/context.py
+++ b/zmq/backend/cffi/context.py
@@ -96,7 +96,7 @@ class Context(object):
         for s in sockets:
             s = s()
             if s and not s.closed:
-                if linger:
+                if linger is not None:
                     s.setsockopt(LINGER, linger)
                 s.close()
         

--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -90,6 +90,8 @@ class Socket(object):
         rc = 0
         if not self._closed and hasattr(self, '_zmq_socket'):
             if self._zmq_socket is not None:
+                if linger is not None:
+                    self.set(zmq.LINGER, linger)
                 rc = C.zmq_close(self._zmq_socket)
             self._closed = True
             if self.context:


### PR DESCRIPTION
This changeset fixes bugs regarding how 'linger' was handled in the cffi
backend. Prior to this fix, running the following example would exit
immediately (as expected) when run under the cython backend, but would hang
under the cffi backend (`PYZMQ_BACKEND=cffi`).

```
import zmq

ctx = zmq.Context()
s = ctx.socket(zmq.REQ)
s.connect('tcp://localhost:34567')
s.send('test')

s.close(linger=0)      # <- cffi backend hangs here...
ctx.destroy(linger=0)  # <- ... and here
```

Context.destroy() did not correctly handle the case where linger=0, in which
case linger evaluates to False. The fix is to check specifically for None, not
for any non-True value.

Socket.close() was completely ignoring the 'linger' argument.