### PR TITLE
make Context.instance() thread safe

### DIFF
--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -6,6 +6,10 @@ import gc
 import sys
 import time
 from threading import Thread, Event
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
 
 import zmq
 from zmq.tests import (
@@ -76,6 +80,35 @@ class TestContext(BaseZMQTestCase):
         self.assertFalse(c3 is c2)
         self.assertFalse(c3.closed)
         self.assertTrue(c3 is c4)
+
+    def test_instance_threadsafe(self):
+        self.context.term() # clear default context
+
+        q = Queue()
+        # slow context initialization,
+        # to ensure that we are both trying to create one at the same time
+        class SlowContext(self.Context):
+            def __init__(self, *a, **kw):
+                time.sleep(1)
+                super(SlowContext, self).__init__(*a, **kw)
+
+        def f():
+            q.put(SlowContext.instance())
+
+        # call ctx.instance() in several threads at once
+        N = 16
+        threads = [ Thread(target=f) for i in range(N) ]
+        [ t.start() for t in threads ]
+        # also call it in the main thread (not first)
+        ctx = SlowContext.instance()
+        assert isinstance(ctx, SlowContext)
+        # check that all the threads got the same context
+        for i in range(N):
+            thread_ctx = q.get(timeout=5)
+            assert thread_ctx is ctx
+        # cleanup
+        ctx.term()
+        [ t.join(timeout=5) for t in threads ]
 
     def test_socket_passes_kwargs(self):
         test_kwarg_value = 'testing one two three'


### PR DESCRIPTION
with a lock, only grabbed if instance is not running. Same as tornado IOLoop.instance.

closes #875