### PR TITLE
SUBSCRIBE/UNSUBSCRIBE notifies state changing for gevent

### DIFF
--- a/zmq/green/core.py
+++ b/zmq/green/core.py
@@ -276,7 +276,10 @@ class _Socket(_original_Socket):
         """set socket option"""
         if opt in TIMEOS:
             warnings.warn("TIMEO socket options have no effect in zmq.green", UserWarning)
-        return super(_Socket, self).set(opt, val)
+        result = super(_Socket, self).set(opt, val)
+        if opt in (zmq.SUBSCRIBE, zmq.UNSUBSCRIBE):
+            self.__state_changed()
+        return result
 
 
 class _Context(_original_Context):

--- a/zmq/tests/test_pubsub.py
+++ b/zmq/tests/test_pubsub.py
@@ -67,7 +67,7 @@ if have_gevent:
                         sub.set(zmq.UNSUBSCRIBE, topic)
                     # Sleep with 0 is necessary to reproduce the crash.
                     gevent.sleep(0)
-            for x in range(10):
+            for x in range(3):
                 sub, addr = self.create_sub()
                 pub.connect(addr)
                 workload(sub)

--- a/zmq/tests/test_pubsub.py
+++ b/zmq/tests/test_pubsub.py
@@ -47,15 +47,16 @@ if have_gevent:
             addr = '%s:%s' % (interface, port)
             return sub, addr
 
-        def test_sigabrt_issue(self):
+        def test_sigabrt_issue(self, random=Random(42)):
             import gevent
             pub = self.context.socket(zmq.PUB)
             pub.setsockopt(zmq.LINGER, 0)
             self.sockets.append(pub)
-            random = Random(42)
             topics = [str(random.random())[2:] for x in range(10000)]
             def workload(sub):
                 subscribed = set()
+                # Many subscriptions, for example above 5000, are
+                # raising up reproducibility of the crash.
                 for x in range(10000):
                     if not subscribed or random.random() < 0.9:
                         topic = random.choice(topics)
@@ -65,10 +66,13 @@ if have_gevent:
                         topic = random.choice(list(subscribed))
                         subscribed.remove(topic)
                         sub.set(zmq.UNSUBSCRIBE, topic)
-                    # Sleep with 0 is necessary to reproduce the crash.
+                    # Sleeping with gevent for 0 seconds is necessary
+                    # to reproduce the crash.
                     gevent.sleep(0)
             for x in range(3):
                 sub, addr = self.create_sub()
                 pub.connect(addr)
                 workload(sub)
+                # Only SUB socket closes.  If PUB socket disconnects,
+                # the crash won't be reproduced.
                 sub.close()

--- a/zmq/tests/test_pubsub.py
+++ b/zmq/tests/test_pubsub.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 
+from random import Random
 import time
 from unittest import TestCase
 
@@ -17,7 +18,7 @@ class TestPubSub(BaseZMQTestCase):
     # We are disabling this test while an issue is being resolved.
     def test_basic(self):
         s1, s2 = self.create_bound_pair(zmq.PUB, zmq.SUB)
-        s2.setsockopt(zmq.SUBSCRIBE,b'')
+        s2.setsockopt(zmq.SUBSCRIBE, b'')
         time.sleep(0.1)
         msg1 = b'message'
         s1.send(msg1)
@@ -38,4 +39,36 @@ class TestPubSub(BaseZMQTestCase):
 
 if have_gevent:
     class TestPubSubGreen(GreenTest, TestPubSub):
-        pass
+
+        def create_sub(self, interface='tcp://127.0.0.1'):
+            sub = self.context.socket(zmq.SUB)
+            sub.setsockopt(zmq.LINGER, 0)
+            port = sub.bind_to_random_port(interface)
+            addr = '%s:%s' % (interface, port)
+            return sub, addr
+
+        def test_sigabrt_issue(self):
+            import gevent
+            pub = self.context.socket(zmq.PUB)
+            pub.setsockopt(zmq.LINGER, 0)
+            self.sockets.append(pub)
+            random = Random(42)
+            topics = [str(random.random())[2:] for x in range(10000)]
+            def workload(sub):
+                subscribed = set()
+                for x in range(10000):
+                    if not subscribed or random.random() < 0.9:
+                        topic = random.choice(topics)
+                        subscribed.add(topic)
+                        sub.set(zmq.SUBSCRIBE, topic)
+                    else:
+                        topic = random.choice(list(subscribed))
+                        subscribed.remove(topic)
+                        sub.set(zmq.UNSUBSCRIBE, topic)
+                    # Sleep with 0 is necessary to reproduce the crash.
+                    gevent.sleep(0)
+            for x in range(10):
+                sub, addr = self.create_sub()
+                pub.connect(addr)
+                workload(sub)
+                sub.close()


### PR DESCRIPTION
`set()` with `SUBSCRIBE` and `UNSUBSCRIBE` actually sends a message like `send()`.  So this event should be notified to the I/O loop.

This patch fixes [one of crash issues](https://github.com/zeromq/libzmq/issues/2252) on `PUB`/`SUB` sockets.