### PR TITLE
support draft sockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,13 @@ before_install:
       unzip libzmq.zip
       pushd "$ZMQ-master"
       ./autogen.sh
-      ./configure
+      ./configure --enable-draft
       make -j
       sudo make install
       sudo ldconfig
       popd
       export ZMQ=/usr/local
+      export ZMQ_BUILD_DRAFT=1
     fi
   - pip install -r test-requirements.txt
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
       sudo ldconfig
       popd
       export ZMQ=/usr/local
-      export ZMQ_BUILD_DRAFT=1
+      export ZMQ_DRAFT_API=1
     fi
   - pip install -r test-requirements.txt
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
       unzip libzmq.zip
       pushd "$ZMQ-master"
       ./autogen.sh
-      ./configure --enable-draft
+      ./configure --enable-drafts
       make -j
       sudo make install
       sudo ldconfig

--- a/buildutils/config.py
+++ b/buildutils/config.py
@@ -60,10 +60,14 @@ def get_env_args():
 
     settings = {}
 
-    zmq = os.environ.get("ZMQ_PREFIX", None)
-    if zmq is not None:
+    zmq = os.environ.get("ZMQ_PREFIX")
+    if zmq:
         debug("Found environ var ZMQ_PREFIX=%s" % zmq)
         settings['zmq_prefix'] = zmq
+    draft_api = os.environ.get("ZMQ_DRAFT_API")
+    if draft_api:
+        debug("Found environ var ZMQ_DRAFT_API=%s" % draft_api)
+        settings['zmq_draft_api'] = int(draft_api)
 
     return settings
 
@@ -141,6 +145,7 @@ def discover_settings(conf_base=None):
     """ Discover custom settings for ZMQ path"""
     settings = {
         'zmq_prefix': '',
+        'zmq_draft_api': False,
         'libzmq_extension': False,
         'no_libzmq_extension': False,
         'skip_check_zmq': False,

--- a/setup.py
+++ b/setup.py
@@ -342,14 +342,16 @@ class Configure(build_ext):
                 cfg['have_sys_un_h'] = False
             else:
                 cfg['have_sys_un_h'] = True
-        
+
             self.save_config('config', cfg)
-    
+
         if cfg['have_sys_un_h']:
             settings['define_macros'] = [('HAVE_SYS_UN_H', 1)]
-    
+
         settings.setdefault('define_macros', [])
-    
+        if cfg.get('zmq_draft_api'):
+            settings['define_macros'].append(('ZMQ_BUILD_DRAFT_API', 1))
+
         # include internal directories
         settings.setdefault('include_dirs', [])
         settings['include_dirs'] += [pjoin('zmq', sub) for sub in (

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ for idx, arg in enumerate(list(sys.argv)):
     if arg.startswith('--libzmq='):
         sys.argv.remove(arg)
         libzmq_name = arg.split("=",1)[1]
-    if arg == '--enable-draft':
+    if arg == '--enable-drafts':
         sys.argv.remove(arg)
         os.environ['ZMQ_DRAFT_API'] = '1'
 

--- a/setup.py
+++ b/setup.py
@@ -107,9 +107,11 @@ for idx, arg in enumerate(list(sys.argv)):
 
 for idx, arg in enumerate(list(sys.argv)):
     if arg.startswith('--libzmq='):
-        sys.argv.pop(idx)
+        sys.argv.remove(arg)
         libzmq_name = arg.split("=",1)[1]
-        break
+    if arg == '--enable-draft':
+        sys.argv.remove(arg)
+        os.environ['ZMQ_DRAFT_API'] = '1'
 
 #-----------------------------------------------------------------------------
 # Configuration (adapted from h5py: http://h5py.googlecode.com)

--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -172,25 +172,23 @@ class _AsyncSocket(_zmq.Socket):
             dict(flags=flags, copy=copy, track=track)
         )
     
-    def send_multipart(self, msg, flags=0, copy=True, track=False):
+    def send_multipart(self, msg, flags=0, copy=True, track=False, **kwargs):
         """Send a complete multipart zmq message.
         
         Returns a Future that resolves when sending is complete.
         """
-        return self._add_send_event('send_multipart', msg=msg,
-            kwargs=dict(flags=flags, copy=copy, track=track),
-        )
+        kwargs.update(dict(flags=flags, copy=copy, track=track))
+        return self._add_send_event('send_multipart', msg=msg, kwargs=kwargs)
     
-    def send(self, msg, flags=0, copy=True, track=False):
+    def send(self, msg, flags=0, copy=True, track=False, **kwargs):
         """Send a single zmq frame.
         
         Returns a Future that resolves when sending is complete.
         
         Recommend using send_multipart instead.
         """
-        return self._add_send_event('send', msg=msg,
-            kwargs=dict(flags=flags, copy=copy, track=track),
-        )
+        kwargs.update(dict(flags=flags, copy=copy, track=track))
+        return self._add_send_event('send', msg=msg, kwargs=kwargs)
 
     def _deserialize(self, recvd, load):
         """Deserialize with Futures"""

--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -31,8 +31,11 @@ cdef extern from *:
     ctypedef void* const_void_ptr "const void *"
     ctypedef char* const_char_ptr "const char *"
 
+# were it not for Windows,
+# we could cimport these from libc.stdint
 cdef extern from "zmq_compat.h":
     ctypedef signed long long int64_t "pyzmq_int64_t"
+    ctypedef unsigned int uint32_t "pyzmq_uint32_t"
 
 include "constant_enums.pxi"
 
@@ -103,3 +106,11 @@ cdef extern from "zmq.h" nogil:
 
     int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key)
 
+    # 4.2 draft
+    int zmq_join (void *s, const_char_ptr group)
+    int zmq_leave (void *s, const_char_ptr group)
+
+    int zmq_msg_set_routing_id(zmq_msg_t *msg, uint32_t routing_id);
+    uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
+    int zmq_msg_set_group(zmq_msg_t *msg, const_char_ptr group);
+    const_char_ptr zmq_msg_group(zmq_msg_t *msg);

--- a/zmq/backend/cython/message.pyx
+++ b/zmq/backend/cython/message.pyx
@@ -343,6 +343,20 @@ cdef class Frame:
         cdef int rc = zmq_msg_set(&self.zmq_msg, option, value)
         _check_rc(rc)
 
+    def _get_group(self):
+        cdef const_char_ptr buf
+        buf = zmq_msg_group(&self.zmq_msg)
+        if buf == NULL:
+            _check_rc(-1)
+        return buf.decode('utf8')
+
+    def _set_group(self, group):
+        if isinstance(group, unicode):
+            group = group.encode('utf8')
+        cdef const_char_ptr c_group = group
+        cdef int rc = zmq_msg_set_group(&self.zmq_msg, c_group)
+        _check_rc(rc)
+
     def get(self, option):
         """Frame.get(option)
 

--- a/zmq/backend/cython/message.pyx
+++ b/zmq/backend/cython/message.pyx
@@ -329,7 +329,7 @@ cdef class Frame:
             self._bytes = copy_zmq_msg_bytes(&self.zmq_msg)
         return self._bytes
     
-    def set(self, int option, int value):
+    def set(self, option, value):
         """Frame.set(option, value)
         
         Set a Frame option.
@@ -340,21 +340,24 @@ cdef class Frame:
         .. versionadded:: libzmq-3.2
         .. versionadded:: 13.0
         """
-        cdef int rc = zmq_msg_set(&self.zmq_msg, option, value)
-        _check_rc(rc)
-
-    def _get_group(self):
+        cdef int rc
+        cdef uint32_t routing_id
         cdef const_char_ptr buf
-        buf = zmq_msg_group(&self.zmq_msg)
-        if buf == NULL:
-            _check_rc(-1)
-        return buf.decode('utf8')
 
-    def _set_group(self, group):
-        if isinstance(group, unicode):
-            group = group.encode('utf8')
-        cdef const_char_ptr c_group = group
-        cdef int rc = zmq_msg_set_group(&self.zmq_msg, c_group)
+        if option == 'routing_id':
+            routing_id = value
+            rc = zmq_msg_set_routing_id(&self.zmq_msg, routing_id)
+            _check_rc(rc)
+            return
+        elif option == 'group':
+            if isinstance(value, unicode):
+                value = value.encode('utf8')
+            buf = value
+            rc = zmq_msg_set_group(&self.zmq_msg, buf)
+            _check_rc(rc)
+            return
+
+        rc = zmq_msg_set(&self.zmq_msg, option, value)
         _check_rc(rc)
 
     def get(self, option):
@@ -374,12 +377,25 @@ cdef class Frame:
         cdef int rc = 0
         cdef char *property_c = NULL
         cdef Py_ssize_t property_len_c = 0
+        cdef uint32_t routing_id
+        cdef const_char_ptr buf
 
         # zmq_msg_get
         if isinstance(option, int):
             rc = zmq_msg_get(&self.zmq_msg, option)
             _check_rc(rc)
             return rc
+        
+        if option == 'routing_id':
+            routing_id = zmq_msg_routing_id(&self.zmq_msg)
+            if (routing_id == 0):
+                _check_rc(-1)
+            return routing_id
+        elif option == 'group':
+            buf = zmq_msg_group(&self.zmq_msg)
+            if buf == NULL:
+                _check_rc(-1)
+            return buf.decode('utf8')
 
         # zmq_msg_gets
         _check_version((4,1), "get string properties")

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -682,7 +682,7 @@ cdef class Socket:
     # Sending and receiving messages
     #-------------------------------------------------------------------------
 
-    cpdef object send(self, object data, int flags=0, copy=True, track=False):
+    cpdef send(self, object data, int flags=0, copy=True, track=False):
         """s.send(data, flags=0, copy=True, track=False)
 
         Send a message on this socket.
@@ -725,11 +725,7 @@ cdef class Socket:
         if isinstance(data, unicode):
             raise TypeError("unicode not allowed, use send_string")
 
-        if copy:
-            # msg.bytes never returns the input data object
-            # it is always a copy, but always the same copy
-            if isinstance(data, Frame):
-                data = data.buffer
+        if copy and not isinstance(data, Frame):
             return _send_copy(self.handle, data, flags)
         else:
             if isinstance(data, Frame):
@@ -746,7 +742,7 @@ cdef class Socket:
                 msg = Frame(data, track=track)
             return _send_frame(self.handle, msg, flags)
 
-    cpdef object recv(self, int flags=0, copy=True, track=False):
+    cpdef recv(self, int flags=0, copy=True, track=False):
         """s.recv(flags=0, copy=True, track=False)
 
         Receive a message.

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -39,6 +39,7 @@ from zmq.utils.buffers cimport asbuffer_r, viewfromobject_r
 from .libzmq cimport (
     fd_t,
     int64_t,
+    const_char_ptr,
 
     zmq_errno,
 
@@ -60,6 +61,8 @@ from .libzmq cimport (
     zmq_setsockopt,
     zmq_getsockopt,
     zmq_close,
+    zmq_join,
+    zmq_leave,
 
     ZMQ_EVENT_ALL,
     ZMQ_IDENTITY,
@@ -677,6 +680,41 @@ cdef class Socket:
         c_flags = events
         rc = zmq_socket_monitor(self.handle, c_addr, c_flags)
         _check_rc(rc)
+    
+    def join(self, group):
+        """Join a RADIO-DISH group
+
+        Only for DISH sockets.
+
+        libzmq and pyzmq must have been built with ZMQ_BUILD_DRAFT_API
+
+        .. versionadded:: 17
+        """
+        _check_version((4,2), "RADIO-DISH")
+        if not zmq.has('draft'):
+            raise RuntimeError("libzmq must be built with draft support")
+        if isinstance(group, unicode):
+            group = group.encode('utf8')
+        cdef const_char_ptr c_group = group
+        cdef int rc = zmq_join(self.handle, c_group)
+        _check_rc(rc)
+    
+    def leave(self, group):
+        """Leave a RADIO-DISH group
+
+        Only for DISH sockets.
+
+        libzmq and pyzmq must have been built with ZMQ_BUILD_DRAFT_API
+
+        .. versionadded:: 17
+        """
+        _check_version((4,2), "RADIO-DISH")
+        if not zmq.has('draft'):
+            raise RuntimeError("libzmq must be built with draft support")
+        cdef const_char_ptr c_group = group
+        cdef int rc = zmq_leave(self.handle, c_group)
+        _check_rc(rc)
+        
 
     #-------------------------------------------------------------------------
     # Sending and receiving messages

--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -247,17 +247,17 @@ class ZMQStream(object):
             self.on_send(lambda msg, status: callback(self, msg, status))
         
         
-    def send(self, msg, flags=0, copy=True, track=False, callback=None):
+    def send(self, msg, flags=0, copy=True, track=False, callback=None, **kwargs):
         """Send a message, optionally also register a new callback for sends.
         See zmq.socket.send for details.
         """
-        return self.send_multipart([msg], flags=flags, copy=copy, track=track, callback=callback)
+        return self.send_multipart([msg], flags=flags, copy=copy, track=track, callback=callback, **kwargs)
 
-    def send_multipart(self, msg, flags=0, copy=True, track=False, callback=None):
+    def send_multipart(self, msg, flags=0, copy=True, track=False, callback=None, **kwargs):
         """Send a multipart message, optionally also register a new callback for sends.
         See zmq.socket.send_multipart for details.
         """
-        kwargs = dict(flags=flags, copy=copy, track=track)
+        kwargs.update(dict(flags=flags, copy=copy, track=track))
         self._send_queue.put((msg, kwargs))
         callback = callback or self._send_callback
         if callback is not None:
@@ -267,17 +267,17 @@ class ZMQStream(object):
             self.on_send(lambda *args: None)
         self._add_io_state(zmq.POLLOUT)
     
-    def send_string(self, u, flags=0, encoding='utf-8', callback=None):
+    def send_string(self, u, flags=0, encoding='utf-8', callback=None, **kwargs):
         """Send a unicode message with an encoding.
         See zmq.socket.send_unicode for details.
         """
         if not isinstance(u, basestring):
             raise TypeError("unicode/str objects only")
-        return self.send(u.encode(encoding), flags=flags, callback=callback)
+        return self.send(u.encode(encoding), flags=flags, callback=callback, **kwargs)
     
     send_unicode = send_string
     
-    def send_json(self, obj, flags=0, callback=None):
+    def send_json(self, obj, flags=0, callback=None, **kwargs):
         """Send json-serialized version of an object.
         See zmq.socket.send_json for details.
         """
@@ -285,15 +285,15 @@ class ZMQStream(object):
             raise ImportError('jsonlib{1,2}, json or simplejson library is required.')
         else:
             msg = jsonapi.dumps(obj)
-            return self.send(msg, flags=flags, callback=callback)
+            return self.send(msg, flags=flags, callback=callback, **kwargs)
 
-    def send_pyobj(self, obj, flags=0, protocol=-1, callback=None):
+    def send_pyobj(self, obj, flags=0, protocol=-1, callback=None, **kwargs):
         """Send a Python object as a message using pickle to serialize.
 
         See zmq.socket.send_json for details.
         """
         msg = pickle.dumps(obj, protocol)
-        return self.send(msg, flags, callback=callback)
+        return self.send(msg, flags, callback=callback, **kwargs)
     
     def _finish_flush(self):
         """callback for unsetting _flushed flag."""

--- a/zmq/green/core.py
+++ b/zmq/green/core.py
@@ -180,7 +180,7 @@ class _Socket(_original_Socket):
                 timeout.cancel()
             self.__readable.set()
 
-    def send(self, data, flags=0, copy=True, track=False):
+    def send(self, data, flags=0, copy=True, track=False, **kwargs):
         """send, which will only block current greenlet
         
         state_changed always fires exactly once (success or fail) at the
@@ -190,7 +190,7 @@ class _Socket(_original_Socket):
         # if we're given the NOBLOCK flag act as normal and let the EAGAIN get raised
         if flags & zmq.NOBLOCK:
             try:
-                msg = super(_Socket, self).send(data, flags, copy, track)
+                msg = super(_Socket, self).send(data, flags, copy, track, **kwargs)
             finally:
                 if not self.__in_send_multipart:
                     self.__state_changed()

--- a/zmq/sugar/constants.py
+++ b/zmq/sugar/constants.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from zmq.backend import constants
+from zmq.backend import has
 from zmq.utils.constant_names import (
     base_names,
     switched_sockopt_names,
@@ -28,7 +29,7 @@ __all__ = [
     'DRAFT_API',
     ]
 
-DRAFT_API = constants.DRAFT_API
+DRAFT_API = has('draft') and constants.DRAFT_API
 
 int_sockopts    = set()
 int64_sockopts  = set()

--- a/zmq/sugar/constants.py
+++ b/zmq/sugar/constants.py
@@ -29,7 +29,10 @@ __all__ = [
     'DRAFT_API',
     ]
 
-DRAFT_API = has('draft') and constants.DRAFT_API
+if constants.VERSION < 40200:
+    DRAFT_API = False
+else:
+    DRAFT_API = bool(has('draft') and constants.DRAFT_API)
 
 int_sockopts    = set()
 int64_sockopts  = set()

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -13,6 +13,20 @@ class Frame(FrameBase, AttributeSetter):
         # map Frame['User-Id'] to Frame.get('User-Id')
         return self.get(key)
 
+    @property
+    def group(self):
+        _check_version((4,2), "RADIO-DISH")
+        if not zmq.has('draft'):
+            raise RuntimeError("libzmq must be built with draft support")
+        return self._get_group()
+
+    @group.setter
+    def group(self, group):
+        _check_version((4,2), "RADIO-DISH")
+        if not zmq.has('draft'):
+            raise RuntimeError("libzmq must be built with draft support")
+        self._set_group(group)
+
 
 # keep deprecated alias
 Message = Frame

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -6,6 +6,7 @@
 
 from .attrsettr import AttributeSetter
 from zmq.backend import Frame as FrameBase
+import zmq
 
 
 class Frame(FrameBase, AttributeSetter):
@@ -16,15 +17,15 @@ class Frame(FrameBase, AttributeSetter):
     @property
     def group(self):
         _check_version((4,2), "RADIO-DISH")
-        if not zmq.has('draft'):
-            raise RuntimeError("libzmq must be built with draft support")
+        if not zmq.DRAFT_API:
+            raise RuntimeError("libzmq and pyzmq must be built with draft support")
         return self._get_group()
 
     @group.setter
     def group(self, group):
         _check_version((4,2), "RADIO-DISH")
-        if not zmq.has('draft'):
-            raise RuntimeError("libzmq must be built with draft support")
+        if not zmq.DRAFT_API:
+            raise RuntimeError("libzmq and pyzmq must be built with draft support")
         self._set_group(group)
 
 

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -7,6 +7,7 @@
 from .attrsettr import AttributeSetter
 from zmq.backend import Frame as FrameBase
 import zmq
+from zmq.error import _check_version
 
 
 class Frame(FrameBase, AttributeSetter):
@@ -19,14 +20,29 @@ class Frame(FrameBase, AttributeSetter):
         _check_version((4,2), "RADIO-DISH")
         if not zmq.DRAFT_API:
             raise RuntimeError("libzmq and pyzmq must be built with draft support")
-        return self._get_group()
+        return self.get('group')
 
     @group.setter
     def group(self, group):
         _check_version((4,2), "RADIO-DISH")
         if not zmq.DRAFT_API:
             raise RuntimeError("libzmq and pyzmq must be built with draft support")
-        self._set_group(group)
+        self.set('group', group)
+
+    @property
+    def routing_id(self):
+        print('getting routing id')
+        _check_version((4,2), "CLIENT-SERVER")
+        if not zmq.DRAFT_API:
+            raise RuntimeError("libzmq and pyzmq must be built with draft support")
+        return self.get('routing_id')
+
+    @routing_id.setter
+    def routing_id(self, routing_id):
+        _check_version((4,2), "CLIENT-SERVER")
+        if not zmq.DRAFT_API:
+            raise RuntimeError("libzmq and pyzmq must be built with draft support")
+        self.set('routing_id', routing_id)
 
 
 # keep deprecated alias

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -7,8 +7,11 @@
 from .attrsettr import AttributeSetter
 from zmq.backend import Frame as FrameBase
 import zmq
-from zmq.error import _check_version
 
+def _draft(v, feature):
+    zmq.error._check_version(v, feature)
+    if not zmq.DRAFT_API:
+        raise RuntimeError("libzmq and pyzmq must be built with draft support for %s" % features)
 
 class Frame(FrameBase, AttributeSetter):
     def __getitem__(self, key):
@@ -17,31 +20,22 @@ class Frame(FrameBase, AttributeSetter):
 
     @property
     def group(self):
-        _check_version((4,2), "RADIO-DISH")
-        if not zmq.DRAFT_API:
-            raise RuntimeError("libzmq and pyzmq must be built with draft support")
+        _draft((4,2), "RADIO-DISH")
         return self.get('group')
 
     @group.setter
     def group(self, group):
-        _check_version((4,2), "RADIO-DISH")
-        if not zmq.DRAFT_API:
-            raise RuntimeError("libzmq and pyzmq must be built with draft support")
+        _draft((4,2), "RADIO-DISH")
         self.set('group', group)
 
     @property
     def routing_id(self):
-        print('getting routing id')
-        _check_version((4,2), "CLIENT-SERVER")
-        if not zmq.DRAFT_API:
-            raise RuntimeError("libzmq and pyzmq must be built with draft support")
+        _draft((4,2), "CLIENT-SERVER")
         return self.get('routing_id')
 
     @routing_id.setter
     def routing_id(self, routing_id):
-        _check_version((4,2), "CLIENT-SERVER")
-        if not zmq.DRAFT_API:
-            raise RuntimeError("libzmq and pyzmq must be built with draft support")
+        _draft((4,2), "CLIENT-SERVER")
         self.set('routing_id', routing_id)
 
 

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -608,6 +608,7 @@ class Socket(SocketBase, AttributeSetter):
             Any valid send flag
         """
         from zmq.utils import jsonapi
+        send_kwargs = {}
         for key in ('routing_id', 'group'):
             if key in kwargs:
                 send_kwargs[key] = kwargs.pop(key)

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -333,8 +333,58 @@ class Socket(SocketBase, AttributeSetter):
     #-------------------------------------------------------------------------
     # Sending and receiving messages
     #-------------------------------------------------------------------------
+    
+    def send(self, frame, flags=0, copy=True, track=False, routing_id=None, group=None):
+        """s.send(data, flags=0, copy=True, track=False)
 
-    def send_multipart(self, msg_parts, flags=0, copy=True, track=False):
+        Send a single zmq message frame on this socket.
+
+        Parameters
+        ----------
+        data : bytes, Frame, memoryview
+            The content of the message. This can be any object that provides
+            the Python buffer API (`memoryview(data)` can be called).
+        flags : int
+            Any supported flag: NOBLOCK, SNDMORE.
+        copy : bool
+            Should the message be sent in a copying or non-copying manner.
+        track : bool
+            Should the message be tracked for notification that ZMQ has
+            finished with it? (ignored if copy=True)
+        routing_id : int
+            For use with SERVER sockets
+        group: text
+            For use with RADIO sockets
+
+        Returns
+        -------
+        None : if `copy` or not track
+            None if message was sent, raises an exception otherwise.
+        MessageTracker : if track and not copy
+            a MessageTracker object, whose `pending` property will
+            be True until the send is completed.
+
+        Raises
+        ------
+        TypeError
+            If a unicode object is passed
+        ValueError
+            If `track=True`, but an untracked Frame is passed.
+        ZMQError
+            If the send does not succeed for any reason.
+
+        """
+        if routing_id is not None:
+            if not isinstance(frame, zmq.Frame):
+                frame = zmq.Frame(frame, track=track)
+            frame.routing_id = routing_id
+        if group is not None:
+            if not isinstance(frame, zmq.Frame):
+                frame = zmq.Frame(frame, track=track)
+            frame.group = group
+        return super(Socket, self).send(frame, flags=flags, copy=copy, track=track)
+
+    def send_multipart(self, msg_parts, flags=0, copy=True, track=False, **kwargs):
         """send a sequence of buffers as a multipart message
 
         The zmq.SNDMORE flag is added to all msg parts before the last.
@@ -431,7 +481,7 @@ class Socket(SocketBase, AttributeSetter):
         """
         return load(recvd)
 
-    def send_serialized(self, msg, serialize, flags=0, copy=True):
+    def send_serialized(self, msg, serialize, flags=0, copy=True, **kwargs):
         """Send a message with a custom serialization function.
 
         .. versionadded:: 17
@@ -450,7 +500,7 @@ class Socket(SocketBase, AttributeSetter):
 
         """
         frames = serialize(msg)
-        return self.send_multipart(frames, flags=flags, copy=copy)
+        return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
     def recv_serialized(self, deserialize, flags=0, copy=True):
         """Receive a message with a custom deserialization function.
@@ -513,7 +563,7 @@ class Socket(SocketBase, AttributeSetter):
     
     recv_unicode = recv_string
     
-    def send_pyobj(self, obj, flags=0, protocol=DEFAULT_PROTOCOL):
+    def send_pyobj(self, obj, flags=0, protocol=DEFAULT_PROTOCOL, **kwargs):
         """send a Python object as a message using pickle to serialize
 
         Parameters
@@ -527,7 +577,7 @@ class Socket(SocketBase, AttributeSetter):
             where defined, and pickle.HIGHEST_PROTOCOL elsewhere.
         """
         msg = pickle.dumps(obj, protocol)
-        return self.send(msg, flags)
+        return self.send(msg, flags=flags, **kwargs)
 
     def recv_pyobj(self, flags=0):
         """receive a Python object as a message using pickle to serialize
@@ -558,8 +608,11 @@ class Socket(SocketBase, AttributeSetter):
             Any valid send flag
         """
         from zmq.utils import jsonapi
+        for key in ('routing_id', 'group'):
+            if key in kwargs:
+                send_kwargs[key] = kwargs.pop(key)
         msg = jsonapi.dumps(obj, **kwargs)
-        return self.send(msg, flags)
+        return self.send(msg, flags=flags, **send_kwargs)
 
     def recv_json(self, flags=0, **kwargs):
         """receive a Python object as a message using json to serialize

--- a/zmq/tests/__init__.py
+++ b/zmq/tests/__init__.py
@@ -128,7 +128,7 @@ got '%s'" % (zmq.ZMQError(errno), zmq.ZMQError(e.errno)))
             # See LIBZMQ-280 on JIRA
             time.sleep(0.1)
         
-        r,w,x = zmq.select([socket], [], [], timeout=5)
+        r,w,x = zmq.select([socket], [], [], timeout=kwargs.pop('timeout', 5))
         assert len(r) > 0, "Should have received a message"
         kwargs['flags'] = zmq.DONTWAIT | kwargs.get('flags', 0)
         

--- a/zmq/tests/test_draft.py
+++ b/zmq/tests/test_draft.py
@@ -1,0 +1,52 @@
+# -*- coding: utf8 -*-
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import platform
+import time
+
+import pytest
+import zmq
+from zmq.tests import (
+    BaseZMQTestCase, skip_pypy
+)
+
+
+class TestDraftSockets(BaseZMQTestCase):
+    def setUp(self):
+        if not zmq.DRAFT_API:
+            raise pytest.skip("draft api unavailable")
+        super(TestDraftSockets, self).setUp()
+    
+
+    def test_client_server(self):
+        client, server = self.create_bound_pair(zmq.CLIENT, zmq.SERVER)
+        client.send(b'request')
+        msg = self.recv(server, copy=False)
+        assert msg.routing_id is not None
+        server.send(b'reply', routing_id=msg.routing_id)
+        reply = self.recv(client)
+        assert reply == b'reply'
+
+    def test_radio_dish(self):
+        dish, radio = self.create_bound_pair(zmq.DISH, zmq.RADIO)
+        dish.rcvtimeo = 250
+        group = 'mygroup'
+        dish.join(group)
+        received_count = 0
+        received = set()
+        sent = set()
+        for i in range(10):
+            msg = str(i).encode('ascii')
+            sent.add(msg)
+            radio.send(msg, group=group)
+            try:
+                recvd = dish.recv()
+            except zmq.Again:
+                time.sleep(0.1)
+            else:
+                received.add(recvd)
+                received_count += 1
+        # assert that we got *something*
+        assert len(received.intersection(sent)) >= 5

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -7,7 +7,7 @@
 
 #if defined(_MSC_VER)
 #define pyzmq_int64_t __int64
-#define pyzmq_uint32_t __uint32
+#define pyzmq_uint32_t unsigned __int32
 #else
 #include <stdint.h>
 #define pyzmq_int64_t int64_t

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -56,9 +56,9 @@
     #define zmq_join(s, group) _missing
     #define zmq_leave(s, group) _missing
     #define zmq_msg_set_routing_id(msg, routing_id) _missing
-    #define zmq_msg_routing_id(msg) _missing
+    #define zmq_msg_routing_id(msg) 0
     #define zmq_msg_set_group(msg, group) _missing
-    #define zmq_msg_group(msg) _missing
+    #define zmq_msg_group(msg) NULL
 #endif
 
 #if ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 1

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -56,6 +56,7 @@
     #define zmq_join(s, group) _missing
     #define zmq_leave(s, group) _missing
     #define zmq_msg_set_routing_id(msg, routing_id) _missing
+    #define zmq_msg_routing_id(msg) _missing
     #define zmq_msg_set_group(msg, group) _missing
     #define zmq_msg_group(msg) _missing
 #endif

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -7,9 +7,11 @@
 
 #if defined(_MSC_VER)
 #define pyzmq_int64_t __int64
+#define pyzmq_uint32_t __uint32
 #else
 #include <stdint.h>
 #define pyzmq_int64_t int64_t
+#define pyzmq_uint32_t uint32_t
 #endif
 
 
@@ -42,6 +44,20 @@
     #endif
 #else
     #define zmq_curve_keypair(z85_public_key, z85_secret_key) _missing
+#endif
+
+// libzmq 4.2 draft API
+#ifdef ZMQ_BUILD_DRAFT_API
+    #if ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 2
+        #define PYZMQ_DRAFT_42
+    #endif
+#endif
+#ifndef PYZMQ_DRAFT_42
+    #define zmq_join(s, group) _missing
+    #define zmq_leave(s, group) _missing
+    #define zmq_msg_set_routing_id(msg, routing_id) _missing
+    #define zmq_msg_set_group(msg, group) _missing
+    #define zmq_msg_group(msg) _missing
 #endif
 
 #if ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 1


### PR DESCRIPTION
CLIENT-SERVER, RADIO-DISH

adds `group`, `routing_id` args to send for convenient sending without instantiating Frame objects.

I'm not 100% sure what to do on the receiving side, since the default `recv(copy=True)` on SERVER will not provide enough info to construct a reply, and I would rather avoid forcing `copy=True`. I may save that for another PR.

closes #911

To install with draft:

    python setup.py install --enable-drafts

or

    ZMQ_DRAFT_API=1 python setup.py install

Once there has been a release with this, you will be able to do:

    pip install pyzmq --install-option=--enable-drafts

Sufficiently recent pip recognizes the `--install-option` and prevents installing from wheels that won't have draft installed.