### PR TITLE
 Python 3.6 support and Python 3.3 EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: python
-dist: trusty
 
 cache:
   - apt
   - pip
+
 python:
   - 2.7
   - 3.6
   - pypy2.7-5.8.0
   - pypy3.5-5.8.0
+
 env:
     - ZMQ=
     - ZMQ=bundled
+
 before_install:
   - sudo add-apt-repository -y ppa:anton+/dnscrypt
   - sudo apt-get update
@@ -76,8 +78,6 @@ matrix:
       env: ZMQ=zeromq4-1
     - python: 3.4
       env: ZMQ=zeromq3-x
-    - python: 3.3
-      env: ZMQ=
     - python: nightly
       env: ZMQ=
     - python: nightly

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package contains Python bindings for [ØMQ](http://www.zeromq.org).
 ØMQ is a lightweight and fast messaging implementation.
 
 PyZMQ should work with any reasonable version of Python (≥ 3.4),
-as well as Python 2.7 and 3.3, as well as PyPy.
+as well as Python 2.7 and PyPy.
 The Cython backend used by CPython supports libzmq ≥ 2.1.4 (including 3.2.x and 4.x),
 but the CFFI backend used by PyPy only supports libzmq ≥ 3.2.2 (including 4.x).
 
@@ -78,6 +78,10 @@ Building pyzmq from the git repo (including release tags on GitHub) requires Cyt
 
 ## Old versions
 
+pyzmq 17 drops support Python 3.3.
+If you need to use Python 3.3, you can pin your pyzmq version to before 17:
+
+    pip install 'pyzmq<17'
 
 pyzmq 16 drops support Python 2.6 and 3.2.
 If you need to use one of those Python versions, you can pin your pyzmq version to before 16:

--- a/setup.py
+++ b/setup.py
@@ -1253,9 +1253,9 @@ setup_args = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )
 if 'setuptools' in sys.modules:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,5 @@
 gevent; python_version == '2.7' and platform_python_implementation != "PyPy"
-pytest; python_version != '3.2'
-pytest < 3; python_version == '3.2'
+pytest
 unittest2; python_version < '3'
-tornado; python_version != '3.2'
-tornado < 4.4 ; python_version == '3.2'
+tornado
 aiohttp; python_version >= '3.4'


### PR DESCRIPTION
I do not know if this is they way that you want to go but some food for thought...

* Add a PyPI trove classifier for Python 3.6.
* Python 3.3 goes EOL in a few weeks https://docs.python.org/devguide/index.html#branchstatus  Should we remove it?
* Clean out some Python 3.2 requirements.