### PR TITLE
Fix zmq.get_includes and zmq.get_library_dirs

### DIFF
--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -42,8 +42,8 @@ def get_includes():
     base = dirname(__file__)
     parent = abspath(join(base, pardir))
     includes = [ parent ] + [ join(parent, base, subdir) for subdir in ('utils',) ]
-    if exists(pjoin(parent, base, 'include')):
-        includes.append(pjoin(parent, base, 'include'))
+    if exists(join(parent, base, 'include')):
+        includes.append(join(parent, base, 'include'))
     return includes
     
 def get_library_dirs():
@@ -51,7 +51,7 @@ def get_library_dirs():
     from os.path import join, dirname, abspath, pardir
     base = dirname(__file__)
     parent = abspath(join(base, pardir))
-    return [ pjoin(parent, base, pardir) ]
+    return [ join(parent, base) ]
 
 
 __all__ = ['get_includes'] + sugar.__all__ + backend.__all__

--- a/zmq/tests/test_includes.py
+++ b/zmq/tests/test_includes.py
@@ -1,0 +1,33 @@
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+
+from unittest import TestCase
+import zmq
+import os
+
+class TestIncludes(TestCase):
+
+    def test_get_includes(self):
+        from os.path import dirname, basename
+        includes = zmq.get_includes()
+        self.assertTrue(isinstance(includes, list))
+        self.assertTrue(len(includes) >= 2)
+        parent = includes[0]
+        self.assertTrue(isinstance(parent, str))
+        utilsdir = includes[1]
+        self.assertTrue(isinstance(utilsdir, str))
+        utils = basename(utilsdir)
+        self.assertEqual(utils, "utils")
+
+    def test_get_library_dirs(self):
+        from os.path import dirname, basename
+        libdirs = zmq.get_library_dirs()
+        self.assertTrue(isinstance(libdirs, list))
+        self.assertEqual(len(libdirs), 1)
+        parent = libdirs[0]
+        self.assertTrue(isinstance(parent, str))
+        libdir = basename(parent)
+        self.assertEqual(libdir, "zmq")
+        
+         


### PR DESCRIPTION
My PR #905 contained two bugs. This PR fixes those two bugs, and adds a quick test case for them.