### PR TITLE
bare raise in IOLoop.start

### DIFF
--- a/zmq/eventloop/ioloop.py
+++ b/zmq/eventloop/ioloop.py
@@ -180,7 +180,7 @@ class ZMQIOLoop(PollIOLoop):
                 # quietly return on ETERM
                 pass
             else:
-                raise e
+                raise
 
 
 if (3, 0) <= tornado_version < (3, 1):


### PR DESCRIPTION
rather than raise e, which cuts off traceback