### PR TITLE
Bundle libzmq headers when libzmq is bundled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 zmq/backend/cython/*.c
 zmq/devices/*.c
 zmq/utils/*.json
+zmq/include/*.h
 __pycache__
 build
 dist

--- a/setup.py
+++ b/setup.py
@@ -587,6 +587,17 @@ class Configure(build_ext):
                     # not sure why
                     libzmq.libraries.append("stdc++")
         
+        # copy the header files to the source tree.
+        bundledincludedir = pjoin('zmq', 'include')
+        if not os.path.exists(bundledincludedir):
+            os.makedirs(bundledincludedir)
+        if not os.path.exists(pjoin(self.build_lib, bundledincludedir)):
+            os.makedirs(pjoin(self.build_lib, bundledincludedir))
+        
+        for header in glob(pjoin(bundledir, 'zeromq', 'include', '*.h')):
+            shutil.copyfile(header, pjoin(bundledincludedir, basename(header)))
+            shutil.copyfile(header, pjoin(self.build_lib, bundledincludedir, basename(header)))
+        
         # update other extensions, with bundled settings
         self.config['libzmq_extension'] = True
         self.init_settings_from_config()
@@ -887,6 +898,9 @@ class CleanCommand(Command):
         
         bundled = glob(pjoin('zmq', 'libzmq*'))
         _clean_me.extend([ b for b in bundled if b not in _clean_me ])
+        
+        bundled_headers = glob(pjoin('zmq', 'include', '*.h'))
+        _clean_me.extend([ h for h in bundled_headers if h not in _clean_me])
         
         for clean_me in _clean_me:
             print("removing %s" % clean_me)

--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -46,7 +46,7 @@ def get_includes():
         includes.append(pjoin(parent, base, 'include'))
     return includes
     
-def get_libdirs():
+def get_library_dirs():
     """Get the library directory for linking to the bundled copy of libzmq."""
     from os.path import join, dirname, abspath, pardir
     base = dirname(__file__)

--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -38,10 +38,26 @@ from zmq.sugar import *
 
 def get_includes():
     """Return a list of directories to include for linking against pyzmq with cython."""
+    from os.path import join, dirname, abspath, pardir, exists
+    base = dirname(__file__)
+    parent = abspath(join(base, pardir))
+    includes = [ parent ] + [ join(parent, base, subdir) for subdir in ('utils',) ]
+    if exists(pjoin(parent, base, 'include')):
+        includes.append(pjoin(parent, base, 'include'))
+    return includes
+    
+def get_libdirs():
+    """Get the library directory for linking to the bundled copy of libzmq."""
     from os.path import join, dirname, abspath, pardir
     base = dirname(__file__)
     parent = abspath(join(base, pardir))
-    return [ parent ] + [ join(parent, base, subdir) for subdir in ('utils',) ]
+    global _libzmq
+    try:
+        _libzmq
+    except NameError:
+        return []
+    else:
+        return [pjoin(parent, base, pardir)]
 
 
 __all__ = ['get_includes'] + sugar.__all__ + backend.__all__

--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -51,13 +51,7 @@ def get_library_dirs():
     from os.path import join, dirname, abspath, pardir
     base = dirname(__file__)
     parent = abspath(join(base, pardir))
-    global _libzmq
-    try:
-        _libzmq
-    except NameError:
-        return []
-    else:
-        return [pjoin(parent, base, pardir)]
+    return [ pjoin(parent, base, pardir) ]
 
 
 __all__ = ['get_includes'] + sugar.__all__ + backend.__all__


### PR DESCRIPTION
This PR is in response to #903. When libzmq is bundled with pyzmq, this PR also bundles the libzmq header files in ``zmq/include`` so that you can compile against the bundled libzmq. It adds this header directory to ``zmq.get_includes()`` and adds a new function ``zmq.get_library_dirs`` which returns the appropriate library search path for binding against the bundled libzmq.

I've caused many bugs in my own code because I've compiled against the pyzmq cython extensions, but linked to a copy of libzmq previously installed on my machine. Ideally, the solution is to install pyzmq with ``pip install --no-binary :all: pyzmq``, but I don't always have control over how pyzmq is installed. If pyzmq has already been linked to its own copy of libzmq, including the libzmq headers for the bundled copy would allow me to build cython extensions against pyzmq.

Packaging is hard, so I suspect there are edge cases or specifics I might have missed here.