### PR TITLE
pin tornado < 4.4 on Python 3.2

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 gevent; python_version == '2.7' and platform_python_implementation != "PyPy"
 pytest
 unittest2; python_version < '3'
-tornado
+tornado; python_version != '3.2'
+tornado < 4.4 ; python_version == '3.2'
 aiohttp; python_version >= '3.4'


### PR DESCRIPTION
tornado 4.4 drops Python 3.2 support