### PR TITLE
handle copy_threshold in Frame

### DIFF
--- a/zmq/backend/cffi/message.py
+++ b/zmq/backend/cffi/message.py
@@ -23,7 +23,7 @@ class Frame(object):
     buffer = None
 
 
-    def __init__(self, data, track=False):
+    def __init__(self, data, track=False, copy=None, copy_threshold=None):
         try:
             view(data)
         except TypeError:
@@ -39,7 +39,7 @@ class Frame(object):
         self.tracker = None
         self.closed = False
         if track:
-            self.tracker = zmq.MessageTracker()
+            self.tracker = zmq._FINISHED_TRACKER
 
         self.buffer = view(self.bytes)
 

--- a/zmq/backend/cython/message.pyx
+++ b/zmq/backend/cython/message.pyx
@@ -111,38 +111,6 @@ cdef void free_python_msg(void *data, void *vhint) nogil:
 gc = None
 
 cdef class Frame:
-    """Frame(data=None, track=False)
-
-    A zmq message Frame class for non-copy send/recvs.
-
-    This class is only needed if you want to do non-copying send and recvs.
-    When you pass a string to this class, like ``Frame(s)``, the 
-    ref-count of `s` is increased by two: once because the Frame saves `s` as 
-    an instance attribute and another because a ZMQ message is created that
-    points to the buffer of `s`. This second ref-count increase makes sure
-    that `s` lives until all messages that use it have been sent. Once 0MQ
-    sends all the messages and it doesn't need the buffer of s, 0MQ will call
-    ``Py_DECREF(s)``.
-
-    Parameters
-    ----------
-
-    data : object, optional
-        any object that provides the buffer interface will be used to
-        construct the 0MQ message data.
-    track : bool [default: False]
-        whether a MessageTracker_ should be created to track this object.
-        Tracking a message has a cost at creation, because it creates a threadsafe
-        Event object.
-    copy : bool [default: depends on copy_threshold]
-        Whether to create a copy of the data to pass to libzmq
-        or share the memory with libzmq.
-        If unspecified, copy_threshold is used.
-    copy_threshold: int [default: zmq.COPY_THRESHOLD]
-        If copy is unspecified, messages smaller than this size
-        will be copied and messages larger than this size will be shared with libzmq.
-    """
-
     def __cinit__(self, object data=None, track=False, copy=None, copy_threshold=None, **kwargs):
         cdef int rc
         cdef char *data_c = NULL

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -781,7 +781,7 @@ cdef class Socket:
                     if nbytes(buf) < self.copy_threshold:
                         _send_copy(self.handle, buf, flags)
                         return zmq._FINISHED_TRACKER
-                msg = Frame(data, track=track)
+                msg = Frame(data, track=track, copy_threshold=self.copy_threshold)
             return _send_frame(self.handle, msg, flags)
 
     cpdef recv(self, int flags=0, copy=True, track=False):

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -14,6 +14,38 @@ def _draft(v, feature):
         raise RuntimeError("libzmq and pyzmq must be built with draft support for %s" % features)
 
 class Frame(FrameBase, AttributeSetter):
+    """Frame(data=None, track=False, copy=None, copy_threshold=zmq.COPY_THRESHOLD)
+
+    A zmq message Frame class for non-copy send/recvs.
+
+    This class is only needed if you want to do non-copying send and recvs.
+    When you pass a string to this class, like ``Frame(s)``, the 
+    ref-count of `s` is increased by two: once because the Frame saves `s` as 
+    an instance attribute and another because a ZMQ message is created that
+    points to the buffer of `s`. This second ref-count increase makes sure
+    that `s` lives until all messages that use it have been sent. Once 0MQ
+    sends all the messages and it doesn't need the buffer of s, 0MQ will call
+    ``Py_DECREF(s)``.
+
+    Parameters
+    ----------
+
+    data : object, optional
+        any object that provides the buffer interface will be used to
+        construct the 0MQ message data.
+    track : bool [default: False]
+        whether a MessageTracker_ should be created to track this object.
+        Tracking a message has a cost at creation, because it creates a threadsafe
+        Event object.
+    copy : bool [default: use copy_threshold]
+        Whether to create a copy of the data to pass to libzmq
+        or share the memory with libzmq.
+        If unspecified, copy_threshold is used.
+    copy_threshold: int [default: zmq.COPY_THRESHOLD]
+        If copy is unspecified, messages smaller than this many bytes
+        will be copied and messages larger than this will be shared with libzmq.
+    """
+
     def __getitem__(self, key):
         # map Frame['User-Id'] to Frame.get('User-Id')
         return self.get(key)

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -377,11 +377,13 @@ class Socket(SocketBase, AttributeSetter):
         """
         if routing_id is not None:
             if not isinstance(data, zmq.Frame):
-                data = zmq.Frame(data, track=track)
+                data = zmq.Frame(data, track=track, copy=copy or None,
+                                 copy_threshold=self.copy_threshold)
             data.routing_id = routing_id
         if group is not None:
             if not isinstance(data, zmq.Frame):
-                data = zmq.Frame(data, track=track)
+                data = zmq.Frame(data, track=track, copy=copy or None,
+                                 copy_threshold=self.copy_threshold)
             data.group = group
         return super(Socket, self).send(data, flags=flags, copy=copy, track=track)
 

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -53,7 +53,7 @@ class TestFrame(BaseZMQTestCase):
         for i in range(5, 16):  # 32, 64,..., 65536
             s = (2**i)*x
             self.assertEqual(grc(s), 2)
-            m = zmq.Frame(s)
+            m = zmq.Frame(s, copy=False)
             self.assertEqual(grc(s), 4)
             del m
             await_gc(s, 2)
@@ -105,7 +105,7 @@ class TestFrame(BaseZMQTestCase):
             s = (2**i)*x
             rc = 2
             self.assertEqual(grc(s), rc)
-            m = zmq.Frame(s)
+            m = zmq.Frame(s, copy=False)
             rc += 2
             self.assertEqual(grc(s), rc)
             m2 = copy.copy(m)
@@ -141,7 +141,7 @@ class TestFrame(BaseZMQTestCase):
             s = (2**i)*x
             rc = 2
             self.assertEqual(grc(s), rc)
-            m = zmq.Frame(s)
+            m = zmq.Frame(s, copy=False)
             rc += 2
             self.assertEqual(grc(s), rc)
             m2 = copy.copy(m)
@@ -172,7 +172,7 @@ class TestFrame(BaseZMQTestCase):
     
     @skip_pypy
     def test_tracker(self):
-        m = zmq.Frame(b'asdf', track=True)
+        m = zmq.Frame(b'asdf', copy=False, track=True)
         self.assertFalse(m.tracker.done)
         pm = zmq.MessageTracker(m)
         self.assertFalse(pm.done)
@@ -192,8 +192,8 @@ class TestFrame(BaseZMQTestCase):
     
     @skip_pypy
     def test_multi_tracker(self):
-        m = zmq.Frame(b'asdf', track=True)
-        m2 = zmq.Frame(b'whoda', track=True)
+        m = zmq.Frame(b'asdf', copy=False, track=True)
+        m2 = zmq.Frame(b'whoda', copy=False, track=True)
         mt = zmq.MessageTracker(m,m2)
         self.assertFalse(m.tracker.done)
         self.assertFalse(mt.done)

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -263,7 +263,7 @@ class TestSocket(BaseZMQTestCase):
             time.sleep(0.1)
         self.assertEqual(p2.done, True)
         self.assertEqual(msg, [b'something', b'else'])
-        m = zmq.Frame(b"again", track=True)
+        m = zmq.Frame(b"again", copy=False, track=True)
         self.assertEqual(m.tracker.done, False)
         p1 = a.send(m, copy=False)
         p2 = a.send(m, copy=False)


### PR DESCRIPTION
instantiating a `Frame(data)` now applies the same copy-threshold
behavior as `send(copy=False).

This is mostly an internal change as Frames can be created during internal code, which shouldn't trigger zero-copy logic unconditionally.