### PR TITLE
Revert PR #951

### DIFF
--- a/zmq/green/core.py
+++ b/zmq/green/core.py
@@ -276,10 +276,7 @@ class _Socket(_original_Socket):
         """set socket option"""
         if opt in TIMEOS:
             warnings.warn("TIMEO socket options have no effect in zmq.green", UserWarning)
-        result = super(_Socket, self).set(opt, val)
-        if opt in (zmq.SUBSCRIBE, zmq.UNSUBSCRIBE):
-            self.__state_changed()
-        return result
+        return super(_Socket, self).set(opt, val)
 
 
 class _Context(_original_Context):

--- a/zmq/tests/test_pubsub.py
+++ b/zmq/tests/test_pubsub.py
@@ -39,40 +39,4 @@ class TestPubSub(BaseZMQTestCase):
 
 if have_gevent:
     class TestPubSubGreen(GreenTest, TestPubSub):
-
-        def create_sub(self, interface='tcp://127.0.0.1'):
-            sub = self.context.socket(zmq.SUB)
-            sub.setsockopt(zmq.LINGER, 0)
-            port = sub.bind_to_random_port(interface)
-            addr = '%s:%s' % (interface, port)
-            return sub, addr
-
-        def test_sigabrt_issue(self, random=Random(42)):
-            import gevent
-            pub = self.context.socket(zmq.PUB)
-            pub.setsockopt(zmq.LINGER, 0)
-            self.sockets.append(pub)
-            topics = [str(random.random())[2:] for x in range(10000)]
-            def workload(sub):
-                subscribed = set()
-                # Many subscriptions, for example above 5000, are
-                # raising up reproducibility of the crash.
-                for x in range(10000):
-                    if not subscribed or random.random() < 0.9:
-                        topic = random.choice(topics)
-                        subscribed.add(topic)
-                        sub.set(zmq.SUBSCRIBE, topic)
-                    else:
-                        topic = random.choice(list(subscribed))
-                        subscribed.remove(topic)
-                        sub.set(zmq.UNSUBSCRIBE, topic)
-                    # Sleeping with gevent for 0 seconds is necessary
-                    # to reproduce the crash.
-                    gevent.sleep(0)
-            for x in range(3):
-                sub, addr = self.create_sub()
-                pub.connect(addr)
-                workload(sub)
-                # Only SUB socket closes.  If PUB socket disconnects,
-                # the crash won't be reproduced.
-                sub.close()
+        pass


### PR DESCRIPTION
We've talked about it at https://github.com/zeromq/pyzmq/pull/1141.

There is a crash issue on PUB/SUB sockets.  The bug is at libzmq not PyZMQ.  It is reported at https://github.com/zeromq/libzmq/issues/2942.  When I worked on https://github.com/zeromq/pyzmq/pull/951, I thought it is PyZMQ's thread-unsafety issue.  But it seems to be wrong.

I want to revert my code to make PyZMQ focus on only its problems.
