### PR TITLE
asyncio fixes

### DIFF
--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -453,18 +453,16 @@ class _AsyncSocket(_zmq.Socket):
             events = self._shadow_sock.EVENTS
         if events & self._state:
             self._call_later(0, self._handle_events)
-    
+
     def _add_io_state(self, state):
         """Add io_state to poller."""
-        if not self._state & state:
-            self._state = self._state | state
-            self._update_handler(self._state)
+        self._state = self._state | state
+        self._update_handler(self._state)
 
     def _drop_io_state(self, state):
         """Stop poller from watching an io_state."""
-        if self._state & state:
-            self._state = self._state & (~state)
-            self._update_handler(self._state)
+        self._state = self._state & (~state)
+        self._update_handler(self._state)
 
     def _update_handler(self, state):
         """Update IOLoop handler with state.
@@ -476,6 +474,7 @@ class _AsyncSocket(_zmq.Socket):
     def _init_io_state(self):
         """initialize the ioloop event handler"""
         self.io_loop.add_handler(self._shadow_sock, self._handle_events, self._READ)
+        self._call_later(0, self._handle_events)
 
     def _clear_io_state(self):
         """unregister the ioloop event handler

--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -227,7 +227,7 @@ class _AsyncSocket(_zmq.Socket):
 
     def poll(self, timeout=None, flags=_zmq.POLLIN):
         """poll the socket for events
-        
+
         returns a Future for the poll results.
         """
 
@@ -237,7 +237,7 @@ class _AsyncSocket(_zmq.Socket):
         p = self._poller_class()
         p.register(self, flags)
         f = p.poll(timeout)
-        
+
         future = self._Future()
         def unwrap_result(f):
             if future.done():
@@ -248,7 +248,11 @@ class _AsyncSocket(_zmq.Socket):
                 evts = dict(f.result())
                 future.set_result(evts.get(self, 0))
 
-        f.add_done_callback(unwrap_result)
+        if f.done():
+            # hook up result if
+            unwrap_result(f)
+        else:
+            f.add_done_callback(unwrap_result)
         return future
 
     def _add_timeout(self, future, timeout):

--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -140,7 +140,11 @@ class _AsyncSocket(_zmq.Socket):
         if not self.closed:
             for event in chain(self._recv_futures, self._send_futures):
                 if not event.future.done():
-                    event.future.cancel()
+                    try:
+                        event.future.cancel()
+                    except RuntimeError:
+                        # RuntimeError may be called during teardown
+                        pass
             self._clear_io_state()
         super(_AsyncSocket, self).close(linger=linger)
     close.__doc__ = _zmq.Socket.close.__doc__

--- a/zmq/asyncio/__init__.py
+++ b/zmq/asyncio/__init__.py
@@ -50,14 +50,14 @@ class Socket(_AsyncIO, _future._AsyncSocket):
 
     def _init_io_state(self):
         """initialize the ioloop event handler"""
-        self.io_loop.add_reader(self._shadow_sock.FD, lambda : self._handle_events(0, 0))
+        self.io_loop.add_reader(self._fd, lambda : self._handle_events(0, 0))
 
     def _clear_io_state(self):
         """clear any ioloop event handler
 
         called once at close
         """
-        self.io_loop.remove_reader(self._shadow_sock.FD)
+        self.io_loop.remove_reader(self._fd)
 
 Poller._socket_class = Socket
 

--- a/zmq/tests/test_future.py
+++ b/zmq/tests/test_future.py
@@ -250,6 +250,7 @@ class TestFutureSocket(BaseZMQTestCase):
         def test():
             a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
             f = b.poll(timeout=0)
+            assert f.done()
             self.assertEqual(f.result(), 0)
 
             f = b.poll(timeout=1)


### PR DESCRIPTION
- Failure to check for waiting events when calling `add|drop_io_state` could result in failure to wake for incoming messages.
- Save FD for use to avoid operation on closed socket during teardown
- Catch RuntimeError when cancelling futures during close if the eventloop is itself closing

closes #1065
closes #1085
closes #1106