### PR TITLE
Windows: bundle C++ DLLs when not static-linking on Python >= 3.5

### DIFF
--- a/buildutils/config.py
+++ b/buildutils/config.py
@@ -93,6 +93,7 @@ def get_cfg_args():
                 'no_libzmq_extension',
                 'have_sys_un_h',
                 'skip_check_zmq',
+                'bundle_msvcp',
                 ]:
         if key in g:
             g[key] = eval(g[key])
@@ -144,6 +145,7 @@ def discover_settings(conf_base=None):
         'no_libzmq_extension': False,
         'skip_check_zmq': False,
         'allow_legacy_libzmq': False,
+        'bundle_msvcp': None,
         'build_ext': {},
         'bdist_egg': {},
     }

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,6 @@ def bundled_settings(debug):
             ext_suffix = distutils.sysconfig.get_config_var('EXT_SUFFIX')
             suffix = os.path.splitext(ext_suffix)[0]
 
-
         if debug:
             suffix = '_d' + suffix
             release = 'Debug'
@@ -239,9 +238,6 @@ def settings_from_prefix(prefix=None, bundle_libzmq_dylib=False):
                     env = os.environ['VIRTUAL_ENV']
                     settings['include_dirs'] += [pjoin(env, 'include')]
                     settings['library_dirs'] += [pjoin(env, 'lib')]
-    
-
-
 
         if bundle_libzmq_dylib:
             # bdist should link against bundled libzmq
@@ -306,12 +302,23 @@ class Configure(build_ext):
     def init_settings_from_config(self):
         """set up compiler settings, based on config"""
         cfg = self.config
-        
+
+        if sys.platform == 'win32' and cfg.get('bundle_msvcp') is None:
+            # default bundle_msvcp=True on:
+            # Windows Python 3.5 bdist *without* DISTUTILS_USE_SDK
+            if os.environ.get("PYZMQ_BUNDLE_CRT") or (
+                sys.version_info >= (3,5)
+                and self.compiler_type == 'msvc'
+                and not os.environ.get('DISTUTILS_USE_SDK')
+                and doing_bdist
+            ):
+                cfg['bundle_msvcp'] = True
+
         if cfg['libzmq_extension']:
             settings = bundled_settings(self.debug)
         else:
             settings = settings_from_prefix(cfg['zmq_prefix'], self.bundle_libzmq_dylib)
-    
+        
         if 'have_sys_un_h' not in cfg:
             # don't link against anything when checking for sys/un.h
             minus_zmq = copy.deepcopy(settings)
@@ -537,16 +544,15 @@ class Configure(build_ext):
             # And things like sockets come from libraries that must be named.
             libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32'])
             
-            # bundle MSCVP redist for CPython 3.5 if linking dynamically
-            if sys.version_info >= (3,5) \
-            and self.compiler_type == 'msvc' \
-            and not os.environ.get('DISTUTILS_USE_SDK'):
+            # bundle MSCVP redist
+            if self.config['bundle_msvcp']:
                 cc = new_compiler(compiler=self.compiler_type)
                 cc.initialize()
                 # get vc_redist location via private API
                 try:
                     cc._vcruntime_redist
                 except AttributeError:
+                    # fatal error if env set, warn otherwise
                     msg = fatal if os.environ.get("PYZMQ_BUNDLE_CRT") else warn
                     msg("Failed to get cc._vcruntime via private API, not bundling CRT")
                 if cc._vcruntime_redist:

--- a/tools/run_with_env.cmd
+++ b/tools/run_with_env.cmd
@@ -58,6 +58,7 @@ IF %MAJOR_PYTHON_VERSION% == 2 (
             SET SET_SDK_64=Y
         ) ELSE (
             SET SET_SDK_64=N
+            SET PYZMQ_BUNDLE_CRT=1
             IF EXIST "%WIN_WDK%" (
                 :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
                 REN "%WIN_WDK%" 0wdf


### PR DESCRIPTION
This should fix Python 3.5 Windows installs when not built with DISTUTILS_USE_SDK=1
for users who don't have the VC++2015 redistributable package.

relies on private `msvc._vcruntime_redist` for simplest discovery of redist DLL location,
so warn if/when this stops working.

closes #858