### PR TITLE
Restore deprecated minitornado

### DIFF
--- a/zmq/eventloop/_deprecated.py
+++ b/zmq/eventloop/_deprecated.py
@@ -1,0 +1,219 @@
+# coding: utf-8
+"""tornado IOLoop API with zmq compatibility
+
+If you have tornado ≥ 3.0, this is a subclass of tornado's IOLoop,
+otherwise we ship a minimal subset of tornado in zmq.eventloop.minitornado.
+
+The minimal shipped version of tornado's IOLoop does not include
+support for concurrent futures - this will only be available if you
+have tornado ≥ 3.0.
+"""
+
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import absolute_import, division, with_statement
+
+import os
+import time
+import warnings
+
+from zmq import (
+    Poller,
+    POLLIN, POLLOUT, POLLERR,
+    ZMQError, ETERM,
+)
+
+try:
+    import tornado
+    tornado_version = tornado.version_info
+except (ImportError, AttributeError):
+    tornado_version = ()
+
+try:
+    # tornado ≥ 3
+    from tornado.ioloop import PollIOLoop, PeriodicCallback
+    from tornado.log import gen_log
+except ImportError:
+    from .minitornado.ioloop import PollIOLoop, PeriodicCallback
+    from .minitornado.log import gen_log
+
+
+class DelayedCallback(PeriodicCallback):
+    """Schedules the given callback to be called once.
+
+    The callback is called once, after callback_time milliseconds.
+
+    `start` must be called after the DelayedCallback is created.
+    
+    The timeout is calculated from when `start` is called.
+    """
+    def __init__(self, callback, callback_time, io_loop=None):
+        # PeriodicCallback require callback_time to be positive
+        warnings.warn("""DelayedCallback is deprecated.
+        Use loop.add_timeout instead.""", DeprecationWarning)
+        callback_time = max(callback_time, 1e-3)
+        super(DelayedCallback, self).__init__(callback, callback_time, io_loop)
+    
+    def start(self):
+        """Starts the timer."""
+        self._running = True
+        self._firstrun = True
+        self._next_timeout = time.time() + self.callback_time / 1000.0
+        self.io_loop.add_timeout(self._next_timeout, self._run)
+    
+    def _run(self):
+        if not self._running: return
+        self._running = False
+        try:
+            self.callback()
+        except Exception:
+            gen_log.error("Error in delayed callback", exc_info=True)
+
+
+class ZMQPoller(object):
+    """A poller that can be used in the tornado IOLoop.
+    
+    This simply wraps a regular zmq.Poller, scaling the timeout
+    by 1000, so that it is in seconds rather than milliseconds.
+    """
+    
+    def __init__(self):
+        self._poller = Poller()
+    
+    @staticmethod
+    def _map_events(events):
+        """translate IOLoop.READ/WRITE/ERROR event masks into zmq.POLLIN/OUT/ERR"""
+        z_events = 0
+        if events & IOLoop.READ:
+            z_events |= POLLIN
+        if events & IOLoop.WRITE:
+            z_events |= POLLOUT
+        if events & IOLoop.ERROR:
+            z_events |= POLLERR
+        return z_events
+    
+    @staticmethod
+    def _remap_events(z_events):
+        """translate zmq.POLLIN/OUT/ERR event masks into IOLoop.READ/WRITE/ERROR"""
+        events = 0
+        if z_events & POLLIN:
+            events |= IOLoop.READ
+        if z_events & POLLOUT:
+            events |= IOLoop.WRITE
+        if z_events & POLLERR:
+            events |= IOLoop.ERROR
+        return events
+    
+    def register(self, fd, events):
+        return self._poller.register(fd, self._map_events(events))
+    
+    def modify(self, fd, events):
+        return self._poller.modify(fd, self._map_events(events))
+    
+    def unregister(self, fd):
+        return self._poller.unregister(fd)
+    
+    def poll(self, timeout):
+        """poll in seconds rather than milliseconds.
+        
+        Event masks will be IOLoop.READ/WRITE/ERROR
+        """
+        z_events = self._poller.poll(1000*timeout)
+        return [ (fd,self._remap_events(evt)) for (fd,evt) in z_events ]
+    
+    def close(self):
+        pass
+
+
+class ZMQIOLoop(PollIOLoop):
+    """ZMQ subclass of tornado's IOLoop
+    
+    Minor modifications, so that .current/.instance return self
+    """
+    
+    _zmq_impl = ZMQPoller
+    
+    def initialize(self, impl=None, **kwargs):
+        impl = self._zmq_impl() if impl is None else impl
+        super(ZMQIOLoop, self).initialize(impl=impl, **kwargs)
+    
+    @classmethod
+    def instance(cls, *args, **kwargs):
+        """Returns a global `IOLoop` instance.
+        
+        Most applications have a single, global `IOLoop` running on the
+        main thread.  Use this method to get this instance from
+        another thread.  To get the current thread's `IOLoop`, use `current()`.
+        """
+        # install ZMQIOLoop as the active IOLoop implementation
+        # when using tornado 3
+        if tornado_version >= (3,):
+            PollIOLoop.configure(cls)
+        loop = PollIOLoop.instance(*args, **kwargs)
+        if not isinstance(loop, cls):
+            warnings.warn("IOLoop.current expected instance of %r, got %r" % (cls, loop),
+                RuntimeWarning, stacklevel=2,
+            )
+        return loop
+    
+    @classmethod
+    def current(cls, *args, **kwargs):
+        """Returns the current thread’s IOLoop.
+        """
+        # install ZMQIOLoop as the active IOLoop implementation
+        # when using tornado 3
+        if tornado_version >= (3,):
+            PollIOLoop.configure(cls)
+        loop = PollIOLoop.current(*args, **kwargs)
+        if not isinstance(loop, cls):
+            warnings.warn("IOLoop.current expected instance of %r, got %r" % (cls, loop),
+                RuntimeWarning, stacklevel=2,
+            )
+        return loop
+    
+    def start(self):
+        try:
+            super(ZMQIOLoop, self).start()
+        except ZMQError as e:
+            if e.errno == ETERM:
+                # quietly return on ETERM
+                pass
+            else:
+                raise
+
+
+if (3, 0) <= tornado_version < (3, 1):
+    def backport_close(self, all_fds=False):
+        """backport IOLoop.close to 3.0 from 3.1 (supports fd.close() method)"""
+        from zmq.eventloop.minitornado.ioloop import PollIOLoop as mini_loop
+        return mini_loop.close.__get__(self)(all_fds)
+    ZMQIOLoop.close = backport_close
+
+
+# public API name
+IOLoop = ZMQIOLoop
+
+
+def install():
+    """set the tornado IOLoop instance with the pyzmq IOLoop.
+    
+    After calling this function, tornado's IOLoop.instance() and pyzmq's
+    IOLoop.instance() will return the same object.
+    
+    An assertion error will be raised if tornado's IOLoop has been initialized
+    prior to calling this function.
+    """
+    from tornado import ioloop
+    # check if tornado's IOLoop is already initialized to something other
+    # than the pyzmq IOLoop instance:
+    assert (not ioloop.IOLoop.initialized()) or \
+        ioloop.IOLoop.instance() is IOLoop.instance(), "tornado IOLoop already initialized"
+    
+    if tornado_version >= (3,):
+        # tornado 3 has an official API for registering new defaults, yay!
+        ioloop.IOLoop.configure(ZMQIOLoop)
+    else:
+        # we have to set the global instance explicitly
+        ioloop.IOLoop._instance = IOLoop.instance()
+

--- a/zmq/eventloop/_deprecated.py
+++ b/zmq/eventloop/_deprecated.py
@@ -30,13 +30,8 @@ try:
 except (ImportError, AttributeError):
     tornado_version = ()
 
-try:
-    # tornado ≥ 3
-    from tornado.ioloop import PollIOLoop, PeriodicCallback
-    from tornado.log import gen_log
-except ImportError:
-    from .minitornado.ioloop import PollIOLoop, PeriodicCallback
-    from .minitornado.log import gen_log
+from .minitornado.ioloop import PollIOLoop, PeriodicCallback
+from .minitornado.log import gen_log
 
 
 class DelayedCallback(PeriodicCallback):
@@ -45,7 +40,7 @@ class DelayedCallback(PeriodicCallback):
     The callback is called once, after callback_time milliseconds.
 
     `start` must be called after the DelayedCallback is created.
-    
+
     The timeout is calculated from when `start` is called.
     """
     def __init__(self, callback, callback_time, io_loop=None):
@@ -54,14 +49,14 @@ class DelayedCallback(PeriodicCallback):
         Use loop.add_timeout instead.""", DeprecationWarning)
         callback_time = max(callback_time, 1e-3)
         super(DelayedCallback, self).__init__(callback, callback_time, io_loop)
-    
+
     def start(self):
         """Starts the timer."""
         self._running = True
         self._firstrun = True
         self._next_timeout = time.time() + self.callback_time / 1000.0
         self.io_loop.add_timeout(self._next_timeout, self._run)
-    
+
     def _run(self):
         if not self._running: return
         self._running = False

--- a/zmq/eventloop/ioloop.py
+++ b/zmq/eventloop/ioloop.py
@@ -71,13 +71,13 @@ _deprecated.called = False
 
 
 # resolve 'true' default loop
-print(ioloop)
 if '.minitornado.' in ioloop.__name__:
-    _IOLoop = ioloop.IOLoop
+    from ._deprecated import ZMQIOLoop as _IOLoop
 else:
     _IOLoop = ioloop.IOLoop
     while _IOLoop.configurable_default() is not _IOLoop:
         _IOLoop = _IOLoop.configurable_default()
+
 
 class ZMQIOLoop(_IOLoop):
     """DEPRECATED: No longer needed as of pyzmq-17
@@ -123,8 +123,14 @@ IOLoop = ZMQIOLoop
 
 def install():
     """DEPRECATED
-    
+
     pyzmq 17 no longer needs any special integration for tornado.
     """
     _deprecated()
     ioloop.IOLoop.configure(ZMQIOLoop)
+
+
+# if minitornado is used, fallback on deprecated ZMQIOLoop, install implementations
+if '.minitornado.' in ioloop.__name__:
+    from ._deprecated import ZMQIOLoop, install, IOLoop
+

--- a/zmq/eventloop/ioloop.py
+++ b/zmq/eventloop/ioloop.py
@@ -15,12 +15,17 @@ from __future__ import absolute_import, division, with_statement
 import time
 import warnings
 
-import tornado
-from tornado import ioloop
-if not hasattr(ioloop.IOLoop, 'configurable_default'):
-    raise ImportError("Tornado too old: %s" % getattr(tornado, 'version', 'unknown'))
-from tornado.ioloop import PeriodicCallback
-from tornado.log import gen_log
+try:
+    import tornado
+    from tornado.log import gen_log
+    from tornado import ioloop
+    if not hasattr(ioloop.IOLoop, 'configurable_default'):
+        raise ImportError("Tornado too old: %s" % getattr(tornado, 'version', 'unknown'))
+except ImportError:
+    from .minitornado import ioloop
+    from .minitornado.log import gen_log
+
+PeriodicCallback = ioloop.PeriodicCallback
 
 
 class DelayedCallback(PeriodicCallback):
@@ -66,9 +71,13 @@ _deprecated.called = False
 
 
 # resolve 'true' default loop
-_IOLoop = ioloop.IOLoop
-while _IOLoop.configurable_default() is not _IOLoop:
-    _IOLoop = _IOLoop.configurable_default()
+print(ioloop)
+if '.minitornado.' in ioloop.__name__:
+    _IOLoop = ioloop.IOLoop
+else:
+    _IOLoop = ioloop.IOLoop
+    while _IOLoop.configurable_default() is not _IOLoop:
+        _IOLoop = _IOLoop.configurable_default()
 
 class ZMQIOLoop(_IOLoop):
     """DEPRECATED: No longer needed as of pyzmq-17

--- a/zmq/eventloop/minitornado/__init__.py
+++ b/zmq/eventloop/minitornado/__init__.py
@@ -7,4 +7,5 @@ warnings.warn("""zmq.eventloop.minitornado is deprecated in pyzmq 14.0 and will 
     Install tornado itself to use zmq with the tornado IOLoop.
     """,
     VisibleDeprecationWarning,
+    stacklevel=4,
 )

--- a/zmq/eventloop/minitornado/__init__.py
+++ b/zmq/eventloop/minitornado/__init__.py
@@ -1,0 +1,10 @@
+import warnings
+class VisibleDeprecationWarning(UserWarning):
+    """A DeprecationWarning that users should see."""
+    pass
+
+warnings.warn("""zmq.eventloop.minitornado is deprecated in pyzmq 14.0 and will be removed.
+    Install tornado itself to use zmq with the tornado IOLoop.
+    """,
+    VisibleDeprecationWarning,
+)

--- a/zmq/eventloop/minitornado/concurrent.py
+++ b/zmq/eventloop/minitornado/concurrent.py
@@ -1,0 +1,14 @@
+"""pyzmq does not ship tornado's futures,
+this just raises informative NotImplementedErrors to avoid having to change too much code.
+"""
+
+class NotImplementedFuture(object):
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("pyzmq does not ship tornado's Futures, "
+            "install tornado >= 3.0 for future support."
+        )
+
+Future = TracebackFuture = NotImplementedFuture
+
+def is_future(x):
+    return isinstance(x, Future)

--- a/zmq/eventloop/minitornado/ioloop.py
+++ b/zmq/eventloop/minitornado/ioloop.py
@@ -1,0 +1,1056 @@
+#!/usr/bin/env python
+#
+# Copyright 2009 Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""An I/O event loop for non-blocking sockets.
+
+Typical applications will use a single `IOLoop` object, in the
+`IOLoop.instance` singleton.  The `IOLoop.start` method should usually
+be called at the end of the ``main()`` function.  Atypical applications may
+use more than one `IOLoop`, such as one `IOLoop` per thread, or per `unittest`
+case.
+
+In addition to I/O events, the `IOLoop` can also schedule time-based events.
+`IOLoop.add_timeout` is a non-blocking alternative to `time.sleep`.
+"""
+
+from __future__ import absolute_import, division, print_function, with_statement
+
+import datetime
+import errno
+import functools
+import heapq
+import itertools
+import logging
+import numbers
+import os
+import select
+import sys
+import threading
+import time
+import traceback
+import math
+
+from .concurrent import TracebackFuture, is_future
+from .log import app_log, gen_log
+from . import stack_context
+from .util import Configurable, errno_from_exception, timedelta_to_seconds
+
+try:
+    import signal
+except ImportError:
+    signal = None
+
+try:
+    import thread  # py2
+except ImportError:
+    import _thread as thread  # py3
+
+from .platform.auto import set_close_exec, Waker
+
+
+_POLL_TIMEOUT = 3600.0
+
+
+class TimeoutError(Exception):
+    pass
+
+
+class IOLoop(Configurable):
+    """A level-triggered I/O loop.
+
+    We use ``epoll`` (Linux) or ``kqueue`` (BSD and Mac OS X) if they
+    are available, or else we fall back on select(). If you are
+    implementing a system that needs to handle thousands of
+    simultaneous connections, you should use a system that supports
+    either ``epoll`` or ``kqueue``.
+
+    Example usage for a simple TCP server:
+
+    .. testcode::
+
+        import errno
+        import functools
+        import tornado.ioloop
+        import socket
+
+        def connection_ready(sock, fd, events):
+            while True:
+                try:
+                    connection, address = sock.accept()
+                except socket.error as e:
+                    if e.args[0] not in (errno.EWOULDBLOCK, errno.EAGAIN):
+                        raise
+                    return
+                connection.setblocking(0)
+                handle_connection(connection, address)
+
+        if __name__ == '__main__':
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.setblocking(0)
+            sock.bind(("", port))
+            sock.listen(128)
+
+            io_loop = tornado.ioloop.IOLoop.current()
+            callback = functools.partial(connection_ready, sock)
+            io_loop.add_handler(sock.fileno(), callback, io_loop.READ)
+            io_loop.start()
+
+    .. testoutput::
+       :hide:
+
+    By default, a newly-constructed `IOLoop` becomes the thread's current
+    `IOLoop`, unless there already is a current `IOLoop`. This behavior
+    can be controlled with the ``make_current`` argument to the `IOLoop`
+    constructor: if ``make_current=True``, the new `IOLoop` will always
+    try to become current and it raises an error if there is already a
+    current instance. If ``make_current=False``, the new `IOLoop` will
+    not try to become current.
+
+    .. versionchanged:: 4.2
+       Added the ``make_current`` keyword argument to the `IOLoop`
+       constructor.
+    """
+    # Constants from the epoll module
+    _EPOLLIN = 0x001
+    _EPOLLPRI = 0x002
+    _EPOLLOUT = 0x004
+    _EPOLLERR = 0x008
+    _EPOLLHUP = 0x010
+    _EPOLLRDHUP = 0x2000
+    _EPOLLONESHOT = (1 << 30)
+    _EPOLLET = (1 << 31)
+
+    # Our events map exactly to the epoll events
+    NONE = 0
+    READ = _EPOLLIN
+    WRITE = _EPOLLOUT
+    ERROR = _EPOLLERR | _EPOLLHUP
+
+    # Global lock for creating global IOLoop instance
+    _instance_lock = threading.Lock()
+
+    _current = threading.local()
+
+    @staticmethod
+    def instance():
+        """Returns a global `IOLoop` instance.
+
+        Most applications have a single, global `IOLoop` running on the
+        main thread.  Use this method to get this instance from
+        another thread.  In most other cases, it is better to use `current()`
+        to get the current thread's `IOLoop`.
+        """
+        if not hasattr(IOLoop, "_instance"):
+            with IOLoop._instance_lock:
+                if not hasattr(IOLoop, "_instance"):
+                    # New instance after double check
+                    IOLoop._instance = IOLoop()
+        return IOLoop._instance
+
+    @staticmethod
+    def initialized():
+        """Returns true if the singleton instance has been created."""
+        return hasattr(IOLoop, "_instance")
+
+    def install(self):
+        """Installs this `IOLoop` object as the singleton instance.
+
+        This is normally not necessary as `instance()` will create
+        an `IOLoop` on demand, but you may want to call `install` to use
+        a custom subclass of `IOLoop`.
+        """
+        assert not IOLoop.initialized()
+        IOLoop._instance = self
+
+    @staticmethod
+    def clear_instance():
+        """Clear the global `IOLoop` instance.
+
+        .. versionadded:: 4.0
+        """
+        if hasattr(IOLoop, "_instance"):
+            del IOLoop._instance
+
+    @staticmethod
+    def current(instance=True):
+        """Returns the current thread's `IOLoop`.
+
+        If an `IOLoop` is currently running or has been marked as
+        current by `make_current`, returns that instance.  If there is
+        no current `IOLoop`, returns `IOLoop.instance()` (i.e. the
+        main thread's `IOLoop`, creating one if necessary) if ``instance``
+        is true.
+
+        In general you should use `IOLoop.current` as the default when
+        constructing an asynchronous object, and use `IOLoop.instance`
+        when you mean to communicate to the main thread from a different
+        one.
+
+        .. versionchanged:: 4.1
+           Added ``instance`` argument to control the fallback to
+           `IOLoop.instance()`.
+        """
+        current = getattr(IOLoop._current, "instance", None)
+        if current is None and instance:
+            return IOLoop.instance()
+        return current
+
+    def make_current(self):
+        """Makes this the `IOLoop` for the current thread.
+
+        An `IOLoop` automatically becomes current for its thread
+        when it is started, but it is sometimes useful to call
+        `make_current` explicitly before starting the `IOLoop`,
+        so that code run at startup time can find the right
+        instance.
+
+        .. versionchanged:: 4.1
+           An `IOLoop` created while there is no current `IOLoop`
+           will automatically become current.
+        """
+        IOLoop._current.instance = self
+
+    @staticmethod
+    def clear_current():
+        IOLoop._current.instance = None
+
+    @classmethod
+    def configurable_base(cls):
+        return IOLoop
+
+    @classmethod
+    def configurable_default(cls):
+        # this is the only patch to IOLoop:
+        from zmq.eventloop.ioloop import ZMQIOLoop
+        return ZMQIOLoop
+        if hasattr(select, "epoll"):
+            from tornado.platform.epoll import EPollIOLoop
+            return EPollIOLoop
+        if hasattr(select, "kqueue"):
+            # Python 2.6+ on BSD or Mac
+            from tornado.platform.kqueue import KQueueIOLoop
+            return KQueueIOLoop
+        from tornado.platform.select import SelectIOLoop
+        return SelectIOLoop
+
+    def initialize(self, make_current=None):
+        if make_current is None:
+            if IOLoop.current(instance=False) is None:
+                self.make_current()
+        elif make_current:
+            if IOLoop.current(instance=False) is not None:
+                raise RuntimeError("current IOLoop already exists")
+            self.make_current()
+
+    def close(self, all_fds=False):
+        """Closes the `IOLoop`, freeing any resources used.
+
+        If ``all_fds`` is true, all file descriptors registered on the
+        IOLoop will be closed (not just the ones created by the
+        `IOLoop` itself).
+
+        Many applications will only use a single `IOLoop` that runs for the
+        entire lifetime of the process.  In that case closing the `IOLoop`
+        is not necessary since everything will be cleaned up when the
+        process exits.  `IOLoop.close` is provided mainly for scenarios
+        such as unit tests, which create and destroy a large number of
+        ``IOLoops``.
+
+        An `IOLoop` must be completely stopped before it can be closed.  This
+        means that `IOLoop.stop()` must be called *and* `IOLoop.start()` must
+        be allowed to return before attempting to call `IOLoop.close()`.
+        Therefore the call to `close` will usually appear just after
+        the call to `start` rather than near the call to `stop`.
+
+        .. versionchanged:: 3.1
+           If the `IOLoop` implementation supports non-integer objects
+           for "file descriptors", those objects will have their
+           ``close`` method when ``all_fds`` is true.
+        """
+        raise NotImplementedError()
+
+    def add_handler(self, fd, handler, events):
+        """Registers the given handler to receive the given events for ``fd``.
+
+        The ``fd`` argument may either be an integer file descriptor or
+        a file-like object with a ``fileno()`` method (and optionally a
+        ``close()`` method, which may be called when the `IOLoop` is shut
+        down).
+
+        The ``events`` argument is a bitwise or of the constants
+        ``IOLoop.READ``, ``IOLoop.WRITE``, and ``IOLoop.ERROR``.
+
+        When an event occurs, ``handler(fd, events)`` will be run.
+
+        .. versionchanged:: 4.0
+           Added the ability to pass file-like objects in addition to
+           raw file descriptors.
+        """
+        raise NotImplementedError()
+
+    def update_handler(self, fd, events):
+        """Changes the events we listen for ``fd``.
+
+        .. versionchanged:: 4.0
+           Added the ability to pass file-like objects in addition to
+           raw file descriptors.
+        """
+        raise NotImplementedError()
+
+    def remove_handler(self, fd):
+        """Stop listening for events on ``fd``.
+
+        .. versionchanged:: 4.0
+           Added the ability to pass file-like objects in addition to
+           raw file descriptors.
+        """
+        raise NotImplementedError()
+
+    def set_blocking_signal_threshold(self, seconds, action):
+        """Sends a signal if the `IOLoop` is blocked for more than
+        ``s`` seconds.
+
+        Pass ``seconds=None`` to disable.  Requires Python 2.6 on a unixy
+        platform.
+
+        The action parameter is a Python signal handler.  Read the
+        documentation for the `signal` module for more information.
+        If ``action`` is None, the process will be killed if it is
+        blocked for too long.
+        """
+        raise NotImplementedError()
+
+    def set_blocking_log_threshold(self, seconds):
+        """Logs a stack trace if the `IOLoop` is blocked for more than
+        ``s`` seconds.
+
+        Equivalent to ``set_blocking_signal_threshold(seconds,
+        self.log_stack)``
+        """
+        self.set_blocking_signal_threshold(seconds, self.log_stack)
+
+    def log_stack(self, signal, frame):
+        """Signal handler to log the stack trace of the current thread.
+
+        For use with `set_blocking_signal_threshold`.
+        """
+        gen_log.warning('IOLoop blocked for %f seconds in\n%s',
+                        self._blocking_signal_threshold,
+                        ''.join(traceback.format_stack(frame)))
+
+    def start(self):
+        """Starts the I/O loop.
+
+        The loop will run until one of the callbacks calls `stop()`, which
+        will make the loop stop after the current event iteration completes.
+        """
+        raise NotImplementedError()
+
+    def _setup_logging(self):
+        """The IOLoop catches and logs exceptions, so it's
+        important that log output be visible.  However, python's
+        default behavior for non-root loggers (prior to python
+        3.2) is to print an unhelpful "no handlers could be
+        found" message rather than the actual log entry, so we
+        must explicitly configure logging if we've made it this
+        far without anything.
+
+        This method should be called from start() in subclasses.
+        """
+        if not any([logging.getLogger().handlers,
+                    logging.getLogger('tornado').handlers,
+                    logging.getLogger('tornado.application').handlers]):
+            logging.basicConfig()
+
+    def stop(self):
+        """Stop the I/O loop.
+
+        If the event loop is not currently running, the next call to `start()`
+        will return immediately.
+
+        To use asynchronous methods from otherwise-synchronous code (such as
+        unit tests), you can start and stop the event loop like this::
+
+          ioloop = IOLoop()
+          async_method(ioloop=ioloop, callback=ioloop.stop)
+          ioloop.start()
+
+        ``ioloop.start()`` will return after ``async_method`` has run
+        its callback, whether that callback was invoked before or
+        after ``ioloop.start``.
+
+        Note that even after `stop` has been called, the `IOLoop` is not
+        completely stopped until `IOLoop.start` has also returned.
+        Some work that was scheduled before the call to `stop` may still
+        be run before the `IOLoop` shuts down.
+        """
+        raise NotImplementedError()
+
+    def run_sync(self, func, timeout=None):
+        """Starts the `IOLoop`, runs the given function, and stops the loop.
+
+        The function must return either a yieldable object or
+        ``None``. If the function returns a yieldable object, the
+        `IOLoop` will run until the yieldable is resolved (and
+        `run_sync()` will return the yieldable's result). If it raises
+        an exception, the `IOLoop` will stop and the exception will be
+        re-raised to the caller.
+
+        The keyword-only argument ``timeout`` may be used to set
+        a maximum duration for the function.  If the timeout expires,
+        a `TimeoutError` is raised.
+
+        This method is useful in conjunction with `tornado.gen.coroutine`
+        to allow asynchronous calls in a ``main()`` function::
+
+            @gen.coroutine
+            def main():
+                # do stuff...
+
+            if __name__ == '__main__':
+                IOLoop.current().run_sync(main)
+
+        .. versionchanged:: 4.3
+           Returning a non-``None``, non-yieldable value is now an error.
+        """
+        future_cell = [None]
+
+        def run():
+            try:
+                result = func()
+                if result is not None:
+                    from tornado.gen import convert_yielded
+                    result = convert_yielded(result)
+            except Exception:
+                future_cell[0] = TracebackFuture()
+                future_cell[0].set_exc_info(sys.exc_info())
+            else:
+                if is_future(result):
+                    future_cell[0] = result
+                else:
+                    future_cell[0] = TracebackFuture()
+                    future_cell[0].set_result(result)
+            self.add_future(future_cell[0], lambda future: self.stop())
+        self.add_callback(run)
+        if timeout is not None:
+            timeout_handle = self.add_timeout(self.time() + timeout, self.stop)
+        self.start()
+        if timeout is not None:
+            self.remove_timeout(timeout_handle)
+        if not future_cell[0].done():
+            raise TimeoutError('Operation timed out after %s seconds' % timeout)
+        return future_cell[0].result()
+
+    def time(self):
+        """Returns the current time according to the `IOLoop`'s clock.
+
+        The return value is a floating-point number relative to an
+        unspecified time in the past.
+
+        By default, the `IOLoop`'s time function is `time.time`.  However,
+        it may be configured to use e.g. `time.monotonic` instead.
+        Calls to `add_timeout` that pass a number instead of a
+        `datetime.timedelta` should use this function to compute the
+        appropriate time, so they can work no matter what time function
+        is chosen.
+        """
+        return time.time()
+
+    def add_timeout(self, deadline, callback, *args, **kwargs):
+        """Runs the ``callback`` at the time ``deadline`` from the I/O loop.
+
+        Returns an opaque handle that may be passed to
+        `remove_timeout` to cancel.
+
+        ``deadline`` may be a number denoting a time (on the same
+        scale as `IOLoop.time`, normally `time.time`), or a
+        `datetime.timedelta` object for a deadline relative to the
+        current time.  Since Tornado 4.0, `call_later` is a more
+        convenient alternative for the relative case since it does not
+        require a timedelta object.
+
+        Note that it is not safe to call `add_timeout` from other threads.
+        Instead, you must use `add_callback` to transfer control to the
+        `IOLoop`'s thread, and then call `add_timeout` from there.
+
+        Subclasses of IOLoop must implement either `add_timeout` or
+        `call_at`; the default implementations of each will call
+        the other.  `call_at` is usually easier to implement, but
+        subclasses that wish to maintain compatibility with Tornado
+        versions prior to 4.0 must use `add_timeout` instead.
+
+        .. versionchanged:: 4.0
+           Now passes through ``*args`` and ``**kwargs`` to the callback.
+        """
+        if isinstance(deadline, numbers.Real):
+            return self.call_at(deadline, callback, *args, **kwargs)
+        elif isinstance(deadline, datetime.timedelta):
+            return self.call_at(self.time() + timedelta_to_seconds(deadline),
+                                callback, *args, **kwargs)
+        else:
+            raise TypeError("Unsupported deadline %r" % deadline)
+
+    def call_later(self, delay, callback, *args, **kwargs):
+        """Runs the ``callback`` after ``delay`` seconds have passed.
+
+        Returns an opaque handle that may be passed to `remove_timeout`
+        to cancel.  Note that unlike the `asyncio` method of the same
+        name, the returned object does not have a ``cancel()`` method.
+
+        See `add_timeout` for comments on thread-safety and subclassing.
+
+        .. versionadded:: 4.0
+        """
+        return self.call_at(self.time() + delay, callback, *args, **kwargs)
+
+    def call_at(self, when, callback, *args, **kwargs):
+        """Runs the ``callback`` at the absolute time designated by ``when``.
+
+        ``when`` must be a number using the same reference point as
+        `IOLoop.time`.
+
+        Returns an opaque handle that may be passed to `remove_timeout`
+        to cancel.  Note that unlike the `asyncio` method of the same
+        name, the returned object does not have a ``cancel()`` method.
+
+        See `add_timeout` for comments on thread-safety and subclassing.
+
+        .. versionadded:: 4.0
+        """
+        return self.add_timeout(when, callback, *args, **kwargs)
+
+    def remove_timeout(self, timeout):
+        """Cancels a pending timeout.
+
+        The argument is a handle as returned by `add_timeout`.  It is
+        safe to call `remove_timeout` even if the callback has already
+        been run.
+        """
+        raise NotImplementedError()
+
+    def add_callback(self, callback, *args, **kwargs):
+        """Calls the given callback on the next I/O loop iteration.
+
+        It is safe to call this method from any thread at any time,
+        except from a signal handler.  Note that this is the **only**
+        method in `IOLoop` that makes this thread-safety guarantee; all
+        other interaction with the `IOLoop` must be done from that
+        `IOLoop`'s thread.  `add_callback()` may be used to transfer
+        control from other threads to the `IOLoop`'s thread.
+
+        To add a callback from a signal handler, see
+        `add_callback_from_signal`.
+        """
+        raise NotImplementedError()
+
+    def add_callback_from_signal(self, callback, *args, **kwargs):
+        """Calls the given callback on the next I/O loop iteration.
+
+        Safe for use from a Python signal handler; should not be used
+        otherwise.
+
+        Callbacks added with this method will be run without any
+        `.stack_context`, to avoid picking up the context of the function
+        that was interrupted by the signal.
+        """
+        raise NotImplementedError()
+
+    def spawn_callback(self, callback, *args, **kwargs):
+        """Calls the given callback on the next IOLoop iteration.
+
+        Unlike all other callback-related methods on IOLoop,
+        ``spawn_callback`` does not associate the callback with its caller's
+        ``stack_context``, so it is suitable for fire-and-forget callbacks
+        that should not interfere with the caller.
+
+        .. versionadded:: 4.0
+        """
+        with stack_context.NullContext():
+            self.add_callback(callback, *args, **kwargs)
+
+    def add_future(self, future, callback):
+        """Schedules a callback on the ``IOLoop`` when the given
+        `.Future` is finished.
+
+        The callback is invoked with one argument, the
+        `.Future`.
+        """
+        assert is_future(future)
+        callback = stack_context.wrap(callback)
+        future.add_done_callback(
+            lambda future: self.add_callback(callback, future))
+
+    def _run_callback(self, callback):
+        """Runs a callback with error handling.
+
+        For use in subclasses.
+        """
+        try:
+            ret = callback()
+            if ret is not None:
+                from tornado import gen
+                # Functions that return Futures typically swallow all
+                # exceptions and store them in the Future.  If a Future
+                # makes it out to the IOLoop, ensure its exception (if any)
+                # gets logged too.
+                try:
+                    ret = gen.convert_yielded(ret)
+                except gen.BadYieldError:
+                    # It's not unusual for add_callback to be used with
+                    # methods returning a non-None and non-yieldable
+                    # result, which should just be ignored.
+                    pass
+                else:
+                    self.add_future(ret, lambda f: f.result())
+        except Exception:
+            self.handle_callback_exception(callback)
+
+    def handle_callback_exception(self, callback):
+        """This method is called whenever a callback run by the `IOLoop`
+        throws an exception.
+
+        By default simply logs the exception as an error.  Subclasses
+        may override this method to customize reporting of exceptions.
+
+        The exception itself is not passed explicitly, but is available
+        in `sys.exc_info`.
+        """
+        app_log.error("Exception in callback %r", callback, exc_info=True)
+
+    def split_fd(self, fd):
+        """Returns an (fd, obj) pair from an ``fd`` parameter.
+
+        We accept both raw file descriptors and file-like objects as
+        input to `add_handler` and related methods.  When a file-like
+        object is passed, we must retain the object itself so we can
+        close it correctly when the `IOLoop` shuts down, but the
+        poller interfaces favor file descriptors (they will accept
+        file-like objects and call ``fileno()`` for you, but they
+        always return the descriptor itself).
+
+        This method is provided for use by `IOLoop` subclasses and should
+        not generally be used by application code.
+
+        .. versionadded:: 4.0
+        """
+        try:
+            return fd.fileno(), fd
+        except AttributeError:
+            return fd, fd
+
+    def close_fd(self, fd):
+        """Utility method to close an ``fd``.
+
+        If ``fd`` is a file-like object, we close it directly; otherwise
+        we use `os.close`.
+
+        This method is provided for use by `IOLoop` subclasses (in
+        implementations of ``IOLoop.close(all_fds=True)`` and should
+        not generally be used by application code.
+
+        .. versionadded:: 4.0
+        """
+        try:
+            try:
+                fd.close()
+            except AttributeError:
+                os.close(fd)
+        except OSError:
+            pass
+
+
+class PollIOLoop(IOLoop):
+    """Base class for IOLoops built around a select-like function.
+
+    For concrete implementations, see `tornado.platform.epoll.EPollIOLoop`
+    (Linux), `tornado.platform.kqueue.KQueueIOLoop` (BSD and Mac), or
+    `tornado.platform.select.SelectIOLoop` (all platforms).
+    """
+    def initialize(self, impl, time_func=None, **kwargs):
+        super(PollIOLoop, self).initialize(**kwargs)
+        self._impl = impl
+        if hasattr(self._impl, 'fileno'):
+            set_close_exec(self._impl.fileno())
+        self.time_func = time_func or time.time
+        self._handlers = {}
+        self._events = {}
+        self._callbacks = []
+        self._callback_lock = threading.Lock()
+        self._timeouts = []
+        self._cancellations = 0
+        self._running = False
+        self._stopped = False
+        self._closing = False
+        self._thread_ident = None
+        self._blocking_signal_threshold = None
+        self._timeout_counter = itertools.count()
+
+        # Create a pipe that we send bogus data to when we want to wake
+        # the I/O loop when it is idle
+        self._waker = Waker()
+        self.add_handler(self._waker.fileno(),
+                         lambda fd, events: self._waker.consume(),
+                         self.READ)
+
+    def close(self, all_fds=False):
+        with self._callback_lock:
+            self._closing = True
+        self.remove_handler(self._waker.fileno())
+        if all_fds:
+            for fd, handler in self._handlers.values():
+                self.close_fd(fd)
+        self._waker.close()
+        self._impl.close()
+        self._callbacks = None
+        self._timeouts = None
+
+    def add_handler(self, fd, handler, events):
+        fd, obj = self.split_fd(fd)
+        self._handlers[fd] = (obj, stack_context.wrap(handler))
+        self._impl.register(fd, events | self.ERROR)
+
+    def update_handler(self, fd, events):
+        fd, obj = self.split_fd(fd)
+        self._impl.modify(fd, events | self.ERROR)
+
+    def remove_handler(self, fd):
+        fd, obj = self.split_fd(fd)
+        self._handlers.pop(fd, None)
+        self._events.pop(fd, None)
+        try:
+            self._impl.unregister(fd)
+        except Exception:
+            gen_log.debug("Error deleting fd from IOLoop", exc_info=True)
+
+    def set_blocking_signal_threshold(self, seconds, action):
+        if not hasattr(signal, "setitimer"):
+            gen_log.error("set_blocking_signal_threshold requires a signal module "
+                          "with the setitimer method")
+            return
+        self._blocking_signal_threshold = seconds
+        if seconds is not None:
+            signal.signal(signal.SIGALRM,
+                          action if action is not None else signal.SIG_DFL)
+
+    def start(self):
+        if self._running:
+            raise RuntimeError("IOLoop is already running")
+        self._setup_logging()
+        if self._stopped:
+            self._stopped = False
+            return
+        old_current = getattr(IOLoop._current, "instance", None)
+        IOLoop._current.instance = self
+        self._thread_ident = thread.get_ident()
+        self._running = True
+
+        # signal.set_wakeup_fd closes a race condition in event loops:
+        # a signal may arrive at the beginning of select/poll/etc
+        # before it goes into its interruptible sleep, so the signal
+        # will be consumed without waking the select.  The solution is
+        # for the (C, synchronous) signal handler to write to a pipe,
+        # which will then be seen by select.
+        #
+        # In python's signal handling semantics, this only matters on the
+        # main thread (fortunately, set_wakeup_fd only works on the main
+        # thread and will raise a ValueError otherwise).
+        #
+        # If someone has already set a wakeup fd, we don't want to
+        # disturb it.  This is an issue for twisted, which does its
+        # SIGCHLD processing in response to its own wakeup fd being
+        # written to.  As long as the wakeup fd is registered on the IOLoop,
+        # the loop will still wake up and everything should work.
+        old_wakeup_fd = None
+        if hasattr(signal, 'set_wakeup_fd') and os.name == 'posix':
+            # requires python 2.6+, unix.  set_wakeup_fd exists but crashes
+            # the python process on windows.
+            try:
+                old_wakeup_fd = signal.set_wakeup_fd(self._waker.write_fileno())
+                if old_wakeup_fd != -1:
+                    # Already set, restore previous value.  This is a little racy,
+                    # but there's no clean get_wakeup_fd and in real use the
+                    # IOLoop is just started once at the beginning.
+                    signal.set_wakeup_fd(old_wakeup_fd)
+                    old_wakeup_fd = None
+            except ValueError:
+                # Non-main thread, or the previous value of wakeup_fd
+                # is no longer valid.
+                old_wakeup_fd = None
+
+        try:
+            while True:
+                # Prevent IO event starvation by delaying new callbacks
+                # to the next iteration of the event loop.
+                with self._callback_lock:
+                    callbacks = self._callbacks
+                    self._callbacks = []
+
+                # Add any timeouts that have come due to the callback list.
+                # Do not run anything until we have determined which ones
+                # are ready, so timeouts that call add_timeout cannot
+                # schedule anything in this iteration.
+                due_timeouts = []
+                if self._timeouts:
+                    now = self.time()
+                    while self._timeouts:
+                        if self._timeouts[0].callback is None:
+                            # The timeout was cancelled.  Note that the
+                            # cancellation check is repeated below for timeouts
+                            # that are cancelled by another timeout or callback.
+                            heapq.heappop(self._timeouts)
+                            self._cancellations -= 1
+                        elif self._timeouts[0].deadline <= now:
+                            due_timeouts.append(heapq.heappop(self._timeouts))
+                        else:
+                            break
+                    if (self._cancellations > 512
+                            and self._cancellations > (len(self._timeouts) >> 1)):
+                        # Clean up the timeout queue when it gets large and it's
+                        # more than half cancellations.
+                        self._cancellations = 0
+                        self._timeouts = [x for x in self._timeouts
+                                          if x.callback is not None]
+                        heapq.heapify(self._timeouts)
+
+                for callback in callbacks:
+                    self._run_callback(callback)
+                for timeout in due_timeouts:
+                    if timeout.callback is not None:
+                        self._run_callback(timeout.callback)
+                # Closures may be holding on to a lot of memory, so allow
+                # them to be freed before we go into our poll wait.
+                callbacks = callback = due_timeouts = timeout = None
+
+                if self._callbacks:
+                    # If any callbacks or timeouts called add_callback,
+                    # we don't want to wait in poll() before we run them.
+                    poll_timeout = 0.0
+                elif self._timeouts:
+                    # If there are any timeouts, schedule the first one.
+                    # Use self.time() instead of 'now' to account for time
+                    # spent running callbacks.
+                    poll_timeout = self._timeouts[0].deadline - self.time()
+                    poll_timeout = max(0, min(poll_timeout, _POLL_TIMEOUT))
+                else:
+                    # No timeouts and no callbacks, so use the default.
+                    poll_timeout = _POLL_TIMEOUT
+
+                if not self._running:
+                    break
+
+                if self._blocking_signal_threshold is not None:
+                    # clear alarm so it doesn't fire while poll is waiting for
+                    # events.
+                    signal.setitimer(signal.ITIMER_REAL, 0, 0)
+
+                try:
+                    event_pairs = self._impl.poll(poll_timeout)
+                except Exception as e:
+                    # Depending on python version and IOLoop implementation,
+                    # different exception types may be thrown and there are
+                    # two ways EINTR might be signaled:
+                    # * e.errno == errno.EINTR
+                    # * e.args is like (errno.EINTR, 'Interrupted system call')
+                    if errno_from_exception(e) == errno.EINTR:
+                        continue
+                    else:
+                        raise
+
+                if self._blocking_signal_threshold is not None:
+                    signal.setitimer(signal.ITIMER_REAL,
+                                     self._blocking_signal_threshold, 0)
+
+                # Pop one fd at a time from the set of pending fds and run
+                # its handler. Since that handler may perform actions on
+                # other file descriptors, there may be reentrant calls to
+                # this IOLoop that update self._events
+                self._events.update(event_pairs)
+                while self._events:
+                    fd, events = self._events.popitem()
+                    try:
+                        fd_obj, handler_func = self._handlers[fd]
+                        handler_func(fd_obj, events)
+                    except (OSError, IOError) as e:
+                        if errno_from_exception(e) == errno.EPIPE:
+                            # Happens when the client closes the connection
+                            pass
+                        else:
+                            self.handle_callback_exception(self._handlers.get(fd))
+                    except Exception:
+                        self.handle_callback_exception(self._handlers.get(fd))
+                fd_obj = handler_func = None
+
+        finally:
+            # reset the stopped flag so another start/stop pair can be issued
+            self._stopped = False
+            if self._blocking_signal_threshold is not None:
+                signal.setitimer(signal.ITIMER_REAL, 0, 0)
+            IOLoop._current.instance = old_current
+            if old_wakeup_fd is not None:
+                signal.set_wakeup_fd(old_wakeup_fd)
+
+    def stop(self):
+        self._running = False
+        self._stopped = True
+        self._waker.wake()
+
+    def time(self):
+        return self.time_func()
+
+    def call_at(self, deadline, callback, *args, **kwargs):
+        timeout = _Timeout(
+            deadline,
+            functools.partial(stack_context.wrap(callback), *args, **kwargs),
+            self)
+        heapq.heappush(self._timeouts, timeout)
+        return timeout
+
+    def remove_timeout(self, timeout):
+        # Removing from a heap is complicated, so just leave the defunct
+        # timeout object in the queue (see discussion in
+        # http://docs.python.org/library/heapq.html).
+        # If this turns out to be a problem, we could add a garbage
+        # collection pass whenever there are too many dead timeouts.
+        timeout.callback = None
+        self._cancellations += 1
+
+    def add_callback(self, callback, *args, **kwargs):
+        if thread.get_ident() != self._thread_ident:
+            # If we're not on the IOLoop's thread, we need to synchronize
+            # with other threads, or waking logic will induce a race.
+            with self._callback_lock:
+                if self._closing:
+                    return
+                list_empty = not self._callbacks
+                self._callbacks.append(functools.partial(
+                    stack_context.wrap(callback), *args, **kwargs))
+                if list_empty:
+                    # If we're not in the IOLoop's thread, and we added the
+                    # first callback to an empty list, we may need to wake it
+                    # up (it may wake up on its own, but an occasional extra
+                    # wake is harmless).  Waking up a polling IOLoop is
+                    # relatively expensive, so we try to avoid it when we can.
+                    self._waker.wake()
+        else:
+            if self._closing:
+                return
+            # If we're on the IOLoop's thread, we don't need the lock,
+            # since we don't need to wake anyone, just add the
+            # callback. Blindly insert into self._callbacks. This is
+            # safe even from signal handlers because the GIL makes
+            # list.append atomic. One subtlety is that if the signal
+            # is interrupting another thread holding the
+            # _callback_lock block in IOLoop.start, we may modify
+            # either the old or new version of self._callbacks, but
+            # either way will work.
+            self._callbacks.append(functools.partial(
+                stack_context.wrap(callback), *args, **kwargs))
+
+    def add_callback_from_signal(self, callback, *args, **kwargs):
+        with stack_context.NullContext():
+            self.add_callback(callback, *args, **kwargs)
+
+
+class _Timeout(object):
+    """An IOLoop timeout, a UNIX timestamp and a callback"""
+
+    # Reduce memory overhead when there are lots of pending callbacks
+    __slots__ = ['deadline', 'callback', 'tiebreaker']
+
+    def __init__(self, deadline, callback, io_loop):
+        if not isinstance(deadline, numbers.Real):
+            raise TypeError("Unsupported deadline %r" % deadline)
+        self.deadline = deadline
+        self.callback = callback
+        self.tiebreaker = next(io_loop._timeout_counter)
+
+    # Comparison methods to sort by deadline, with object id as a tiebreaker
+    # to guarantee a consistent ordering.  The heapq module uses __le__
+    # in python2.5, and __lt__ in 2.6+ (sort() and most other comparisons
+    # use __lt__).
+    def __lt__(self, other):
+        return ((self.deadline, self.tiebreaker) <
+                (other.deadline, other.tiebreaker))
+
+    def __le__(self, other):
+        return ((self.deadline, self.tiebreaker) <=
+                (other.deadline, other.tiebreaker))
+
+
+class PeriodicCallback(object):
+    """Schedules the given callback to be called periodically.
+
+    The callback is called every ``callback_time`` milliseconds.
+    Note that the timeout is given in milliseconds, while most other
+    time-related functions in Tornado use seconds.
+
+    If the callback runs for longer than ``callback_time`` milliseconds,
+    subsequent invocations will be skipped to get back on schedule.
+
+    `start` must be called after the `PeriodicCallback` is created.
+
+    .. versionchanged:: 4.1
+       The ``io_loop`` argument is deprecated.
+    """
+    def __init__(self, callback, callback_time, io_loop=None):
+        self.callback = callback
+        if callback_time <= 0:
+            raise ValueError("Periodic callback must have a positive callback_time")
+        self.callback_time = callback_time
+        self.io_loop = io_loop or IOLoop.current()
+        self._running = False
+        self._timeout = None
+
+    def start(self):
+        """Starts the timer."""
+        self._running = True
+        self._next_timeout = self.io_loop.time()
+        self._schedule_next()
+
+    def stop(self):
+        """Stops the timer."""
+        self._running = False
+        if self._timeout is not None:
+            self.io_loop.remove_timeout(self._timeout)
+            self._timeout = None
+
+    def is_running(self):
+        """Return True if this `.PeriodicCallback` has been started.
+
+        .. versionadded:: 4.1
+        """
+        return self._running
+
+    def _run(self):
+        if not self._running:
+            return
+        try:
+            return self.callback()
+        except Exception:
+            self.io_loop.handle_callback_exception(self.callback)
+        finally:
+            self._schedule_next()
+
+    def _schedule_next(self):
+        if self._running:
+            current_time = self.io_loop.time()
+
+            if self._next_timeout <= current_time:
+                callback_time_sec = self.callback_time / 1000.0
+                self._next_timeout += (math.floor((current_time - self._next_timeout) / callback_time_sec) + 1) * callback_time_sec
+
+            self._timeout = self.io_loop.add_timeout(self._next_timeout, self._run)

--- a/zmq/eventloop/minitornado/log.py
+++ b/zmq/eventloop/minitornado/log.py
@@ -1,0 +1,6 @@
+"""minimal subset of tornado.log for zmq.eventloop.minitornado"""
+
+import logging
+
+app_log = logging.getLogger("tornado.application")
+gen_log = logging.getLogger("tornado.general")

--- a/zmq/eventloop/minitornado/platform/auto.py
+++ b/zmq/eventloop/minitornado/platform/auto.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#
+# Copyright 2011 Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Implementation of platform-specific functionality.
+
+For each function or class described in `tornado.platform.interface`,
+the appropriate platform-specific implementation exists in this module.
+Most code that needs access to this functionality should do e.g.::
+
+    from tornado.platform.auto import set_close_exec
+"""
+
+from __future__ import absolute_import, division, print_function, with_statement
+
+import os
+
+if os.name == 'nt':
+    from .common import Waker
+    from .windows import set_close_exec
+else:
+    from .posix import set_close_exec, Waker
+
+try:
+    # monotime monkey-patches the time module to have a monotonic function
+    # in versions of python before 3.3.
+    import monotime
+except ImportError:
+    pass
+try:
+    from time import monotonic as monotonic_time
+except ImportError:
+    monotonic_time = None

--- a/zmq/eventloop/minitornado/platform/common.py
+++ b/zmq/eventloop/minitornado/platform/common.py
@@ -1,0 +1,91 @@
+"""Lowest-common-denominator implementations of platform functionality."""
+from __future__ import absolute_import, division, print_function, with_statement
+
+import errno
+import socket
+
+from . import interface
+
+
+class Waker(interface.Waker):
+    """Create an OS independent asynchronous pipe.
+
+    For use on platforms that don't have os.pipe() (or where pipes cannot
+    be passed to select()), but do have sockets.  This includes Windows
+    and Jython.
+    """
+    def __init__(self):
+        # Based on Zope async.py: http://svn.zope.org/zc.ngi/trunk/src/zc/ngi/async.py
+
+        self.writer = socket.socket()
+        # Disable buffering -- pulling the trigger sends 1 byte,
+        # and we want that sent immediately, to wake up ASAP.
+        self.writer.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+        count = 0
+        while 1:
+            count += 1
+            # Bind to a local port; for efficiency, let the OS pick
+            # a free port for us.
+            # Unfortunately, stress tests showed that we may not
+            # be able to connect to that port ("Address already in
+            # use") despite that the OS picked it.  This appears
+            # to be a race bug in the Windows socket implementation.
+            # So we loop until a connect() succeeds (almost always
+            # on the first try).  See the long thread at
+            # http://mail.zope.org/pipermail/zope/2005-July/160433.html
+            # for hideous details.
+            a = socket.socket()
+            a.bind(("127.0.0.1", 0))
+            a.listen(1)
+            connect_address = a.getsockname()  # assigned (host, port) pair
+            try:
+                self.writer.connect(connect_address)
+                break    # success
+            except socket.error as detail:
+                if (not hasattr(errno, 'WSAEADDRINUSE') or
+                        detail[0] != errno.WSAEADDRINUSE):
+                    # "Address already in use" is the only error
+                    # I've seen on two WinXP Pro SP2 boxes, under
+                    # Pythons 2.3.5 and 2.4.1.
+                    raise
+                # (10048, 'Address already in use')
+                # assert count <= 2 # never triggered in Tim's tests
+                if count >= 10:  # I've never seen it go above 2
+                    a.close()
+                    self.writer.close()
+                    raise socket.error("Cannot bind trigger!")
+                # Close `a` and try again.  Note:  I originally put a short
+                # sleep() here, but it didn't appear to help or hurt.
+                a.close()
+
+        self.reader, addr = a.accept()
+        self.reader.setblocking(0)
+        self.writer.setblocking(0)
+        a.close()
+        self.reader_fd = self.reader.fileno()
+
+    def fileno(self):
+        return self.reader.fileno()
+
+    def write_fileno(self):
+        return self.writer.fileno()
+
+    def wake(self):
+        try:
+            self.writer.send(b"x")
+        except (IOError, socket.error):
+            pass
+
+    def consume(self):
+        try:
+            while True:
+                result = self.reader.recv(1024)
+                if not result:
+                    break
+        except (IOError, socket.error):
+            pass
+
+    def close(self):
+        self.reader.close()
+        self.writer.close()

--- a/zmq/eventloop/minitornado/platform/interface.py
+++ b/zmq/eventloop/minitornado/platform/interface.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#
+# Copyright 2011 Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Interfaces for platform-specific functionality.
+
+This module exists primarily for documentation purposes and as base classes
+for other tornado.platform modules.  Most code should import the appropriate
+implementation from `tornado.platform.auto`.
+"""
+
+from __future__ import absolute_import, division, print_function, with_statement
+
+
+def set_close_exec(fd):
+    """Sets the close-on-exec bit (``FD_CLOEXEC``)for a file descriptor."""
+    raise NotImplementedError()
+
+
+class Waker(object):
+    """A socket-like object that can wake another thread from ``select()``.
+
+    The `~tornado.ioloop.IOLoop` will add the Waker's `fileno()` to
+    its ``select`` (or ``epoll`` or ``kqueue``) calls.  When another
+    thread wants to wake up the loop, it calls `wake`.  Once it has woken
+    up, it will call `consume` to do any necessary per-wake cleanup.  When
+    the ``IOLoop`` is closed, it closes its waker too.
+    """
+    def fileno(self):
+        """Returns the read file descriptor for this waker.
+
+        Must be suitable for use with ``select()`` or equivalent on the
+        local platform.
+        """
+        raise NotImplementedError()
+
+    def write_fileno(self):
+        """Returns the write file descriptor for this waker."""
+        raise NotImplementedError()
+
+    def wake(self):
+        """Triggers activity on the waker's file descriptor."""
+        raise NotImplementedError()
+
+    def consume(self):
+        """Called after the listen has woken up to do any necessary cleanup."""
+        raise NotImplementedError()
+
+    def close(self):
+        """Closes the waker's file descriptor(s)."""
+        raise NotImplementedError()

--- a/zmq/eventloop/minitornado/platform/posix.py
+++ b/zmq/eventloop/minitornado/platform/posix.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Copyright 2011 Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Posix implementations of platform-specific functionality."""
+
+from __future__ import absolute_import, division, print_function, with_statement
+
+import fcntl
+import os
+
+from . import interface
+
+
+def set_close_exec(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+    fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
+
+
+def _set_nonblocking(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+
+class Waker(interface.Waker):
+    def __init__(self):
+        r, w = os.pipe()
+        _set_nonblocking(r)
+        _set_nonblocking(w)
+        set_close_exec(r)
+        set_close_exec(w)
+        self.reader = os.fdopen(r, "rb", 0)
+        self.writer = os.fdopen(w, "wb", 0)
+
+    def fileno(self):
+        return self.reader.fileno()
+
+    def write_fileno(self):
+        return self.writer.fileno()
+
+    def wake(self):
+        try:
+            self.writer.write(b"x")
+        except IOError:
+            pass
+
+    def consume(self):
+        try:
+            while True:
+                result = self.reader.read()
+                if not result:
+                    break
+        except IOError:
+            pass
+
+    def close(self):
+        self.reader.close()
+        self.writer.close()

--- a/zmq/eventloop/minitornado/platform/windows.py
+++ b/zmq/eventloop/minitornado/platform/windows.py
@@ -1,0 +1,20 @@
+# NOTE: win32 support is currently experimental, and not recommended
+# for production use.
+
+
+from __future__ import absolute_import, division, print_function, with_statement
+import ctypes
+import ctypes.wintypes
+
+# See: http://msdn.microsoft.com/en-us/library/ms724935(VS.85).aspx
+SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation
+SetHandleInformation.argtypes = (ctypes.wintypes.HANDLE, ctypes.wintypes.DWORD, ctypes.wintypes.DWORD)
+SetHandleInformation.restype = ctypes.wintypes.BOOL
+
+HANDLE_FLAG_INHERIT = 0x00000001
+
+
+def set_close_exec(fd):
+    success = SetHandleInformation(fd, HANDLE_FLAG_INHERIT, 0)
+    if not success:
+        raise ctypes.GetLastError()

--- a/zmq/eventloop/minitornado/stack_context.py
+++ b/zmq/eventloop/minitornado/stack_context.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python
+#
+# Copyright 2010 Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""`StackContext` allows applications to maintain threadlocal-like state
+that follows execution as it moves to other execution contexts.
+
+The motivating examples are to eliminate the need for explicit
+``async_callback`` wrappers (as in `tornado.web.RequestHandler`), and to
+allow some additional context to be kept for logging.
+
+This is slightly magic, but it's an extension of the idea that an
+exception handler is a kind of stack-local state and when that stack
+is suspended and resumed in a new context that state needs to be
+preserved.  `StackContext` shifts the burden of restoring that state
+from each call site (e.g.  wrapping each `.AsyncHTTPClient` callback
+in ``async_callback``) to the mechanisms that transfer control from
+one context to another (e.g. `.AsyncHTTPClient` itself, `.IOLoop`,
+thread pools, etc).
+
+Example usage::
+
+    @contextlib.contextmanager
+    def die_on_error():
+        try:
+            yield
+        except Exception:
+            logging.error("exception in asynchronous operation",exc_info=True)
+            sys.exit(1)
+
+    with StackContext(die_on_error):
+        # Any exception thrown here *or in callback and its descendants*
+        # will cause the process to exit instead of spinning endlessly
+        # in the ioloop.
+        http_client.fetch(url, callback)
+    ioloop.start()
+
+Most applications shouldn't have to work with `StackContext` directly.
+Here are a few rules of thumb for when it's necessary:
+
+* If you're writing an asynchronous library that doesn't rely on a
+  stack_context-aware library like `tornado.ioloop` or `tornado.iostream`
+  (for example, if you're writing a thread pool), use
+  `.stack_context.wrap()` before any asynchronous operations to capture the
+  stack context from where the operation was started.
+
+* If you're writing an asynchronous library that has some shared
+  resources (such as a connection pool), create those shared resources
+  within a ``with stack_context.NullContext():`` block.  This will prevent
+  ``StackContexts`` from leaking from one request to another.
+
+* If you want to write something like an exception handler that will
+  persist across asynchronous calls, create a new `StackContext` (or
+  `ExceptionStackContext`), and make your asynchronous calls in a ``with``
+  block that references your `StackContext`.
+"""
+
+from __future__ import absolute_import, division, print_function, with_statement
+
+import sys
+import threading
+
+from .util import raise_exc_info
+
+
+class StackContextInconsistentError(Exception):
+    pass
+
+
+class _State(threading.local):
+    def __init__(self):
+        self.contexts = (tuple(), None)
+_state = _State()
+
+
+class StackContext(object):
+    """Establishes the given context as a StackContext that will be transferred.
+
+    Note that the parameter is a callable that returns a context
+    manager, not the context itself.  That is, where for a
+    non-transferable context manager you would say::
+
+      with my_context():
+
+    StackContext takes the function itself rather than its result::
+
+      with StackContext(my_context):
+
+    The result of ``with StackContext() as cb:`` is a deactivation
+    callback.  Run this callback when the StackContext is no longer
+    needed to ensure that it is not propagated any further (note that
+    deactivating a context does not affect any instances of that
+    context that are currently pending).  This is an advanced feature
+    and not necessary in most applications.
+    """
+    def __init__(self, context_factory):
+        self.context_factory = context_factory
+        self.contexts = []
+        self.active = True
+
+    def _deactivate(self):
+        self.active = False
+
+    # StackContext protocol
+    def enter(self):
+        context = self.context_factory()
+        self.contexts.append(context)
+        context.__enter__()
+
+    def exit(self, type, value, traceback):
+        context = self.contexts.pop()
+        context.__exit__(type, value, traceback)
+
+    # Note that some of this code is duplicated in ExceptionStackContext
+    # below.  ExceptionStackContext is more common and doesn't need
+    # the full generality of this class.
+    def __enter__(self):
+        self.old_contexts = _state.contexts
+        self.new_contexts = (self.old_contexts[0] + (self,), self)
+        _state.contexts = self.new_contexts
+
+        try:
+            self.enter()
+        except:
+            _state.contexts = self.old_contexts
+            raise
+
+        return self._deactivate
+
+    def __exit__(self, type, value, traceback):
+        try:
+            self.exit(type, value, traceback)
+        finally:
+            final_contexts = _state.contexts
+            _state.contexts = self.old_contexts
+
+            # Generator coroutines and with-statements with non-local
+            # effects interact badly.  Check here for signs of
+            # the stack getting out of sync.
+            # Note that this check comes after restoring _state.context
+            # so that if it fails things are left in a (relatively)
+            # consistent state.
+            if final_contexts is not self.new_contexts:
+                raise StackContextInconsistentError(
+                    'stack_context inconsistency (may be caused by yield '
+                    'within a "with StackContext" block)')
+
+            # Break up a reference to itself to allow for faster GC on CPython.
+            self.new_contexts = None
+
+
+class ExceptionStackContext(object):
+    """Specialization of StackContext for exception handling.
+
+    The supplied ``exception_handler`` function will be called in the
+    event of an uncaught exception in this context.  The semantics are
+    similar to a try/finally clause, and intended use cases are to log
+    an error, close a socket, or similar cleanup actions.  The
+    ``exc_info`` triple ``(type, value, traceback)`` will be passed to the
+    exception_handler function.
+
+    If the exception handler returns true, the exception will be
+    consumed and will not be propagated to other exception handlers.
+    """
+    def __init__(self, exception_handler):
+        self.exception_handler = exception_handler
+        self.active = True
+
+    def _deactivate(self):
+        self.active = False
+
+    def exit(self, type, value, traceback):
+        if type is not None:
+            return self.exception_handler(type, value, traceback)
+
+    def __enter__(self):
+        self.old_contexts = _state.contexts
+        self.new_contexts = (self.old_contexts[0], self)
+        _state.contexts = self.new_contexts
+
+        return self._deactivate
+
+    def __exit__(self, type, value, traceback):
+        try:
+            if type is not None:
+                return self.exception_handler(type, value, traceback)
+        finally:
+            final_contexts = _state.contexts
+            _state.contexts = self.old_contexts
+
+            if final_contexts is not self.new_contexts:
+                raise StackContextInconsistentError(
+                    'stack_context inconsistency (may be caused by yield '
+                    'within a "with StackContext" block)')
+
+            # Break up a reference to itself to allow for faster GC on CPython.
+            self.new_contexts = None
+
+
+class NullContext(object):
+    """Resets the `StackContext`.
+
+    Useful when creating a shared resource on demand (e.g. an
+    `.AsyncHTTPClient`) where the stack that caused the creating is
+    not relevant to future operations.
+    """
+    def __enter__(self):
+        self.old_contexts = _state.contexts
+        _state.contexts = (tuple(), None)
+
+    def __exit__(self, type, value, traceback):
+        _state.contexts = self.old_contexts
+
+
+def _remove_deactivated(contexts):
+    """Remove deactivated handlers from the chain"""
+    # Clean ctx handlers
+    stack_contexts = tuple([h for h in contexts[0] if h.active])
+
+    # Find new head
+    head = contexts[1]
+    while head is not None and not head.active:
+        head = head.old_contexts[1]
+
+    # Process chain
+    ctx = head
+    while ctx is not None:
+        parent = ctx.old_contexts[1]
+
+        while parent is not None:
+            if parent.active:
+                break
+            ctx.old_contexts = parent.old_contexts
+            parent = parent.old_contexts[1]
+
+        ctx = parent
+
+    return (stack_contexts, head)
+
+
+def wrap(fn):
+    """Returns a callable object that will restore the current `StackContext`
+    when executed.
+
+    Use this whenever saving a callback to be executed later in a
+    different execution context (either in a different thread or
+    asynchronously in the same thread).
+    """
+    # Check if function is already wrapped
+    if fn is None or hasattr(fn, '_wrapped'):
+        return fn
+
+    # Capture current stack head
+    # TODO: Any other better way to store contexts and update them in wrapped function?
+    cap_contexts = [_state.contexts]
+
+    if not cap_contexts[0][0] and not cap_contexts[0][1]:
+        # Fast path when there are no active contexts.
+        def null_wrapper(*args, **kwargs):
+            try:
+                current_state = _state.contexts
+                _state.contexts = cap_contexts[0]
+                return fn(*args, **kwargs)
+            finally:
+                _state.contexts = current_state
+        null_wrapper._wrapped = True
+        return null_wrapper
+
+    def wrapped(*args, **kwargs):
+        ret = None
+        try:
+            # Capture old state
+            current_state = _state.contexts
+
+            # Remove deactivated items
+            cap_contexts[0] = contexts = _remove_deactivated(cap_contexts[0])
+
+            # Force new state
+            _state.contexts = contexts
+
+            # Current exception
+            exc = (None, None, None)
+            top = None
+
+            # Apply stack contexts
+            last_ctx = 0
+            stack = contexts[0]
+
+            # Apply state
+            for n in stack:
+                try:
+                    n.enter()
+                    last_ctx += 1
+                except:
+                    # Exception happened. Record exception info and store top-most handler
+                    exc = sys.exc_info()
+                    top = n.old_contexts[1]
+
+            # Execute callback if no exception happened while restoring state
+            if top is None:
+                try:
+                    ret = fn(*args, **kwargs)
+                except:
+                    exc = sys.exc_info()
+                    top = contexts[1]
+
+            # If there was exception, try to handle it by going through the exception chain
+            if top is not None:
+                exc = _handle_exception(top, exc)
+            else:
+                # Otherwise take shorter path and run stack contexts in reverse order
+                while last_ctx > 0:
+                    last_ctx -= 1
+                    c = stack[last_ctx]
+
+                    try:
+                        c.exit(*exc)
+                    except:
+                        exc = sys.exc_info()
+                        top = c.old_contexts[1]
+                        break
+                else:
+                    top = None
+
+                # If if exception happened while unrolling, take longer exception handler path
+                if top is not None:
+                    exc = _handle_exception(top, exc)
+
+            # If exception was not handled, raise it
+            if exc != (None, None, None):
+                raise_exc_info(exc)
+        finally:
+            _state.contexts = current_state
+        return ret
+
+    wrapped._wrapped = True
+    return wrapped
+
+
+def _handle_exception(tail, exc):
+    while tail is not None:
+        try:
+            if tail.exit(*exc):
+                exc = (None, None, None)
+        except:
+            exc = sys.exc_info()
+
+        tail = tail.old_contexts[1]
+
+    return exc
+
+
+def run_with_stack_context(context, func):
+    """Run a coroutine ``func`` in the given `StackContext`.
+
+    It is not safe to have a ``yield`` statement within a ``with StackContext``
+    block, so it is difficult to use stack context with `.gen.coroutine`.
+    This helper function runs the function in the correct context while
+    keeping the ``yield`` and ``with`` statements syntactically separate.
+
+    Example::
+
+        @gen.coroutine
+        def incorrect():
+            with StackContext(ctx):
+                # ERROR: this will raise StackContextInconsistentError
+                yield other_coroutine()
+
+        @gen.coroutine
+        def correct():
+            yield run_with_stack_context(StackContext(ctx), other_coroutine)
+
+    .. versionadded:: 3.1
+    """
+    with context:
+        return func()

--- a/zmq/eventloop/minitornado/util.py
+++ b/zmq/eventloop/minitornado/util.py
@@ -1,0 +1,216 @@
+"""Miscellaneous utility functions and classes.
+
+This module is used internally by Tornado.  It is not necessarily expected
+that the functions and classes defined here will be useful to other
+applications, but they are documented here in case they are.
+
+The one public-facing part of this module is the `Configurable` class
+and its `~Configurable.configure` method, which becomes a part of the
+interface of its subclasses, including `.AsyncHTTPClient`, `.IOLoop`,
+and `.Resolver`.
+"""
+
+from __future__ import absolute_import, division, print_function, with_statement
+
+import sys
+
+
+# Fake unicode literal support:  Python 3.2 doesn't have the u'' marker for
+# literal strings, and alternative solutions like "from __future__ import
+# unicode_literals" have other problems (see PEP 414).  u() can be applied
+# to ascii strings that include \u escapes (but they must not contain
+# literal non-ascii characters).
+if not isinstance(b'', type('')):
+    def u(s):
+        return s
+    unicode_type = str
+    basestring_type = str
+else:
+    def u(s):
+        return s.decode('unicode_escape')
+    # These names don't exist in py3, so use noqa comments to disable
+    # warnings in flake8.
+    unicode_type = unicode  # noqa
+    basestring_type = basestring  # noqa
+
+
+def import_object(name):
+    """Imports an object by name.
+
+    import_object('x') is equivalent to 'import x'.
+    import_object('x.y.z') is equivalent to 'from x.y import z'.
+
+    >>> import tornado.escape
+    >>> import_object('tornado.escape') is tornado.escape
+    True
+    >>> import_object('tornado.escape.utf8') is tornado.escape.utf8
+    True
+    >>> import_object('tornado') is tornado
+    True
+    >>> import_object('tornado.missing_module')
+    Traceback (most recent call last):
+        ...
+    ImportError: No module named missing_module
+    """
+    if isinstance(name, unicode_type) and str is not unicode_type:
+        # On python 2 a byte string is required.
+        name = name.encode('utf-8')
+    if name.count('.') == 0:
+        return __import__(name, None, None)
+
+    parts = name.split('.')
+    obj = __import__('.'.join(parts[:-1]), None, None, [parts[-1]], 0)
+    try:
+        return getattr(obj, parts[-1])
+    except AttributeError:
+        raise ImportError("No module named %s" % parts[-1])
+
+
+# Deprecated alias that was used before we dropped py25 support.
+# Left here in case anyone outside Tornado is using it.
+bytes_type = bytes
+
+if sys.version_info > (3,):
+    exec("""
+def raise_exc_info(exc_info):
+    raise exc_info[1].with_traceback(exc_info[2])
+
+def exec_in(code, glob, loc=None):
+    if isinstance(code, str):
+        code = compile(code, '<string>', 'exec', dont_inherit=True)
+    exec(code, glob, loc)
+""")
+else:
+    exec("""
+def raise_exc_info(exc_info):
+    raise exc_info[0], exc_info[1], exc_info[2]
+
+def exec_in(code, glob, loc=None):
+    if isinstance(code, basestring):
+        # exec(string) inherits the caller's future imports; compile
+        # the string first to prevent that.
+        code = compile(code, '<string>', 'exec', dont_inherit=True)
+    exec code in glob, loc
+""")
+
+
+def errno_from_exception(e):
+    """Provides the errno from an Exception object.
+
+    There are cases that the errno attribute was not set so we pull
+    the errno out of the args but if someone instantiates an Exception
+    without any args you will get a tuple error. So this function
+    abstracts all that behavior to give you a safe way to get the
+    errno.
+    """
+
+    if hasattr(e, 'errno'):
+        return e.errno
+    elif e.args:
+        return e.args[0]
+    else:
+        return None
+
+
+class Configurable(object):
+    """Base class for configurable interfaces.
+
+    A configurable interface is an (abstract) class whose constructor
+    acts as a factory function for one of its implementation subclasses.
+    The implementation subclass as well as optional keyword arguments to
+    its initializer can be set globally at runtime with `configure`.
+
+    By using the constructor as the factory method, the interface
+    looks like a normal class, `isinstance` works as usual, etc.  This
+    pattern is most useful when the choice of implementation is likely
+    to be a global decision (e.g. when `~select.epoll` is available,
+    always use it instead of `~select.select`), or when a
+    previously-monolithic class has been split into specialized
+    subclasses.
+
+    Configurable subclasses must define the class methods
+    `configurable_base` and `configurable_default`, and use the instance
+    method `initialize` instead of ``__init__``.
+    """
+    __impl_class = None
+    __impl_kwargs = None
+
+    def __new__(cls, *args, **kwargs):
+        base = cls.configurable_base()
+        init_kwargs = {}
+        if cls is base:
+            impl = cls.configured_class()
+            if base.__impl_kwargs:
+                init_kwargs.update(base.__impl_kwargs)
+        else:
+            impl = cls
+        init_kwargs.update(kwargs)
+        instance = super(Configurable, cls).__new__(impl)
+        # initialize vs __init__ chosen for compatibility with AsyncHTTPClient
+        # singleton magic.  If we get rid of that we can switch to __init__
+        # here too.
+        instance.initialize(*args, **init_kwargs)
+        return instance
+
+    @classmethod
+    def configurable_base(cls):
+        """Returns the base class of a configurable hierarchy.
+
+        This will normally return the class in which it is defined.
+        (which is *not* necessarily the same as the cls classmethod parameter).
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def configurable_default(cls):
+        """Returns the implementation class to be used if none is configured."""
+        raise NotImplementedError()
+
+    def initialize(self):
+        """Initialize a `Configurable` subclass instance.
+
+        Configurable classes should use `initialize` instead of ``__init__``.
+
+        .. versionchanged:: 4.2
+           Now accepts positional arguments in addition to keyword arguments.
+        """
+
+    @classmethod
+    def configure(cls, impl, **kwargs):
+        """Sets the class to use when the base class is instantiated.
+
+        Keyword arguments will be saved and added to the arguments passed
+        to the constructor.  This can be used to set global defaults for
+        some parameters.
+        """
+        base = cls.configurable_base()
+        if isinstance(impl, (unicode_type, bytes)):
+            impl = import_object(impl)
+        if impl is not None and not issubclass(impl, cls):
+            raise ValueError("Invalid subclass of %s" % cls)
+        base.__impl_class = impl
+        base.__impl_kwargs = kwargs
+
+    @classmethod
+    def configured_class(cls):
+        """Returns the currently configured class."""
+        base = cls.configurable_base()
+        if cls.__impl_class is None:
+            base.__impl_class = cls.configurable_default()
+        return base.__impl_class
+
+    @classmethod
+    def _save_configuration(cls):
+        base = cls.configurable_base()
+        return (base.__impl_class, base.__impl_kwargs)
+
+    @classmethod
+    def _restore_configuration(cls, saved):
+        base = cls.configurable_base()
+        base.__impl_class = saved[0]
+        base.__impl_kwargs = saved[1]
+
+
+def timedelta_to_seconds(td):
+    """Equivalent to td.total_seconds() (introduced in python 2.7)."""
+    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / float(10 ** 6)

--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -34,10 +34,12 @@ try:
 except ImportError:
     import pickle
 
-from tornado.ioloop import IOLoop
+from .ioloop import IOLoop, gen_log
 
-from tornado.log import gen_log
-from tornado import stack_context
+try:
+    from tornado import stack_context
+except ImportError:
+    from .minitornado import stack_context
 
 try:
     from queue import Queue


### PR DESCRIPTION
Add VisibleDeprecationWarning pointing to 14.0, which is the version at which zmq.eventloop started preferring 'real' tornado.

closes #1121