### PR TITLE
use push/pull in test_tracker

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,8 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "%CMD_IN_ENV% pip install --disable-pip-version-check --user --upgrade pip setuptools wheel cython nose"
+  # pin setuptools to 25.1.3 for pypa/setuptools#722
+  - "%CMD_IN_ENV% pip install --disable-pip-version-check --user --upgrade pip setuptools==25.1.3 wheel cython nose"
 
 build_script:
   # Build the compiled extension

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -7,6 +7,7 @@ import os
 import platform
 import time
 import warnings
+import socket
 import sys
 
 from pytest import mark
@@ -209,20 +210,23 @@ class TestSocket(BaseZMQTestCase):
         self.sockets.extend([a,b])
         self.assertRaises(TypeError, a.send_multipart, [b'a', 5])
         a.send_multipart([b'b'])
-        rcvd = b.recv_multipart()
+        rcvd = self.recv_multipart(b)
         self.assertEqual(rcvd, [b'b'])
     
     @skip_pypy
     def test_tracker(self):
         "test the MessageTracker object for tracking when zmq is done with a buffer"
         addr = 'tcp://127.0.0.1'
-        a = self.context.socket(zmq.PUB)
-        port = a.bind_to_random_port(addr)
-        a.close()
-        iface = "%s:%i"%(addr,port)
-        a = self.context.socket(zmq.PAIR)
-        # a.setsockopt(zmq.IDENTITY, b"a")
-        b = self.context.socket(zmq.PAIR)
+        # get a port:
+        sock = socket.socket()
+        sock.bind(('127.0.0.1', 0))
+        port = sock.getsockname()[1]
+        iface = "%s:%i" % (addr, port)
+        sock.close()
+        time.sleep(0.1)
+
+        a = self.context.socket(zmq.PUSH)
+        b = self.context.socket(zmq.PULL)
         self.sockets.extend([a,b])
         a.connect(iface)
         time.sleep(0.1)
@@ -235,14 +239,14 @@ class TestSocket(BaseZMQTestCase):
         self.assertEqual(p1.done, False)
 
         b.bind(iface)
-        msg = b.recv_multipart()
+        msg = self.recv_multipart(b)
         for i in range(10):
             if p1.done:
                 break
             time.sleep(0.1)
         self.assertEqual(p1.done, True)
         self.assertEqual(msg, [b'something'])
-        msg = b.recv_multipart()
+        msg = self.recv_multipart(b)
         for i in range(10):
             if p2.done:
                 break
@@ -256,10 +260,10 @@ class TestSocket(BaseZMQTestCase):
         self.assertEqual(m.tracker.done, False)
         self.assertEqual(p1.done, False)
         self.assertEqual(p2.done, False)
-        msg = b.recv_multipart()
+        msg = self.recv_multipart(b)
         self.assertEqual(m.tracker.done, False)
         self.assertEqual(msg, [b'again'])
-        msg = b.recv_multipart()
+        msg = self.recv_multipart(b)
         self.assertEqual(m.tracker.done, False)
         self.assertEqual(msg, [b'again'])
         self.assertEqual(p1.done, False)
@@ -274,7 +278,6 @@ class TestSocket(BaseZMQTestCase):
         self.assertEqual(p2.done, True)
         m = zmq.Frame(b'something', track=False)
         self.assertRaises(ValueError, a.send, m, copy=False, track=True)
-        
 
     def test_close(self):
         ctx = self.Context()
@@ -336,7 +339,7 @@ class TestSocket(BaseZMQTestCase):
             a.send(msg)
         time.sleep(0.1)
         for i in range(3):
-            self.assertEqual(b.recv_multipart(), [msg])
+            self.assertEqual(self.recv_multipart(b), [msg])
     
     def test_close_after_destroy(self):
         """s.close() after ctx.destroy() should be fine"""


### PR DESCRIPTION
This may fix the intermittent hang in the test suite recently.

Hypothesis: There might be issues in PAIR causing the hang, possibly related to how the port is selected.