### PR TITLE
pin setuptools to 25.1.3 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,8 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "%CMD_IN_ENV% pip install --disable-pip-version-check --user --upgrade pip setuptools wheel cython nose"
+  # pin setuptools to 25.1.3 for pypa/setuptools#722
+  - "%CMD_IN_ENV% pip install --disable-pip-version-check --user --upgrade pip setuptools==25.1.3 wheel cython nose"
 
 build_script:
   # Build the compiled extension


### PR DESCRIPTION
workaround pypa/setuptools#722 which prevents 25.1.4 from working.