### PR TITLE
Update appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,9 +42,6 @@ cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 
 install:
-  # Set the error action preference to so that output to stderr does not
-  # fail the build
-  - ps: $ErrorActionPreference = "SilentlyContinue"
   # If there is a newer build queued for the same PR, cancel this one.
   # The AppVeyor 'rollout builds' option is supposed to serve the same
   # purpose but it is problematic because it tends to cancel builds pushed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+shallow_clone: false
+skip_branch_with_pr: true
+clone_depth: 1
+
 # mostly copied from
 environment:
   global:
@@ -34,7 +38,13 @@ environment:
 matrix:
   fast_finish: true
 
+cache:
+  - C:\Users\appveyor\AppData\Local\pip\Cache
+
 install:
+  # Set the error action preference to so that output to stderr does not
+  # fail the build
+  - ps: $ErrorActionPreference = "SilentlyContinue"
   # If there is a newer build queued for the same PR, cancel this one.
   # The AppVeyor 'rollout builds' option is supposed to serve the same
   # purpose but it is problematic because it tends to cancel builds pushed
@@ -56,8 +66,10 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.
-  - "%CMD_IN_ENV% pip install --disable-pip-version-check --user --upgrade pip setuptools wheel cython -r test-requirements.txt"
+  # about it being out of date. Install wheel package separate so that
+  # we also cache wheels
+  - pip install --upgrade pip wheel
+  - pip install --upgrade setuptools cython -r test-requirements.txt
 
 build_script:
   # Build the compiled extension
@@ -67,12 +79,21 @@ build_script:
 
 test_script:
   # Run the project tests
-  - ps: cmd /c 'cd dist & python -c "import zmq; print(zmq.zmq_version())"'
-  - ps: cmd /c 'cd dist & python -m pytest -vsx --pyargs zmq.tests.test_socket'
+  - cd dist
+  - python -c "import zmq; print(zmq.zmq_version())"
+  # ``test_win32_shim`` will create a CTLR-C event which will be sent
+  # to all processes that share the same group id and creates problems
+  # with the appveyor build. To avoid the problems we single out that
+  # specific test run it using the ``start`` command and then check
+  # the junit report to pass or fail the build.
+  - pytest -vsx -m "not new_console" --pyargs zmq.tests
+  - start /W pytest -vsx -m "new_console" --pyargs zmq.tests --junit-xml=../results.xml
+  - python ../tools/check_junit_result.py ../results.xml
+  - cd ..
 
 after_test:
   # If tests are successful, create binary packages for the project.
-  - ps: "ls dist"
+  - ps: ls dist
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
@@ -80,4 +101,3 @@ artifacts:
 
 #on_success:
 #  - TODO: upload the content of dist/*.whl to a public wheelhouse
-#

--- a/tools/check_junit_result.py
+++ b/tools/check_junit_result.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+
+import os
+import argparse
+from xml.etree import cElementTree
+
+
+def main(filename):
+    tree = cElementTree.parse(filename)
+    root = tree.getroot()
+    attributes = root.attrib
+    errors = int(attributes.get('errors', '0'))
+    failures = int(attributes.get('failures', '0'))
+    tests = int(attributes.get('tests', '0'))
+    if tests == 0:
+        print('No tests run')
+        exit(1)
+    elif errors + failures > 0:
+        print('Test runs failed')
+        for testcase in root:
+            for item in testcase:
+                if item.tag == 'failure' or item.tag == 'error':
+                    print('=' * 50)
+                    print(item.text)
+                    print('=' * 50)
+        exit(1)
+    else:
+        print('All tests {} passed'.format(tests))
+        for testcase in root:
+            attributes = testcase.attrib
+            print("{name}{classname}".format(**attributes))
+        exit(0)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "filename",
+        help="The filename of the junit xml result file")
+    args = parser.parse_args()
+    main(args.filename)

--- a/zmq/tests/asyncio/_test_asyncio.py
+++ b/zmq/tests/asyncio/_test_asyncio.py
@@ -29,23 +29,23 @@ from zmq.tests.test_auth import TestThreadAuthentication
 class TestAsyncIOSocket(BaseZMQTestCase):
     if asyncio is not None:
         Context = zaio.Context
-    
+
     def setUp(self):
         if asyncio is None:
             raise SkipTest()
         self.loop = zaio.ZMQEventLoop()
         asyncio.set_event_loop(self.loop)
         super(TestAsyncIOSocket, self).setUp()
-    
+
     def tearDown(self):
         self.loop.close()
         super().tearDown()
-    
+
     def test_socket_class(self):
         s = self.context.socket(zmq.PUSH)
         assert isinstance(s, zaio.Socket)
         s.close()
-    
+
     def test_recv_multipart(self):
         @asyncio.coroutine
         def test():
@@ -298,7 +298,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
             recvd = b.recv_multipart()
             self.assertEqual(recvd, [b'hi', b'there'])
         self.loop.run_until_complete(test())
-    
+
     def test_aiohttp(self):
         try:
             import aiohttp
@@ -310,7 +310,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
         def echo(request):
             print(request.path)
             return web.Response(body=str(request).encode('utf8'))
-        
+
         @asyncio.coroutine
         def server(loop):
             app = web.Application(loop=loop)
@@ -324,7 +324,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
         @asyncio.coroutine
         def client():
             push, pull = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            
+
             res = yield from aiohttp.request('GET', 'http://127.0.0.1:8080/')
             text = yield from res.text()
             yield from push.send(text.encode('utf8'))
@@ -336,6 +336,9 @@ class TestAsyncIOSocket(BaseZMQTestCase):
         print("servered")
         loop.run_until_complete(client())
 
+    @pytest.mark.skipif(
+        sys.platform.startswith('win'),
+        reason='Windows does not support polling on files')
     def test_poll_raw(self):
         @asyncio.coroutine
         def test():
@@ -368,7 +371,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(test())
-    
+
     def test_shadow(self):
         @asyncio.coroutine
         def test():
@@ -434,4 +437,3 @@ class TestAsyncioAuthentication(TestThreadAuthentication):
                 raise TimeoutError("Should have received a message")
             return (yield from recv(**kwargs))
         return self.loop.run_until_complete(coro())
-

--- a/zmq/tests/asyncio/_test_asyncio.py
+++ b/zmq/tests/asyncio/_test_asyncio.py
@@ -29,23 +29,23 @@ from zmq.tests.test_auth import TestThreadAuthentication
 class TestAsyncIOSocket(BaseZMQTestCase):
     if asyncio is not None:
         Context = zaio.Context
-
+    
     def setUp(self):
         if asyncio is None:
             raise SkipTest()
         self.loop = zaio.ZMQEventLoop()
         asyncio.set_event_loop(self.loop)
         super(TestAsyncIOSocket, self).setUp()
-
+    
     def tearDown(self):
         self.loop.close()
         super().tearDown()
-
+    
     def test_socket_class(self):
         s = self.context.socket(zmq.PUSH)
         assert isinstance(s, zaio.Socket)
         s.close()
-
+    
     def test_recv_multipart(self):
         @asyncio.coroutine
         def test():
@@ -298,7 +298,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
             recvd = b.recv_multipart()
             self.assertEqual(recvd, [b'hi', b'there'])
         self.loop.run_until_complete(test())
-
+    
     def test_aiohttp(self):
         try:
             import aiohttp
@@ -310,7 +310,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
         def echo(request):
             print(request.path)
             return web.Response(body=str(request).encode('utf8'))
-
+        
         @asyncio.coroutine
         def server(loop):
             app = web.Application(loop=loop)
@@ -324,7 +324,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
         @asyncio.coroutine
         def client():
             push, pull = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-
+            
             res = yield from aiohttp.request('GET', 'http://127.0.0.1:8080/')
             text = yield from res.text()
             yield from push.send(text.encode('utf8'))
@@ -371,7 +371,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(test())
-
+    
     def test_shadow(self):
         @asyncio.coroutine
         def test():

--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -55,15 +55,15 @@ class TestContext(BaseZMQTestCase):
         c = self.Context()
         c.term()
         self.assert_(c.closed)
-
+    
     def test_context_manager(self):
         with self.Context() as c:
             pass
         self.assert_(c.closed)
-
+    
     def test_fail_init(self):
         self.assertRaisesErrno(zmq.EINVAL, self.Context, -1)
-
+    
     def test_term_hang(self):
         rep,req = self.create_bound_pair(zmq.ROUTER, zmq.DEALER)
         req.setsockopt(zmq.LINGER, 0)
@@ -71,7 +71,7 @@ class TestContext(BaseZMQTestCase):
         req.close()
         rep.close()
         self.context.term()
-
+    
     def test_instance(self):
         ctx = self.Context.instance()
         c2 = self.Context.instance(io_threads=2)
@@ -127,7 +127,7 @@ class TestContext(BaseZMQTestCase):
             # give the reaper a chance
             time.sleep(1e-2)
         ctx.term()
-
+    
     def test_sockopts(self):
         """setting socket options with ctx attributes"""
         ctx = self.Context()
@@ -141,7 +141,7 @@ class TestContext(BaseZMQTestCase):
         ctx.subscribe = b''
         s = ctx.socket(zmq.REQ)
         s.close()
-
+        
         ctx.term()
 
     @mark.skipif(
@@ -151,16 +151,16 @@ class TestContext(BaseZMQTestCase):
         """Context.destroy should close sockets"""
         ctx = self.Context()
         sockets = [ ctx.socket(zmq.REP) for i in range(65) ]
-
+        
         # close half of the sockets
         [ s.close() for s in sockets[::2] ]
-
+        
         ctx.destroy()
         # reaper is not instantaneous
         time.sleep(1e-2)
         for s in sockets:
             self.assertTrue(s.closed)
-
+        
     def test_destroy_linger(self):
         """Context.destroy should set linger on closing sockets"""
         req,rep = self.create_bound_pair(zmq.REQ, zmq.REP)
@@ -171,7 +171,7 @@ class TestContext(BaseZMQTestCase):
         time.sleep(1e-2)
         for s in (req,rep):
             self.assertTrue(s.closed)
-
+        
     def test_term_noclose(self):
         """Context.term won't close sockets"""
         ctx = self.Context()
@@ -184,12 +184,12 @@ class TestContext(BaseZMQTestCase):
         s.close()
         t.join(timeout=0.1)
         self.assertFalse(t.is_alive(), "Context should have closed")
-
+    
     def test_gc(self):
         """test close&term by garbage collection alone"""
         if PYPY:
             raise SkipTest("GC doesn't work ")
-
+            
         # test credit @dln (GH #137):
         def gcf():
             def inner():
@@ -201,27 +201,27 @@ class TestContext(BaseZMQTestCase):
         t.start()
         t.join(timeout=1)
         self.assertFalse(t.is_alive(), "Garbage collection should have cleaned up context")
-
+    
     def test_cyclic_destroy(self):
         """ctx.destroy should succeed when cyclic ref prevents gc"""
         # test credit @dln (GH #137):
         class CyclicReference(object):
             def __init__(self, parent=None):
                 self.parent = parent
-
+            
             def crash(self, sock):
                 self.sock = sock
                 self.child = CyclicReference(self)
-
+        
         def crash_zmq():
             ctx = self.Context()
             sock = ctx.socket(zmq.PULL)
             c = CyclicReference()
             c.crash(sock)
             ctx.destroy()
-
+        
         crash_zmq()
-
+    
     def test_term_thread(self):
         """ctx.term should not crash active threads (#139)"""
         ctx = self.Context()
@@ -242,14 +242,14 @@ class TestContext(BaseZMQTestCase):
             self.fail("recv should have been interrupted with ETERM")
         t = Thread(target=block)
         t.start()
-
+        
         evt.wait(1)
         self.assertTrue(evt.is_set(), "sync event never fired")
         time.sleep(0.01)
         ctx.term()
         t.join(timeout=1)
         self.assertFalse(t.is_alive(), "term should have interrupted s.recv()")
-
+    
     def test_destroy_no_sockets(self):
         ctx = self.Context()
         s = ctx.socket(zmq.PUB)
@@ -258,7 +258,7 @@ class TestContext(BaseZMQTestCase):
         ctx.destroy()
         assert s.closed
         assert ctx.closed
-
+    
     def test_ctx_opts(self):
         if zmq.zmq_version_info() < (3,):
             raise SkipTest("context options require libzmq 3")
@@ -268,7 +268,7 @@ class TestContext(BaseZMQTestCase):
         ctx.max_sockets = 100
         self.assertEqual(ctx.max_sockets, 100)
         self.assertEqual(ctx.get(zmq.MAX_SOCKETS), 100)
-
+    
     def test_copy(self):
         c1 = self.Context()
         c2 = copy.copy(c1)
@@ -282,7 +282,7 @@ class TestContext(BaseZMQTestCase):
         s = c3.socket(zmq.PUB)
         s.close()
         c1.term()
-
+    
     def test_shadow(self):
         ctx = self.Context()
         ctx2 = self.Context.shadow(ctx.underlying)
@@ -299,13 +299,13 @@ class TestContext(BaseZMQTestCase):
         ctx.term()
         self.assertRaisesErrno(zmq.EFAULT, ctx2.socket, zmq.PUB)
         del ctx2
-
+    
     def test_shadow_pyczmq(self):
         try:
             from pyczmq import zctx, zsocket, zstr
         except Exception:
             raise SkipTest("Requires pyczmq")
-
+        
         ctx = zctx.new()
         a = zsocket.new(ctx, zmq.PUSH)
         zsocket.bind(a, "inproc://a")

--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     from Queue import Queue
 
+from pytest import mark
+
 import zmq
 from zmq.tests import (
     BaseZMQTestCase, have_gevent, GreenTest, skip_green, PYPY, SkipTest,
@@ -53,15 +55,15 @@ class TestContext(BaseZMQTestCase):
         c = self.Context()
         c.term()
         self.assert_(c.closed)
-    
+
     def test_context_manager(self):
         with self.Context() as c:
             pass
         self.assert_(c.closed)
-    
+
     def test_fail_init(self):
         self.assertRaisesErrno(zmq.EINVAL, self.Context, -1)
-    
+
     def test_term_hang(self):
         rep,req = self.create_bound_pair(zmq.ROUTER, zmq.DEALER)
         req.setsockopt(zmq.LINGER, 0)
@@ -69,7 +71,7 @@ class TestContext(BaseZMQTestCase):
         req.close()
         rep.close()
         self.context.term()
-    
+
     def test_instance(self):
         ctx = self.Context.instance()
         c2 = self.Context.instance(io_threads=2)
@@ -125,7 +127,7 @@ class TestContext(BaseZMQTestCase):
             # give the reaper a chance
             time.sleep(1e-2)
         ctx.term()
-    
+
     def test_sockopts(self):
         """setting socket options with ctx attributes"""
         ctx = self.Context()
@@ -139,24 +141,26 @@ class TestContext(BaseZMQTestCase):
         ctx.subscribe = b''
         s = ctx.socket(zmq.REQ)
         s.close()
-        
+
         ctx.term()
 
-    
+    @mark.skipif(
+        sys.platform.startswith('win'),
+        reason='Segfaults on Windows')
     def test_destroy(self):
         """Context.destroy should close sockets"""
         ctx = self.Context()
         sockets = [ ctx.socket(zmq.REP) for i in range(65) ]
-        
+
         # close half of the sockets
         [ s.close() for s in sockets[::2] ]
-        
+
         ctx.destroy()
         # reaper is not instantaneous
         time.sleep(1e-2)
         for s in sockets:
             self.assertTrue(s.closed)
-        
+
     def test_destroy_linger(self):
         """Context.destroy should set linger on closing sockets"""
         req,rep = self.create_bound_pair(zmq.REQ, zmq.REP)
@@ -167,7 +171,7 @@ class TestContext(BaseZMQTestCase):
         time.sleep(1e-2)
         for s in (req,rep):
             self.assertTrue(s.closed)
-        
+
     def test_term_noclose(self):
         """Context.term won't close sockets"""
         ctx = self.Context()
@@ -180,12 +184,12 @@ class TestContext(BaseZMQTestCase):
         s.close()
         t.join(timeout=0.1)
         self.assertFalse(t.is_alive(), "Context should have closed")
-    
+
     def test_gc(self):
         """test close&term by garbage collection alone"""
         if PYPY:
             raise SkipTest("GC doesn't work ")
-            
+
         # test credit @dln (GH #137):
         def gcf():
             def inner():
@@ -197,27 +201,27 @@ class TestContext(BaseZMQTestCase):
         t.start()
         t.join(timeout=1)
         self.assertFalse(t.is_alive(), "Garbage collection should have cleaned up context")
-    
+
     def test_cyclic_destroy(self):
         """ctx.destroy should succeed when cyclic ref prevents gc"""
         # test credit @dln (GH #137):
         class CyclicReference(object):
             def __init__(self, parent=None):
                 self.parent = parent
-            
+
             def crash(self, sock):
                 self.sock = sock
                 self.child = CyclicReference(self)
-        
+
         def crash_zmq():
             ctx = self.Context()
             sock = ctx.socket(zmq.PULL)
             c = CyclicReference()
             c.crash(sock)
             ctx.destroy()
-        
+
         crash_zmq()
-    
+
     def test_term_thread(self):
         """ctx.term should not crash active threads (#139)"""
         ctx = self.Context()
@@ -238,14 +242,14 @@ class TestContext(BaseZMQTestCase):
             self.fail("recv should have been interrupted with ETERM")
         t = Thread(target=block)
         t.start()
-        
+
         evt.wait(1)
         self.assertTrue(evt.is_set(), "sync event never fired")
         time.sleep(0.01)
         ctx.term()
         t.join(timeout=1)
         self.assertFalse(t.is_alive(), "term should have interrupted s.recv()")
-    
+
     def test_destroy_no_sockets(self):
         ctx = self.Context()
         s = ctx.socket(zmq.PUB)
@@ -254,7 +258,7 @@ class TestContext(BaseZMQTestCase):
         ctx.destroy()
         assert s.closed
         assert ctx.closed
-    
+
     def test_ctx_opts(self):
         if zmq.zmq_version_info() < (3,):
             raise SkipTest("context options require libzmq 3")
@@ -264,7 +268,7 @@ class TestContext(BaseZMQTestCase):
         ctx.max_sockets = 100
         self.assertEqual(ctx.max_sockets, 100)
         self.assertEqual(ctx.get(zmq.MAX_SOCKETS), 100)
-    
+
     def test_copy(self):
         c1 = self.Context()
         c2 = copy.copy(c1)
@@ -278,7 +282,7 @@ class TestContext(BaseZMQTestCase):
         s = c3.socket(zmq.PUB)
         s.close()
         c1.term()
-    
+
     def test_shadow(self):
         ctx = self.Context()
         ctx2 = self.Context.shadow(ctx.underlying)
@@ -295,13 +299,13 @@ class TestContext(BaseZMQTestCase):
         ctx.term()
         self.assertRaisesErrno(zmq.EFAULT, ctx2.socket, zmq.PUB)
         del ctx2
-    
+
     def test_shadow_pyczmq(self):
         try:
             from pyczmq import zctx, zsocket, zstr
         except Exception:
             raise SkipTest("Requires pyczmq")
-        
+
         ctx = zctx.new()
         a = zsocket.new(ctx, zmq.PUSH)
         zsocket.bind(a, "inproc://a")

--- a/zmq/tests/test_future.py
+++ b/zmq/tests/test_future.py
@@ -19,12 +19,12 @@ from zmq.tests import BaseZMQTestCase
 
 class TestFutureSocket(BaseZMQTestCase):
     Context = future.Context
-
+    
     def setUp(self):
         self.loop = IOLoop()
         self.loop.make_current()
         super(TestFutureSocket, self).setUp()
-
+    
     def tearDown(self):
         super(TestFutureSocket, self).tearDown()
         if self.loop:
@@ -105,7 +105,7 @@ class TestFutureSocket(BaseZMQTestCase):
             with pytest.raises(zmq.Again):
                 yield s.send(b'not going anywhere')
         self.loop.run_sync(test)
-
+    
     @pytest.mark.now
     def test_send_noblock(self):
         @gen.coroutine

--- a/zmq/tests/test_monqueue.py
+++ b/zmq/tests/test_monqueue.py
@@ -18,21 +18,21 @@ if PYPY or zmq.zmq_version_info() >= (4,1):
 
 
 class TestMonitoredQueue(BaseZMQTestCase):
-
+    
     sockets = []
-
+    
     def build_device(self, mon_sub=b"", in_prefix=b'in', out_prefix=b'out'):
         self.device = devices.ThreadMonitoredQueue(zmq.PAIR, zmq.PAIR, zmq.PUB,
                                             in_prefix, out_prefix)
         alice = self.context.socket(zmq.PAIR)
         bob = self.context.socket(zmq.PAIR)
         mon = self.context.socket(zmq.SUB)
-
+        
         aport = alice.bind_to_random_port('tcp://127.0.0.1')
         bport = bob.bind_to_random_port('tcp://127.0.0.1')
         mport = mon.bind_to_random_port('tcp://127.0.0.1')
         mon.setsockopt(zmq.SUBSCRIBE, mon_sub)
-
+        
         self.device.connect_in("tcp://127.0.0.1:%i"%aport)
         self.device.connect_out("tcp://127.0.0.1:%i"%bport)
         self.device.connect_mon("tcp://127.0.0.1:%i"%mport)
@@ -46,14 +46,13 @@ class TestMonitoredQueue(BaseZMQTestCase):
             pass
         self.sockets.extend([alice, bob, mon])
         return alice, bob, mon
-
-
+            
     def teardown_device(self):
         for socket in self.sockets:
             socket.close()
             del socket
         del self.device
-
+        
     def test_reply(self):
         alice, bob, mon = self.build_device()
         alices = b"hello bob".split()
@@ -65,7 +64,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         alices = self.recv_multipart(alice)
         self.assertEqual(alices, bobs)
         self.teardown_device()
-
+    
     def test_queue(self):
         alice, bob, mon = self.build_device()
         alices = b"hello bob".split()
@@ -85,7 +84,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         alices = self.recv_multipart(alice)
         self.assertEqual(alices, bobs)
         self.teardown_device()
-
+    
     def test_monitor(self):
         alice, bob, mon = self.build_device()
         alices = b"hello bob".split()
@@ -113,7 +112,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         mons = self.recv_multipart(mon)
         self.assertEqual([b'out']+bobs, mons)
         self.teardown_device()
-
+    
     def test_prefix(self):
         alice, bob, mon = self.build_device(b"", b'foo', b'bar')
         alices = b"hello bob".split()
@@ -141,7 +140,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         mons = self.recv_multipart(mon)
         self.assertEqual([b'bar']+bobs, mons)
         self.teardown_device()
-
+    
     def test_monitor_subscribe(self):
         alice, bob, mon = self.build_device(b"out")
         alices = b"hello bob".split()
@@ -163,7 +162,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         mons = self.recv_multipart(mon)
         self.assertEqual([b'out']+bobs, mons)
         self.teardown_device()
-
+    
     def test_router_router(self):
         """test router-router MQ devices"""
         dev = devices.ThreadMonitoredQueue(zmq.ROUTER, zmq.ROUTER, zmq.PUB, b'in', b'out')
@@ -171,7 +170,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         dev.setsockopt_in(zmq.LINGER, 0)
         dev.setsockopt_out(zmq.LINGER, 0)
         dev.setsockopt_mon(zmq.LINGER, 0)
-
+        
         binder = self.context.socket(zmq.DEALER)
         porta = binder.bind_to_random_port('tcp://127.0.0.1')
         portb = binder.bind_to_random_port('tcp://127.0.0.1')
@@ -182,7 +181,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         b = self.context.socket(zmq.DEALER)
         b.identity = b'b'
         self.sockets.extend([a, b])
-
+        
         a.connect('tcp://127.0.0.1:%i'%porta)
         dev.bind_in('tcp://127.0.0.1:%i'%porta)
         b.connect('tcp://127.0.0.1:%i'%portb)
@@ -206,7 +205,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         amsg = self.recv_multipart(a)
         self.assertEqual(amsg, [b'b']+msg)
         self.teardown_device()
-
+    
     def test_default_mq_args(self):
         self.device = dev = devices.ThreadMonitoredQueue(zmq.ROUTER, zmq.DEALER, zmq.PUB)
         dev.setsockopt_in(zmq.LINGER, 0)
@@ -215,13 +214,13 @@ class TestMonitoredQueue(BaseZMQTestCase):
         # this will raise if default args are wrong
         dev.start()
         self.teardown_device()
-
+    
     def test_mq_check_prefix(self):
         ins = self.context.socket(zmq.ROUTER)
         outs = self.context.socket(zmq.DEALER)
         mons = self.context.socket(zmq.PUB)
         self.sockets.extend([ins, outs, mons])
-
+        
         ins = unicode('in')
         outs = unicode('out')
         self.assertRaises(TypeError, devices.monitoredqueue, ins, outs, mons)

--- a/zmq/tests/test_retry_eintr.py
+++ b/zmq/tests/test_retry_eintr.py
@@ -28,7 +28,7 @@ class TestEINTRSysCall(BaseZMQTestCase):
 
     def alarm(self, t=None):
         """start a timer to fire only once
-
+        
         like signal.alarm, but with better resolution than integer seconds.
         """
         if not hasattr(signal, 'setitimer'):
@@ -39,12 +39,12 @@ class TestEINTRSysCall(BaseZMQTestCase):
         self.orig_handler = signal.signal(signal.SIGALRM, self.stop_timer)
         # signal_period ignored, since only one timer event is allowed to fire
         signal.setitimer(signal.ITIMER_REAL, t, 1000)
-
+    
     def stop_timer(self, *args):
         self.timer_fired = True
         signal.setitimer(signal.ITIMER_REAL, 0, 0)
         signal.signal(signal.SIGALRM, self.orig_handler)
-
+    
     @mark.skipif(not hasattr(zmq, 'RCVTIMEO'), reason="requires RCVTIMEO")
     def test_retry_recv(self):
         pull = self.socket(zmq.PULL)
@@ -60,7 +60,7 @@ class TestEINTRSysCall(BaseZMQTestCase):
         self.alarm()
         self.assertRaises(zmq.Again, push.send, b('buf'))
         assert self.timer_fired
-
+    
     def test_retry_poll(self):
         x, y = self.create_bound_pair()
         poller = zmq.Poller()
@@ -76,7 +76,7 @@ class TestEINTRSysCall(BaseZMQTestCase):
         assert x in evts
         assert self.timer_fired
         x.recv()
-
+    
     def test_retry_term(self):
         push = self.socket(zmq.PUSH)
         push.linger = self.timeout_ms
@@ -87,9 +87,9 @@ class TestEINTRSysCall(BaseZMQTestCase):
         self.context.destroy()
         assert self.timer_fired
         assert self.context.closed
-
+    
     def test_retry_getsockopt(self):
         raise SkipTest("TODO: find a way to interrupt getsockopt")
-
+    
     def test_retry_setsockopt(self):
         raise SkipTest("TODO: find a way to interrupt setsockopt")

--- a/zmq/tests/test_security.py
+++ b/zmq/tests/test_security.py
@@ -18,7 +18,7 @@ USER = b"admin"
 PASS = b"password"
 
 class TestSecurity(BaseZMQTestCase):
-    
+
     def setUp(self):
         if zmq.zmq_version_info() < (4,0):
             raise SkipTest("security is new in libzmq 4.0")
@@ -27,8 +27,8 @@ class TestSecurity(BaseZMQTestCase):
         except zmq.ZMQError:
             raise SkipTest("security requires libzmq to be built with CURVE support")
         super(TestSecurity, self).setUp()
-    
-    
+
+
     def zap_handler(self):
         socket = self.context.socket(zmq.REP)
         socket.bind("inproc://zeromq.zap.01")
@@ -63,11 +63,11 @@ class TestSecurity(BaseZMQTestCase):
             socket.send_multipart(reply)
         finally:
             socket.close()
-    
+
     def start_zap(self):
         self.zap_thread = Thread(target=self.zap_handler)
         self.zap_thread.start()
-    
+
     def stop_zap(self):
         self.zap_thread.join()
 
@@ -90,7 +90,7 @@ class TestSecurity(BaseZMQTestCase):
         server.send_multipart(recvd)
         msg2 = self.recv_multipart(client)
         self.assertEqual(msg2, msg)
-    
+
     def test_null(self):
         """test NULL (default) security"""
         server = self.socket(zmq.DEALER)
@@ -120,12 +120,12 @@ class TestSecurity(BaseZMQTestCase):
         server.plain_server = True
         self.assertEqual(server.mechanism, zmq.PLAIN)
         self.assertEqual(client.mechanism, zmq.PLAIN)
-        
+
         assert not client.plain_server
         assert server.plain_server
-        
+
         self.start_zap()
-        
+
         iface = 'tcp://127.0.0.1'
         port = server.bind_to_random_port(iface)
         client.connect("%s:%i" % (iface, port))
@@ -143,9 +143,9 @@ class TestSecurity(BaseZMQTestCase):
         server.plain_server = True
         self.assertEqual(server.mechanism, zmq.PLAIN)
         self.assertEqual(client.mechanism, zmq.PLAIN)
-        
+
         self.start_zap()
-        
+
         iface = 'tcp://127.0.0.1'
         port = server.bind_to_random_port(iface)
         client.connect("%s:%i" % (iface, port))
@@ -153,27 +153,27 @@ class TestSecurity(BaseZMQTestCase):
         server.rcvtimeo = 250
         self.assertRaisesErrno(zmq.EAGAIN, server.recv)
         self.stop_zap()
-    
+
     def test_keypair(self):
         """test curve_keypair"""
         try:
             public, secret = zmq.curve_keypair()
         except zmq.ZMQError:
             raise SkipTest("CURVE unsupported")
-        
+
         self.assertEqual(type(secret), bytes)
         self.assertEqual(type(public), bytes)
         self.assertEqual(len(secret), 40)
         self.assertEqual(len(public), 40)
-        
+
         # verify that it is indeed Z85
         bsecret, bpublic = [ z85.decode(key) for key in (public, secret) ]
         self.assertEqual(type(bsecret), bytes)
         self.assertEqual(type(bpublic), bytes)
         self.assertEqual(len(bsecret), 32)
         self.assertEqual(len(bpublic), 32)
-        
-    
+
+
     def test_curve(self):
         """test CURVE encryption"""
         server = self.socket(zmq.DEALER)
@@ -186,27 +186,27 @@ class TestSecurity(BaseZMQTestCase):
             # will raise EINVAL if no CURVE support
             if e.errno == zmq.EINVAL:
                 raise SkipTest("CURVE unsupported")
-        
+
         server_public, server_secret = zmq.curve_keypair()
         client_public, client_secret = zmq.curve_keypair()
-        
+
         server.curve_secretkey = server_secret
         server.curve_publickey = server_public
         client.curve_serverkey = server_public
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
-        
+
         self.assertEqual(server.mechanism, zmq.CURVE)
         self.assertEqual(client.mechanism, zmq.CURVE)
-        
+
         self.assertEqual(server.get(zmq.CURVE_SERVER), True)
         self.assertEqual(client.get(zmq.CURVE_SERVER), False)
-        
+
         self.start_zap()
-        
-        iface = 'tcp://127.0.0.1'
-        port = server.bind_to_random_port(iface)
-        client.connect("%s:%i" % (iface, port))
-        self.bounce(server, client)
-        self.stop_zap()
-        
+        try:
+            iface = 'tcp://127.0.0.1'
+            port = server.bind_to_random_port(iface)
+            client.connect("%s:%i" % (iface, port))
+            self.bounce(server, client)
+        finally:
+            self.stop_zap()

--- a/zmq/tests/test_security.py
+++ b/zmq/tests/test_security.py
@@ -20,7 +20,7 @@ USER = b"admin"
 PASS = b"password"
 
 class TestSecurity(BaseZMQTestCase):
-
+    
     def setUp(self):
         if zmq.zmq_version_info() < (4,0):
             raise SkipTest("security is new in libzmq 4.0")
@@ -29,8 +29,7 @@ class TestSecurity(BaseZMQTestCase):
         except zmq.ZMQError:
             raise SkipTest("security requires libzmq to be built with CURVE support")
         super(TestSecurity, self).setUp()
-
-
+      
     def zap_handler(self):
         socket = self.context.socket(zmq.REP)
         socket.bind("inproc://zeromq.zap.01")
@@ -78,7 +77,7 @@ class TestSecurity(BaseZMQTestCase):
     def start_zap(self):
         self.zap_thread = Thread(target=self.zap_handler)
         self.zap_thread.start()
-
+    
     def stop_zap(self):
         self.zap_thread.join()
 
@@ -101,7 +100,7 @@ class TestSecurity(BaseZMQTestCase):
         server.send_multipart(recvd)
         msg2 = self.recv_multipart(client)
         self.assertEqual(msg2, msg)
-
+    
     def test_null(self):
         """test NULL (default) security"""
         server = self.socket(zmq.DEALER)
@@ -131,7 +130,7 @@ class TestSecurity(BaseZMQTestCase):
         server.plain_server = True
         self.assertEqual(server.mechanism, zmq.PLAIN)
         self.assertEqual(client.mechanism, zmq.PLAIN)
-
+        
         assert not client.plain_server
         assert server.plain_server
 
@@ -167,20 +166,19 @@ class TestSecurity(BaseZMQTestCase):
             public, secret = zmq.curve_keypair()
         except zmq.ZMQError:
             raise SkipTest("CURVE unsupported")
-
+        
         self.assertEqual(type(secret), bytes)
         self.assertEqual(type(public), bytes)
         self.assertEqual(len(secret), 40)
         self.assertEqual(len(public), 40)
-
+        
         # verify that it is indeed Z85
         bsecret, bpublic = [ z85.decode(key) for key in (public, secret) ]
         self.assertEqual(type(bsecret), bytes)
         self.assertEqual(type(bpublic), bytes)
         self.assertEqual(len(bsecret), 32)
         self.assertEqual(len(bpublic), 32)
-
-
+         
     def test_curve(self):
         """test CURVE encryption"""
         server = self.socket(zmq.DEALER)
@@ -193,19 +191,19 @@ class TestSecurity(BaseZMQTestCase):
             # will raise EINVAL if no CURVE support
             if e.errno == zmq.EINVAL:
                 raise SkipTest("CURVE unsupported")
-
+        
         server_public, server_secret = zmq.curve_keypair()
         client_public, client_secret = zmq.curve_keypair()
-
+        
         server.curve_secretkey = server_secret
         server.curve_publickey = server_public
         client.curve_serverkey = server_public
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
-
+        
         self.assertEqual(server.mechanism, zmq.CURVE)
         self.assertEqual(client.mechanism, zmq.CURVE)
-
+        
         self.assertEqual(server.get(zmq.CURVE_SERVER), True)
         self.assertEqual(client.get(zmq.CURVE_SERVER), False)
 

--- a/zmq/tests/test_win32_shim.py
+++ b/zmq/tests/test_win32_shim.py
@@ -1,8 +1,12 @@
 from __future__ import print_function
 
 import os
-
+import time
+import sys
 from functools import wraps
+
+from pytest import mark
+
 from zmq.tests import BaseZMQTestCase
 from zmq.utils.win32 import allow_interrupt
 
@@ -18,39 +22,42 @@ def count_calls(f):
     return _
 
 
+@mark.new_console
 class TestWindowsConsoleControlHandler(BaseZMQTestCase):
 
+    @mark.new_console
+    @mark.skipif(
+        not sys.platform.startswith('win'),
+        reason='Windows only test')
     def test_handler(self):
         @count_calls
         def interrupt_polling():
             print('Caught CTRL-C!')
 
-        if os.name == 'nt':
-            from ctypes import windll
-            from ctypes.wintypes import BOOL, DWORD
+        from ctypes import windll
+        from ctypes.wintypes import BOOL, DWORD
 
-            kernel32 = windll.LoadLibrary('kernel32')
+        kernel32 = windll.LoadLibrary('kernel32')
 
-            # <http://msdn.microsoft.com/en-us/library/ms683155.aspx>
-            GenerateConsoleCtrlEvent = kernel32.GenerateConsoleCtrlEvent
-            GenerateConsoleCtrlEvent.argtypes = (DWORD, DWORD)
-            GenerateConsoleCtrlEvent.restype = BOOL
+        # <http://msdn.microsoft.com/en-us/library/ms683155.aspx>
+        GenerateConsoleCtrlEvent = kernel32.GenerateConsoleCtrlEvent
+        GenerateConsoleCtrlEvent.argtypes = (DWORD, DWORD)
+        GenerateConsoleCtrlEvent.restype = BOOL
 
-            try:
-                # Simulate CTRL-C event while handler is active.
-                with allow_interrupt(interrupt_polling):
-                    result = GenerateConsoleCtrlEvent(0, 0)
-                    if result == 0:
-                        raise WindowsError
-            except KeyboardInterrupt:
-                pass
+        # Simulate CTRL-C event while handler is active.
+        try:
+            with allow_interrupt(interrupt_polling) as context:
+                result = GenerateConsoleCtrlEvent(0, 0)
+                # Sleep so that we give time to the handler to
+                # capture the Ctrl-C event.
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            pass
+        else:
+            if result == 0:
+                raise WindowsError()
             else:
                 self.fail('Expecting `KeyboardInterrupt` exception!')
 
-            # Make sure our handler was called.
-            self.assertEqual(interrupt_polling.__calls__, 1)
-        else:
-            # On non-Windows systems, this utility is just a no-op!
-            with allow_interrupt(interrupt_polling):
-                pass
-            self.assertEqual(interrupt_polling.__calls__, 0)
+        # Make sure our handler was called.
+        self.assertEqual(interrupt_polling.__calls__, 1)


### PR DESCRIPTION
This PR updates the current appveyor test setup to run all the tests on Windows

in more details:

- Skip tests which are not supported on windows (e.g. using file handles for sockets).
- Skip `TestContext.test_destroy` because it segfaults
- Fix Skip behavior in `TestEINTRSysCall`.  `Pytest` cannot detect items marked as skip if they are not test methods.
- Add/increase timeouts or time.sleep() where necessary to consider slow VM builds.
- Run the `test_win32_shim` test on a separate/new console to avoid issues with the CTRL-C event been sent to all the processes which share the console and abort the appveyor build prematurely.
- Cache wheels (minor build speedups)

The builds are still a little flaky and will need to be rerun from time to time. 
This PR should address #973 