### PR TITLE
update timeout when poll is retried due to interrupted syscalls

### DIFF
--- a/zmq/backend/cffi/_poll.py
+++ b/zmq/backend/cffi/_poll.py
@@ -10,8 +10,7 @@ except ImportError:
     from time import clock as monotonic
 
 from ._cffi import C, ffi
-from .utils import _retry_sys_call
-
+from zmq.error import InterruptedSystemCall, _check_rc
 
 def _make_zmq_pollitem(socket, flags):
     zmq_socket = socket._zmq_socket


### PR DESCRIPTION
avoids extending timeout when interrupts arrive during timeout

closes #996