### PR TITLE
fix RTLD flags on darwin + pypy when loading bundled libzmq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ cache:
 python:
   - 2.7
   - 3.6
-  - pypy
+  - pypy2.7-5.8.0
+  - pypy3.5-5.8.0
 env:
     - ZMQ=
     - ZMQ=bundled
@@ -61,9 +62,6 @@ matrix:
       env: ZMQ=zeromq3-x
     - python: 3.3
       env: ZMQ=
-    # FIXME: pypy3 is still on unsupported Python 3.2
-    # - python: pypy3
-    #   env: ZMQ=
     - python: nightly
       env: ZMQ=
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ install:
 
 matrix:
   include:
+    - python: pypy
+      env: ZMQ=bundled
     - python: 3.6-dev
       env: ZMQ=bundled
     - python: 3.6

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -2,6 +2,8 @@
 """
 invoke script for releasing pyzmq
 
+Must be run on macOS with Framework Python from Python.org
+
 usage:
 
     invoke release 14.3.1
@@ -34,6 +36,10 @@ pjoin = os.path.join
 
 repo = PYZMQ_ROOT
 
+# Workaround for PyPy3 5.8
+if 'LDFLAGS' not in os.environ:
+    os.environ['LDFLAGS'] = '-undefined dynamic_lookup'
+
 _framework_py = lambda xy: "/Library/Frameworks/Python.framework/Versions/{0}/bin/python{0}".format(xy)
 py_exes = {
     '2.7' : _framework_py('2.7'),
@@ -41,8 +47,7 @@ py_exes = {
     '3.5' : _framework_py('3.5'),
     '3.6' : _framework_py('3.6'),
     'pypy': "/usr/local/bin/pypy",
-    # FIXME: pypy3 can have releases when they support Python >= 3.3
-    # 'pypy3': "/usr/local/bin/pypy3",
+    'pypy3': "/usr/local/bin/pypy3",
 }
 egg_pys = {} # no more eggs!
 

--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -30,9 +30,10 @@ def _load_libzmq():
     else:
         # store libzmq as zmq._libzmq for backward-compat
         globals()['_libzmq'] = libzmq
-        if PYPY and sys.pypy_version_info < (5,):
-            # some versions of pypy (< 5?) needs explicit CDLL load for some reason,
+        if PYPY:
+            # some versions of pypy (5.3 < ? < 5.8) needs explicit CDLL load for some reason,
             # otherwise symbols won't be globally available
+            # do this unconditionally because it should be harmless (?)
             ctypes.CDLL(libzmq.__file__, ctypes.RTLD_GLOBAL)
     finally:
         if dlopen:

--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -16,8 +16,8 @@ def _load_libzmq():
         flags = ctypes.RTLD_GLOBAL | dlflags
         # ctypes.RTLD_LOCAL is 0 on pypy, which is *wrong*
         flags &= ~ getattr(os, 'RTLD_LOCAL', 4)
-        # # pypy needs RTLD_LAZY for some reason
-        if platform.python_implementation().lower() == 'pypy':
+        # pypy on darwin needs RTLD_LAZY for some reason
+        if sys.platform == 'darwin' and platform.python_implementation().lower() == 'pypy':
             flags |= getattr(os, 'RTLD_LAZY', 1)
             flags &= ~ getattr(os, 'RTLD_NOW', 2)
         sys.setdlopenflags(flags)

--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -9,7 +9,7 @@ def _load_libzmq():
     import sys, ctypes, platform, os
     dlopen = hasattr(sys, 'getdlopenflags') # unix-only
     # RTLD flags are added to os in Python 3
-    # get values from os because ctypes are WRONG on pypy
+    # get values from os because ctypes values are WRONG on pypy
     if dlopen:
         dlflags = sys.getdlopenflags()
         # set RTLD_GLOBAL, unset RTLD_LOCAL
@@ -28,6 +28,12 @@ def _load_libzmq():
     else:
         # store libzmq as zmq._libzmq for backward-compat
         globals()['_libzmq'] = libzmq
+        # some versions of pyzmq (< 5?) require loading via CDLL
+        if platform.python_implementation().lower() == 'pypy':
+            # some versions of pypy (< 5?) needs explicit CDLL load for some reason,
+            # otherwise symbols won't be globally available
+            # this is *probably* harmless where it's not needed
+            ctypes.CDLL(libzmq.__file__, ctypes.RTLD_GLOBAL)
     finally:
         if dlopen:
             sys.setdlopenflags(dlflags)


### PR DESCRIPTION
- set RTLD_LAZY on darwin + pypy
- ensure mutually exclusive flags are not set