### PR TITLE
add Socket.copy_threshold

### DIFF
--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -53,5 +53,5 @@ def get_library_dirs():
     parent = abspath(join(base, pardir))
     return [ join(parent, base) ]
 
-
-__all__ = ['get_includes'] + sugar.__all__ + backend.__all__
+COPY_THRESHOLD = 65536
+__all__ = ['get_includes', 'COPY_THRESHOLD'] + sugar.__all__ + backend.__all__

--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -62,6 +62,7 @@ class Socket(object):
     _closed = None
     _ref = None
     _shadow = False
+    copy_threshold = 0
 
     def __init__(self, context=None, socket_type=None, shadow=None):
         self.context = context

--- a/zmq/backend/cython/socket.pxd
+++ b/zmq/backend/cython/socket.pxd
@@ -39,6 +39,7 @@ cdef class Socket:
     # collected until the socket it done with it.
     cdef public Context context # The zmq Context object that owns this.
     cdef public bint _closed    # bool property for a closed socket.
+    cdef public int copy_threshold # threshold below which pyzmq will always copy messages
     cdef int _pid               # the pid of the process which created me (for fork safety)
 
     # cpdef methods for direct-cython access:

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -27,7 +27,7 @@
 cdef extern from "pyversion_compat.h":
     pass
 
-from libc.errno cimport ENAMETOOLONG
+from libc.errno cimport ENAMETOOLONG, ENOTSOCK
 from libc.string cimport memcpy
 
 from cpython cimport PyBytes_FromStringAndSize
@@ -36,7 +36,36 @@ from cpython cimport Py_DECREF, Py_INCREF, PY_VERSION_HEX
 
 from zmq.utils.buffers cimport asbuffer_r, viewfromobject_r
 
-from .libzmq cimport *
+from .libzmq cimport (
+    fd_t,
+    int64_t,
+
+    zmq_errno,
+
+    zmq_msg_t,
+    zmq_msg_init,
+    zmq_msg_init_size,
+    zmq_msg_close,
+    zmq_msg_data,
+    zmq_msg_size,
+    zmq_msg_send,
+    zmq_msg_recv,
+
+    zmq_socket,
+    zmq_socket_monitor,
+    zmq_connect,
+    zmq_disconnect,
+    zmq_bind,
+    zmq_unbind,
+    zmq_setsockopt,
+    zmq_getsockopt,
+    zmq_close,
+
+    ZMQ_EVENT_ALL,
+    ZMQ_IDENTITY,
+    ZMQ_LINGER,
+    ZMQ_TYPE,
+)
 from message cimport Frame, copy_zmq_msg_bytes
 
 from context cimport Context
@@ -71,7 +100,6 @@ except:
 
 import zmq
 from zmq.backend.cython import constants
-from .constants import *
 from .checkrc cimport _check_rc
 from zmq.error import ZMQError, ZMQBindError, InterruptedSystemCall, _check_version
 from zmq.utils.strtypes import bytes,unicode,basestring

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -4,7 +4,6 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
-
 from .attrsettr import AttributeSetter
 from zmq.backend import Frame as FrameBase
 
@@ -13,6 +12,7 @@ class Frame(FrameBase, AttributeSetter):
     def __getitem__(self, key):
         # map Frame['User-Id'] to Frame.get('User-Id')
         return self.get(key)
+
 
 # keep deprecated alias
 Message = Frame

--- a/zmq/sugar/tracker.py
+++ b/zmq/sugar/tracker.py
@@ -117,4 +117,6 @@ class MessageTracker(object):
             remaining -= (toc-tic)
             tic = toc
 
-__all__ = ['MessageTracker']
+_FINISHED_TRACKER = MessageTracker()
+
+__all__ = ['MessageTracker', '_FINISHED_TRACKER']

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -235,12 +235,17 @@ class TestSocket(BaseZMQTestCase):
         a.connect(iface)
         time.sleep(0.1)
         p1 = a.send(b'something', copy=False, track=True)
-        self.assertTrue(isinstance(p1, zmq.MessageTracker))
-        self.assertFalse(p1.done)
+        assert isinstance(p1, zmq.MessageTracker)
+        assert p1 is zmq._FINISHED_TRACKER
+        # small message, should start done
+        assert p1.done
+
+        # disable zero-copy threshold
+        a.copy_threshold = 0
+
         p2 = a.send_multipart([b'something', b'else'], copy=False, track=True)
-        self.assert_(isinstance(p2, zmq.MessageTracker))
-        self.assertEqual(p2.done, False)
-        self.assertEqual(p1.done, False)
+        assert isinstance(p2, zmq.MessageTracker)
+        assert not p2.done
 
         b.bind(iface)
         msg = self.recv_multipart(b)


### PR DESCRIPTION
messages smaller than this value will always be copied, even if `copy=False`.

There's a nontrivial overhead to zero-copy, so don't incur it when messages are small. Set the default at 64k, but can be overridden by setting `zmq.COPY_THRESHOLD` for a global (prior to creating sockets), or on individual sockets with `s.copy_threshold`.

64k because perf tests suggest that the crossover is somewhere in the 100k range.