### PR TITLE
Make setup test for "sys/un.h" cross-compile-friendly.

### DIFF
--- a/buildutils/detect.py
+++ b/buildutils/detect.py
@@ -58,7 +58,11 @@ def test_compilation(cfile, compiler=None, **compiler_attrs):
     cc.link_executable(objs, efile, extra_preargs=lpreargs)
     return efile
 
-def compile_and_run(basedir, src, compiler=None, **compiler_attrs):
+def compile_and_forget(basedir, src, compiler=None, **compiler_attrs):
+    """Make sure src compiles and links successfully.
+
+    The resulting binary is deleted without being run.
+    """
     if not os.path.exists(basedir):
         os.makedirs(basedir)
     cfile = pjoin(basedir, os.path.basename(src))
@@ -66,17 +70,8 @@ def compile_and_run(basedir, src, compiler=None, **compiler_attrs):
     try:
         cc = get_compiler(compiler, **compiler_attrs)
         efile = test_compilation(cfile, compiler=cc)
-        patch_lib_paths(efile, cc.library_dirs)
-        result = Popen(efile, stdout=PIPE, stderr=PIPE)
-        so, se = result.communicate()
-        # for py3k:
-        so = so.decode()
-        se = se.decode()
     finally:
         shutil.rmtree(basedir)
-    
-    return result.returncode, so, se
-    
     
 def detect_zmq(basedir, compiler=None, **compiler_attrs):
     """Compile, link & execute a test program, in empty directory `basedir`.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ from buildutils import (
     info, warn, fatal, debug, line, copy_and_patch_libzmq, localpath,
     fetch_libzmq, stage_platform_hpp,
     bundled_version, customize_mingw,
-    compile_and_run,
+    compile_and_forget,
     patch_lib_paths,
     )
 
@@ -327,7 +327,7 @@ class Configure(build_ext):
             except Exception:
                 pass
             try:
-                compile_and_run(self.tempdir,
+                compile_and_forget(self.tempdir,
                     pjoin('buildutils', 'check_sys_un.c'),
                     **minus_zmq
                 )


### PR DESCRIPTION
The previous test used compile_and_run but running the test binary on
the build host is not always possible, for instance when
cross-compiling. Furthermore it's not necessary in this case since a
missing "sys/un.h" header would be caught at compile time and the lack
of library support at link time.

Therefore this patch replaces compile_and_run with compile_and_forget
which builds the test program but doesn't run it. compile_and_run is
removed since it's now unused.