### PR TITLE
Fix building with recent versions of Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1034,7 +1034,11 @@ try:
     import Cython
     if V(Cython.__version__) < V('0.16'):
         raise ImportError("Cython >= 0.16 required, found %s" % Cython.__version__)
-    from Cython.Distutils import build_ext as build_ext_c
+    try:
+        # Cython 0.25 or later
+        from Cython.Distutils.old_build_ext import old_build_ext as build_ext_c
+    except ImportError:
+        from Cython.Distutils import build_ext as build_ext_c
     cython=True
 except Exception:
     cython=False


### PR DESCRIPTION
Cython 0.25 (not released yet) introduced a completely new version of `Cython.Distutils.build_ext`. See https://github.com/cython/cython/pull/1456

Since `pyzmq` uses a lot of internals of the old `build_ext`, it no longer works. However, the old implementation is still available in `Cython.Distutils.old_build_ext`.