### PR TITLE
initialize pollitem.fd = 0 for non-FDs

### DIFF
--- a/zmq/backend/cython/_poll.pyx
+++ b/zmq/backend/cython/_poll.pyx
@@ -82,6 +82,7 @@ def zmq_poll(sockets, long timeout=-1):
         s, events = sockets[i]
         if isinstance(s, Socket):
             pollitems[i].socket = (<Socket>s).handle
+            pollitems[i].fd = 0
             pollitems[i].events = events
             pollitems[i].revents = 0
         elif isinstance(s, int_t):


### PR DESCRIPTION
Shouldn't be strictly necessary, but good hygiene.

A bug in libzmq-4.2.0 makes it actually necessary.