### PR TITLE
Add support for zmq_curve_public

### DIFF
--- a/zmq/backend/cffi/_cdefs.h
+++ b/zmq/backend/cffi/_cdefs.h
@@ -21,6 +21,7 @@ int zmq_proxy(void *frontend, void *backend, void *capture);
 int zmq_socket_monitor(void *socket, const char *addr, int events);
 
 int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
+int zmq_curve_public (char *z85_public_key, char *z85_secret_key);
 int zmq_has (const char *capability);
 
 typedef struct { ...; } zmq_msg_t;

--- a/zmq/backend/cffi/utils.py
+++ b/zmq/backend/cffi/utils.py
@@ -34,12 +34,36 @@ def curve_keypair():
     (public, secret) : two bytestrings
         The public and private keypair as 40 byte z85-encoded bytestrings.
     """
-    _check_version((3,2), "monitor")
+    _check_version((3,2), "curve_keypair")
     public = ffi.new('char[64]')
     private = ffi.new('char[64]')
     rc = C.zmq_curve_keypair(public, private)
     _check_rc(rc)
     return ffi.buffer(public)[:40], ffi.buffer(private)[:40]
+
+
+def curve_public(private):
+    """ Compute the public key corresponding to a private key for use
+    with zmq.CURVE security
+
+    Requires libzmq (≥ 4.2) to have been built with CURVE support.
+
+    Parameters
+    ----------
+    private
+        The private key as a 40 byte z85-encoded bytestring
+    Returns
+    -------
+    bytestring
+        The public key as a 40 byte z85-encoded bytestring.
+    """
+    if isinstance(private, unicode):
+        private = private.encode('utf8')
+    _check_version((4,2), "curve_public")
+    public = ffi.new('char[64]')
+    rc = C.zmq_curve_public(public, private)
+    _check_rc(rc)
+    return ffi.buffer(public)[:40]
 
 
 def _retry_sys_call(f, *args, **kwargs):
@@ -54,4 +78,4 @@ def _retry_sys_call(f, *args, **kwargs):
             break
 
 
-__all__ = ['has', 'curve_keypair']
+__all__ = ['has', 'curve_keypair', 'curve_public']

--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -105,6 +105,7 @@ cdef extern from "zmq.h" nogil:
     int zmq_proxy (void *frontend, void *backend, void *capture)
 
     int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key)
+    int zmq_curve_public (char *z85_public_key, char *z85_secret_key)
 
     # 4.2 draft
     int zmq_join (void *s, const_char_ptr group)

--- a/zmq/backend/select.py
+++ b/zmq/backend/select.py
@@ -15,6 +15,7 @@ public_api = [
     'zmq_errno',
     'has',
     'curve_keypair',
+    'curve_public',
     'constants',
     'zmq_version_info',
     'IPC_PATH_MAX_LEN',

--- a/zmq/tests/test_security.py
+++ b/zmq/tests/test_security.py
@@ -178,6 +178,28 @@ class TestSecurity(BaseZMQTestCase):
         self.assertEqual(type(bpublic), bytes)
         self.assertEqual(len(bsecret), 32)
         self.assertEqual(len(bpublic), 32)
+
+    def test_curve_public(self):
+        """test curve_public"""
+        try:
+            public, secret = zmq.curve_keypair()
+        except zmq.ZMQError:
+            raise SkipTest("CURVE unsupported")
+        if zmq.zmq_version_info() < (4,2):
+            raise SkipTest("curve_public is new in libzmq 4.2")
+
+        derived_public = zmq.curve_public(secret)
+
+        self.assertEqual(type(derived_public), bytes)
+        self.assertEqual(len(derived_public), 40)
+
+        # verify that it is indeed Z85
+        bpublic = z85.decode(derived_public)
+        self.assertEqual(type(bpublic), bytes)
+        self.assertEqual(len(bpublic), 32)
+
+        # verify that it is equal to the known public key
+        self.assertEqual(derived_public, public)
          
     def test_curve(self):
         """test CURVE encryption"""

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -33,6 +33,12 @@
     #define ZMQ_FD_T int
 #endif
 
+#if ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 2
+    // Nothing to remove
+#else
+    #define zmq_curve_public(z85_public_key, z85_secret_key) _missing
+#endif
+
 // use unambiguous aliases for zmq_send/recv functions
 
 #if ZMQ_VERSION_MAJOR >= 4


### PR DESCRIPTION
Add support for [zmq_curve_public](http://api.zeromq.org/4-2:zmq-curve-public), added in zmq 4.2.