### PR TITLE
pass integer FD to asyncio

### DIFF
--- a/zmq/asyncio/__init__.py
+++ b/zmq/asyncio/__init__.py
@@ -50,14 +50,14 @@ class Socket(_AsyncIO, _future._AsyncSocket):
 
     def _init_io_state(self):
         """initialize the ioloop event handler"""
-        self.io_loop.add_reader(self._shadow_sock, lambda : self._handle_events(0, 0))
+        self.io_loop.add_reader(self._shadow_sock.FD, lambda : self._handle_events(0, 0))
 
     def _clear_io_state(self):
         """clear any ioloop event handler
 
         called once at close
         """
-        self.io_loop.remove_reader(self._shadow_sock)
+        self.io_loop.remove_reader(self._shadow_sock.FD)
 
 Poller._socket_class = Socket
 


### PR DESCRIPTION
not all asyncio implementations correctly support objects with `.fileno()` methods (uvloop)

Passing the socket with its fileno method is *important* for tornado, which has things like `IOLoop.close(all_fds=True)`, which **must not** be called on the zmq FD without causing a C-level crash.

Fortunately, asyncio does not appear to have such a feature, which avoids the problem with passing the low-level FD without the wrapper.

closes #1047