### PR TITLE
set user-id for curve/gssapi auth

### DIFF
--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -203,13 +203,18 @@ class Authenticator(object):
                     return
                 key = credentials[0]
                 allowed, reason = self._authenticate_curve(domain, key)
+                if allowed:
+                    # use client public key (z85-encoded) as user-id by default
+                    # TODO: add extensible mechanism for determining user id
+                    username = z85.encode(key)
 
             elif mechanism == b'GSSAPI':
                 if len(credentials) != 1:
                     self.log.error("Invalid GSSAPI credentials: %r", credentials)
                     self._send_zap_reply(request_id, b"400", b"Invalid credentials")
                     return
-                principal = u(credentials[0], 'replace')
+                # use principal as user-id for now
+                principal = username = credentials[0]
                 allowed, reason = self._authenticate_gssapi(domain, principal)
 
         if allowed:

--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -178,7 +178,7 @@ class Authenticator(object):
                 self.log.debug("PASSED (not in blacklist) address=%s", address)
 
         # Perform authentication mechanism-specific checks if necessary
-        username = u("user")
+        username = u("anonymous")
         if not denied:
 
             if mechanism == b'NULL' and not allowed:
@@ -286,7 +286,7 @@ class Authenticator(object):
         self.log.debug("ALLOWED (GSSAPI) domain=%s principal=%s", domain, principal)
         return True, b'OK'
 
-    def _send_zap_reply(self, request_id, status_code, status_text, user_id='user'):
+    def _send_zap_reply(self, request_id, status_code, status_text, user_id='anonymous'):
         """Send a ZAP reply to finish the authentication."""
         user_id = user_id if status_code == b'200' else b''
         if isinstance(user_id, unicode):

--- a/zmq/tests/asyncio/_test_asyncio.py
+++ b/zmq/tests/asyncio/_test_asyncio.py
@@ -338,3 +338,13 @@ class TestAsyncioAuthentication(TestThreadAuthentication):
                 result = True
             return result
         return self.loop.run_until_complete(go())
+
+    def _select_recv(self, multipart, socket, **kwargs):
+        recv = socket.recv_multipart if multipart else socket.recv
+        @asyncio.coroutine
+        def coro():
+            if not (yield from socket.poll(5000)):
+                raise TimeoutError("Should have received a message")
+            return (yield from recv(**kwargs))
+        return self.loop.run_until_complete(coro())
+

--- a/zmq/tests/test_auth.py
+++ b/zmq/tests/test_auth.py
@@ -15,7 +15,7 @@ from zmq.auth.thread import ThreadAuthenticator
 
 from zmq.eventloop import ioloop, zmqstream
 from zmq.utils.strtypes import u
-from zmq.tests import (BaseZMQTestCase, SkipTest)
+from zmq.tests import BaseZMQTestCase, SkipTest, skip_pypy
 
 
 class BaseAuthTestCase(BaseZMQTestCase):
@@ -241,6 +241,7 @@ class TestThreadAuthentication(BaseAuthTestCase):
         client = self.socket(zmq.PULL)
         self.assertTrue(self.can_connect(server, client))
 
+    @skip_pypy
     def test_curve_user_id(self):
         """threaded auth - CURVE"""
         self.auth.allow('127.0.0.1')


### PR DESCRIPTION
Defaults:

- CURVE: z85-encoded client public key
- GSSAPI: principal

curve user-id can be overridden with the `Authenticator.curve_user_id`

closes #804