### PR TITLE
Don't pass FutureSocket to tornado IOLoop

### DIFF
--- a/zmq/eventloop/future.py
+++ b/zmq/eventloop/future.py
@@ -464,6 +464,9 @@ class _AsyncSocket(_zmq.Socket):
         
         called once during close
         """
+        if getattr(self.io_loop, '_closing', False):
+            # check closing flag to avoid RuntimeError in IOLoop.close(all_fds=True)
+            return
         self.io_loop.remove_handler(self)
 
 

--- a/zmq/eventloop/future.py
+++ b/zmq/eventloop/future.py
@@ -453,21 +453,18 @@ class _AsyncSocket(_zmq.Socket):
     def _update_handler(self, state):
         """Update IOLoop handler with state."""
         self._state = state
-        self.io_loop.update_handler(self, state)
+        self.io_loop.update_handler(self._shadow_sock, state)
 
     def _init_io_state(self):
         """initialize the ioloop event handler"""
-        self.io_loop.add_handler(self, self._handle_events, self._state)
+        self.io_loop.add_handler(self._shadow_sock, self._handle_events, self._state)
 
     def _clear_io_state(self):
         """unregister the ioloop event handler
         
         called once during close
         """
-        if getattr(self.io_loop, '_closing', False):
-            # check closing flag to avoid RuntimeError in IOLoop.close(all_fds=True)
-            return
-        self.io_loop.remove_handler(self)
+        self.io_loop.remove_handler(self._shadow_sock)
 
 
 class Socket(_AsyncTornado, _AsyncSocket):

--- a/zmq/tests/test_future.py
+++ b/zmq/tests/test_future.py
@@ -25,7 +25,8 @@ class TestFutureSocket(BaseZMQTestCase):
     
     def tearDown(self):
         super(TestFutureSocket, self).tearDown()
-        self.loop.close(all_fds=True)
+        if self.loop:
+            self.loop.close(all_fds=True)
     
     def test_socket_class(self):
         s = self.context.socket(zmq.PUSH)
@@ -204,6 +205,12 @@ class TestFutureSocket(BaseZMQTestCase):
             recvd = yield b.recv_multipart()
             self.assertEqual(recvd, [b'hi', b'there'])
         self.loop.run_sync(test)
+    
+    def test_close_all_fds(self):
+        s = self.socket(zmq.PUB)
+        self.loop.close(all_fds=True)
+        self.loop = None # avoid second close later
+        assert s.closed
 
     def test_poll_raw(self):
         @gen.coroutine


### PR DESCRIPTION
pass underlying `_shadow_sock` instead

avoids RuntimeError due to modifying dict during iteration in `IOLoop.close(all_fds=True)`

closes #963