### PR TITLE
 zmq/tests/test_error.py from threading import Thread

### DIFF
--- a/zmq/tests/test_error.py
+++ b/zmq/tests/test_error.py
@@ -4,6 +4,7 @@
 
 import sys
 import time
+from threading import Thread
 
 import zmq
 from zmq import ZMQError, strerror, Again, ContextTerminated
@@ -40,4 +41,3 @@ class TestZMQError(BaseZMQTestCase):
         self.assertRaisesErrno(zmq.TERM, s.recv, zmq.NOBLOCK)
         s.close()
         t.join()
-


### PR DESCRIPTION
A `Thread()` is created on line 38.