### PR TITLE
Remove `buffer` because we no longer support Python 2.6.  Use `memoryview` instead.

### DIFF
--- a/zmq/backend/cffi/message.py
+++ b/zmq/backend/cffi/message.py
@@ -8,11 +8,6 @@ from ._cffi import ffi, C
 import zmq
 from zmq.utils.strtypes import unicode
 
-try:
-    view = memoryview
-except NameError:
-    view = buffer
-
 _content = lambda x: x.tobytes() if type(x) == memoryview else x
 
 class Frame(object):
@@ -25,7 +20,7 @@ class Frame(object):
 
     def __init__(self, data, track=False, copy=None, copy_threshold=None):
         try:
-            view(data)
+            memoryview(data)
         except TypeError:
             raise
 
@@ -41,7 +36,7 @@ class Frame(object):
         if track:
             self.tracker = zmq._FINISHED_TRACKER
 
-        self.buffer = view(self.bytes)
+        self.buffer = memoryview(self.bytes)
 
     @property
     def bytes(self):

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -38,10 +38,6 @@ try:
 except AttributeError:
     DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
-try:
-    _buffer_type = memoryview
-except NameError:
-    _buffer_type = buffer
 
 class Socket(SocketBase, AttributeSetter):
     """The ZMQ socket object
@@ -416,10 +412,10 @@ class Socket(SocketBase, AttributeSetter):
         """
         # typecheck parts before sending:
         for i,msg in enumerate(msg_parts):
-            if isinstance(msg, (zmq.Frame, bytes, _buffer_type)):
+            if isinstance(msg, (zmq.Frame, bytes, memoryview)):
                 continue
             try:
-                _buffer_type(msg)
+                memoryview(msg)
             except Exception:
                 rmsg = repr(msg)
                 if len(rmsg) > 32:

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -274,12 +274,8 @@ class TestFrame(BaseZMQTestCase):
             shape = shapes[:i]
             A = numpy.random.random(shape)
             m = zmq.Frame(A)
-            if memoryview.__name__ == 'buffer':
-                self.assertEqual(A.data, m.buffer)
-                B = numpy.frombuffer(m.buffer,dtype=A.dtype).reshape(A.shape)
-            else:
-                self.assertEqual(memoryview(A), m.buffer)
-                B = numpy.array(m.buffer,dtype=A.dtype).reshape(A.shape)
+            self.assertEqual(memoryview(A), m.buffer)
+            B = numpy.array(m.buffer,dtype=A.dtype).reshape(A.shape)
             self.assertEqual((A==B).all(), True)
     
     def test_memoryview(self):
@@ -312,10 +308,7 @@ class TestFrame(BaseZMQTestCase):
                 ff=b'\xff'*(40 + i*10)
                 sb.send(ff, copy=False)
                 m2 = sa.recv(copy=False)
-                if memoryview.__name__ == 'buffer':
-                    b = bytes(buf)
-                else:
-                    b = buf.tobytes()
+                b = buf.tobytes()
                 self.assertEqual(b, null)
                 self.assertEqual(mb, null)
                 self.assertEqual(m2.bytes, ff)

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -23,14 +23,9 @@ from zmq.utils.strtypes import unicode, bytes, b, u
 
 x = b'x'
 
-try:
-    view = memoryview
-except NameError:
-    view = buffer
-
 if grc:
     rc0 = grc(x)
-    v = view(x)
+    v = memoryview(x)
     view_rc = grc(x) - rc0
 
 def await_gc(obj, rc):
@@ -210,7 +205,7 @@ class TestFrame(BaseZMQTestCase):
     def test_buffer_in(self):
         """test using a buffer as input"""
         ins = b("§§¶•ªº˜µ¬˚…∆˙åß∂©œ∑´†≈ç√")
-        m = zmq.Frame(view(ins))
+        m = zmq.Frame(memoryview(ins))
     
     def test_bad_buffer_in(self):
         """test using a bad object"""
@@ -222,7 +217,7 @@ class TestFrame(BaseZMQTestCase):
         ins = b("§§¶•ªº˜µ¬˚…∆˙åß∂©œ∑´†≈ç√")
         m = zmq.Frame(ins)
         outb = m.buffer
-        self.assertTrue(isinstance(outb, view))
+        self.assertTrue(isinstance(outb, memoryview))
         self.assert_(outb is m.buffer)
         self.assert_(m.buffer is m.buffer)
     
@@ -279,7 +274,7 @@ class TestFrame(BaseZMQTestCase):
             shape = shapes[:i]
             A = numpy.random.random(shape)
             m = zmq.Frame(A)
-            if view.__name__ == 'buffer':
+            if memoryview.__name__ == 'buffer':
                 self.assertEqual(A.data, m.buffer)
                 B = numpy.frombuffer(m.buffer,dtype=A.dtype).reshape(A.shape)
             else:
@@ -310,14 +305,14 @@ class TestFrame(BaseZMQTestCase):
             sb.send(null, copy=False)
             m = sa.recv(copy=False)
             mb = m.bytes
-            # buf = view(m)
+            # buf = memoryview(m)
             buf = m.buffer
             del m
             for i in range(5):
                 ff=b'\xff'*(40 + i*10)
                 sb.send(ff, copy=False)
                 m2 = sa.recv(copy=False)
-                if view.__name__ == 'buffer':
+                if memoryview.__name__ == 'buffer':
                     b = bytes(buf)
                 else:
                     b = buf.tobytes()


### PR DESCRIPTION
`buffer` was removed in Python 3.  `memoryview` is supported in Python 2.7+
* https://docs.python.org/2/library/stdtypes.html#memoryview-type