### PR TITLE
send() takes at least 1 positional argument

### DIFF
--- a/zmq/eventloop/future.py
+++ b/zmq/eventloop/future.py
@@ -318,7 +318,7 @@ class _AsyncSocket(_zmq.Socket):
             # short-circuit non-blocking calls
             send = getattr(self._shadow_sock, kind)
             try:
-                r = send(**kwargs)
+                r = send(msg, **kwargs)
             except Exception as e:
                 f.set_exception(e)
             else:


### PR DESCRIPTION
This function may cause python exception if it doesn't have positional argument msg.