### PR TITLE
pin pytest version on Python 3.2

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 gevent; python_version == '2.7' and platform_python_implementation != "PyPy"
-pytest
+pytest; python_version != '3.2'
+pytest < 3; python_version == '3.2'
 unittest2; python_version < '3'
 tornado; python_version != '3.2'
 tornado < 4.4 ; python_version == '3.2'


### PR DESCRIPTION
pytest 3 has dropped Python 3.2 support (as they should)