### PR TITLE
bump bundled libzmq to 4.2.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,12 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tools\\run_with_env.cmd"
 
   matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: 32
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: 64
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: 32
@@ -22,12 +28,6 @@ environment:
       PYTHON_ARCH: 32
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: 64
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: 32
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: 64
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.x"

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -32,14 +32,14 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (4, 2, 3)
+bundled_version = (4, 2, 4)
 vs = '%i.%i.%i' % bundled_version
 libzmq = "zeromq-%s.tar.gz" % vs
 libzmq_url = "https://github.com/zeromq/libzmq/releases/download/v{vs}/{libzmq}".format(
     vs=vs,
     libzmq=libzmq,
 )
-libzmq_checksum = "sha256:8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0"
+libzmq_checksum = "sha256:1ad5c28d44e31f0f7cad09b95bafaca8cc5346ff24a63a5e7d01c954162ad536"
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -32,16 +32,14 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (4,1,6)
+bundled_version = (4, 2, 3)
 vs = '%i.%i.%i' % bundled_version
 libzmq = "zeromq-%s.tar.gz" % vs
-libzmq_url = "https://github.com/zeromq/zeromq{major}-{minor}/releases/download/v{vs}/{libzmq}".format(
-    major=bundled_version[0],
-    minor=bundled_version[1],
+libzmq_url = "https://github.com/zeromq/libzmq/releases/download/v{vs}/{libzmq}".format(
     vs=vs,
     libzmq=libzmq,
 )
-libzmq_checksum = "sha256:02ebf60a43011e770799336365bcbce2eb85569e9b5f52aa0d8cc04672438a0a"
+libzmq_checksum = "sha256:8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0"
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -32,14 +32,14 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (4, 2, 4)
+bundled_version = (4, 2, 5)
 vs = '%i.%i.%i' % bundled_version
 libzmq = "zeromq-%s.tar.gz" % vs
 libzmq_url = "https://github.com/zeromq/libzmq/releases/download/v{vs}/{libzmq}".format(
     vs=vs,
     libzmq=libzmq,
 )
-libzmq_checksum = "sha256:1ad5c28d44e31f0f7cad09b95bafaca8cc5346ff24a63a5e7d01c954162ad536"
+libzmq_checksum = "sha256:cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f"
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)

--- a/setup.py
+++ b/setup.py
@@ -529,14 +529,14 @@ class Configure(build_ext):
             sources=sources,
             include_dirs=includes,
         )
-        
+
         # register the extension:
         self.distribution.ext_modules.insert(0, libzmq)
-        
+
         # use tweetnacl to provide CURVE support
         libzmq.define_macros.append(('ZMQ_HAVE_CURVE', 1))
         libzmq.define_macros.append(('ZMQ_USE_TWEETNACL', 1))
-        
+
         # select polling subsystem based on platform
         if sys.platform  == 'darwin' or 'bsd' in sys.platform:
             libzmq.define_macros.append(('ZMQ_USE_KQUEUE', 1))
@@ -547,13 +547,13 @@ class Configure(build_ext):
         else:
             # this may not be sufficiently precise
             libzmq.define_macros.append(('ZMQ_USE_POLL', 1))
-        
+
         if sys.platform.startswith('win'):
             # include defines from zeromq msvc project:
             libzmq.define_macros.append(('FD_SETSIZE', 16384))
             libzmq.define_macros.append(('DLL_EXPORT', 1))
             libzmq.define_macros.append(('_CRT_SECURE_NO_WARNINGS', 1))
-            
+
             # When compiling the C++ code inside of libzmq itself, we want to
             # avoid "warning C4530: C++ exception handler used, but unwind
             # semantics are not enabled. Specify /EHsc".
@@ -563,8 +563,8 @@ class Configure(build_ext):
                 libzmq.define_macros.append(('ZMQ_HAVE_MINGW32', 1))
 
             # And things like sockets come from libraries that must be named.
-            libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32'])
-            
+            libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32', 'iphlpapi'])
+
             # bundle MSCVP redist
             if self.config['bundle_msvcp']:
                 cc = new_compiler(compiler=self.compiler_type)
@@ -602,29 +602,28 @@ class Configure(build_ext):
                     libzmq.libraries.append('rt')
                 else:
                     info("ok")
-                
+
                 if pypy:
                     # seem to need explicit libstdc++ on linux + pypy
                     # not sure why
                     libzmq.libraries.append("stdc++")
-        
+
         # copy the header files to the source tree.
         bundledincludedir = pjoin('zmq', 'include')
         if not os.path.exists(bundledincludedir):
             os.makedirs(bundledincludedir)
         if not os.path.exists(pjoin(self.build_lib, bundledincludedir)):
             os.makedirs(pjoin(self.build_lib, bundledincludedir))
-        
+
         for header in glob(pjoin(bundledir, 'zeromq', 'include', '*.h')):
             shutil.copyfile(header, pjoin(bundledincludedir, basename(header)))
             shutil.copyfile(header, pjoin(self.build_lib, bundledincludedir, basename(header)))
-        
+
         # update other extensions, with bundled settings
         self.config['libzmq_extension'] = True
         self.init_settings_from_config()
         self.save_config('config', self.config)
-        
-    
+
     def fallback_on_bundled(self):
         """Couldn't build, fallback after waiting a while"""
         


### PR DESCRIPTION
hopefully this fixes the Windows issues that prevented bundling 4.2.2

- [x] wait for #1153 to fix tornado tests