### PR TITLE
Begin RELICENSE process

### DIFF
--- a/RELICENSE/README.md
+++ b/RELICENSE/README.md
@@ -1,0 +1,31 @@
+# Permission to Relicense under MPLv2 or BSD
+
+Most of pyzmq is licensed under [3-Clause BSD](https://opensource.org/licenses/BSD-3-Clause).
+For historical reasons, the 'core' of pyzmq (the low-level Cython bindings)
+is licensed under LGPLv3, like libzmq itself.
+
+libzmq is in the process of moving away from LGPL to the  [Mozilla Public License, version
+2](https://www.mozilla.org/en-US/MPL/2.0/).
+I'd like to take this opportunity to follow libzmq's example and also eliminate LGPL from pyzmq.
+For a similarly copyleft license, MPLv2 can be used for the core.
+However, I would prefer to update the core to follow the example of the rest of pyzmq,
+and adopt the 3-Clause BSD license.
+
+This directory collects grants from individuals and firms that hold
+copyrights in pyzmq to permit licensing the pyzmq code under
+the MPLv2 or BSD license.  See
+the [0MQ Licensing Page](http://zeromq.org/area:licensing) and
+[libzmq relicensing effort](https://github.com/zeromq/libzmq/pull/1917)
+for some background information.
+
+Please create a separate file in this directory for each individual
+or firm holding copyright in pyzmq core, named after the individual or
+firm holding the copyright.
+
+Each patch must be made with a GitHub handle that is clearly
+associated with the copyright owner, to guarantee the identity of
+the signatory.  Please avoid changing the files created by other
+individuals or firms granting a copyright license over their
+copyrights (if rewording is required contact them and ask them to
+submit an updated version).  This makes it easier to verify that
+the license grant was made by an authorized GitHub account.

--- a/RELICENSE/authors.py
+++ b/RELICENSE/authors.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Get the authors of the LGPL-licensed subset of pyzmq (Cython bindings)"""
+
+from collections import defaultdict
+from itertools import chain
+from os.path import abspath, dirname, join
+import re
+
+import git
+
+here = dirname(__file__)
+root = dirname(abspath(here))
+repo = git.Repo(root)
+
+LAST_CORE_COMMIT = 'db1d4d2f2cdd97955a7db620e667a834920a938a'
+PRE_CORE_COMMIT = 'd4e3453b012962fc9bf6ed621019b395f968340c'
+
+EXCLUDED = {
+    # docstring only:
+    'c2db4af3c591aae99bf437a223d97b30ecbfcd38',
+    '7b1ac07a3bbffe70af3adcd663c0cbe6f2a724f7',
+    'ce97f46881168c4c05d7885dc48a430c520a9683',
+    '14c16a97ffa95bf645ab27bf5b06c3eabda30e5e',
+
+    # accidental swapfile
+    '93150feb4a80712c6a379f79d561fbc87405ade8',
+}
+
+def get_all_commits():
+    return chain(
+        repo.iter_commits('master', 'zmq/backend/cython'),
+        repo.iter_commits(LAST_CORE_COMMIT, 'zmq/core'),
+        repo.iter_commits(PRE_CORE_COMMIT, ['zmq/_zmq.*']),
+    )
+
+mailmap = {}
+email_names = {}
+
+pat = re.compile(r'\<([^\>]+)\>')
+with open(join(root, '.mailmap')) as f:
+    for line in f:
+        if not line.strip():
+            continue
+        dest, src = pat.findall(line)
+        mailmap[src] = dest
+        email_names[dest] = line[:line.index('<')].strip()
+
+author_commits = defaultdict(lambda : [])
+
+for commit in get_all_commits():
+    
+    # exclude some specific commits (e.g. docstring typos)
+    if commit.hexsha in EXCLUDED:
+        continue
+    # exclude commits that only touch generated pxi files in backend/cython
+    backend_cython_files = {
+        f for f in commit.stats.files
+        if f.startswith('zmq/backend/cython')
+    }
+    if backend_cython_files and backend_cython_files.issubset({
+        'zmq/backend/cython/constant_enums.pxi',
+        'zmq/backend/cython/constants.pxi',
+    }):
+        continue
+    
+    email = commit.author.email
+    email = mailmap.get(email, email)
+    name = email_names.setdefault(email, commit.author.name)
+    author_commits[email].append(commit)
+
+def sort_key(email_commits):
+    commits = email_commits[1]
+    return (len(commits), commits[0].authored_date)
+
+for email, commits in sorted(author_commits.items(), key=sort_key, reverse=True):
+    if len(commits) <= 2:
+        msg = '%s (%s)' % (' '.join(c.hexsha[:12] for c in commits), commits[0].authored_datetime.year)
+    else:
+        msg = "{commits} commits ({start}-{end})".format(
+            commits=len(commits),
+            start=commits[-1].authored_datetime.year,
+            end=commits[0].authored_datetime.year,
+        )
+    print("- [ ] {name} {email}: {msg}".format(
+        name=email_names[email],
+        email=email,
+        msg=msg,
+    ))

--- a/RELICENSE/minrk.md
+++ b/RELICENSE/minrk.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current PyZMQ BDFL
+
+This is a statement by Min Ragan-Kelley
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current PyZMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the GitHub handle "minrk", with
+commit author "Min RK benjaminrk@gmail.com", are copyright of Min Ragan-Kelley.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Min Ragan-Kelley 
+2017/07/17

--- a/RELICENSE/templates/relicense-template-bsd.txt
+++ b/RELICENSE/templates/relicense-template-bsd.txt
@@ -1,0 +1,13 @@
+# Permission to Relicense under BSD
+
+This is a statement by {{ name of company / name of individual }}
+that grants permission to relicense its copyrights in the Python ZeroMQ bindings
+(pyzmq) under the 3-Clause BSD License (BSD3).
+
+A portion of the commits made by the Github handle "{{github username}}", with
+commit author "{{github commit author}}", are copyright of {{ name }}.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+{{ Full Name }}
+{{ creation date of document (format: yyyy/mm/dd) }}

--- a/RELICENSE/templates/relicense-template-mplv2-any-osi.txt
+++ b/RELICENSE/templates/relicense-template-mplv2-any-osi.txt
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current PyZMQ BDFL
+
+This is a statement by {{ name of company / name of individual }}
+that grants permission to relicense its copyrights in the Python ZeroMQ bindings
+(pyzmq) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current PyZMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the GitHub handle "{{github username}}", with
+commit author "{{github commit author}}", are copyright of {{ name }} .
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+{{ Full Name }}
+{{ creation date of document (format: yyyy/mm/dd) }}

--- a/RELICENSE/templates/relicense-template-mplv2.txt
+++ b/RELICENSE/templates/relicense-template-mplv2.txt
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by {{ name of company / name of individual }}
+that grants permission to relicense its copyrights in the Python ZeroMQ bindings
+(pyzmq) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the GitHub handle "{{github username}}", with
+commit author "{{github commit author}}", are copyright of {{ name }}.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+{{ Full Name }}
+{{ creation date of document (format: yyyy/mm/dd) }}


### PR DESCRIPTION
Follow libzmq (https://github.com/zeromq/libzmq/issues/2376) in attempting to relicense away from LGPL.

Unlike libzmq itself, the preferred new license for pyzmq is [3-Clause BSD](https://opensource.org/licenses/BSD-3-Clause) because the majority of pyzmq is already BSD. Only the low-level Cython bindings are licensed under LGPL, so only those who have contributed to that part of pyzmq are required to submit grants.

I'll open an Issue tracking this shortly.