### PR TITLE
use asyncio.ensure_future instead of deprecated asyncio.async

### DIFF
--- a/zmq/auth/asyncio/__init__.py
+++ b/zmq/auth/asyncio/__init__.py
@@ -35,7 +35,7 @@ class AsyncioAuthenticator(Authenticator):
         super().start()
         self.__poller = Poller()
         self.__poller.register(self.zap_socket, zmq.POLLIN)
-        self.__task = asyncio.async(self.__handle_zap())
+        self.__task = asyncio.ensure_future(self.__handle_zap())
 
     def stop(self):
         """Stop ZAP authentication"""


### PR DESCRIPTION
deprecated since 3.4.4

asyncio.async will become invalid syntax in Python 3.7