### PR TITLE
remove finished futures from pending event lists

### DIFF
--- a/zmq/eventloop/future.py
+++ b/zmq/eventloop/future.py
@@ -267,12 +267,14 @@ class _AsyncSocket(_zmq.Socket):
             for f_idx, (f, kind, kwargs, _) in enumerate(self._recv_futures):
                 if f == future:
                     self._recv_futures.pop(f_idx)
+                    f._pyzmq_popped = True
                     break
 
             # pop the entry from _send_futures
             for f_idx, (f, kind, kwargs, _) in enumerate(self._send_futures):
                 if f == future:
                     self._send_futures.pop(f_idx)
+                    f._pyzmq_popped = True
                     break
 
             # raise EAGAIN
@@ -288,6 +290,20 @@ class _AsyncSocket(_zmq.Socket):
         with the same signature.
         """
         self.io_loop.call_later(delay, callback)
+
+    @staticmethod
+    def _remove_finished_future(future, event_list):
+        """Make sure that futures are removed from the event list when they resolve
+
+        Avoids delaying cleanup until the next send/recv event,
+        which may never come.
+        """
+        if getattr(future, '_pyzmq_popped', False):
+            return
+        for f_idx, (f, kind, kwargs, _) in enumerate(event_list):
+            if f is future:
+                event_list.pop(f_idx)
+                return
 
     def _add_recv_event(self, kind, kwargs=None, future=None):
         """Add a recv event, returning the corresponding Future"""
@@ -308,6 +324,9 @@ class _AsyncSocket(_zmq.Socket):
         self._recv_futures.append(
             _FutureEvent(f, kind, kwargs, msg=None)
         )
+
+        # Don't let the Future sit in _recv_events after it's done
+        f.add_done_callback(lambda f: self._remove_finished_future(f, self._recv_futures))
 
         if hasattr(_zmq, 'RCVTIMEO'):
             timeout_ms = self._shadow_sock.rcvtimeo
@@ -340,6 +359,8 @@ class _AsyncSocket(_zmq.Socket):
         self._send_futures.append(
             _FutureEvent(f, kind, kwargs=kwargs, msg=msg)
         )
+        # Don't let the Future sit in _send_futures after it's done
+        f.add_done_callback(lambda f: self._remove_finished_future(f, self._send_futures))
 
         if hasattr(_zmq, 'SNDTIMEO'):
             timeout_ms = self._shadow_sock.sndtimeo
@@ -361,6 +382,7 @@ class _AsyncSocket(_zmq.Socket):
         f = None
         while self._recv_futures:
             f, kind, kwargs, _ = self._recv_futures.pop(0)
+            f._pyzmq_popped = True
             # skip any cancelled futures
             if f.done():
                 f = None
@@ -399,6 +421,7 @@ class _AsyncSocket(_zmq.Socket):
         f = None
         while self._send_futures:
             f, kind, kwargs, msg = self._send_futures.pop(0)
+            f._pyzmq_popped = True
             # skip any cancelled futures
             if f.done():
                 f = None


### PR DESCRIPTION
avoids waiting for cleanup to fire on the next event, which may never come.

closes #968