### PR TITLE
Adding stdc++ into libzmq libraries under PyPy is not required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -603,11 +603,6 @@ class Configure(build_ext):
                 else:
                     info("ok")
 
-                if pypy:
-                    # seem to need explicit libstdc++ on linux + pypy
-                    # not sure why
-                    libzmq.libraries.append("stdc++")
-
         # copy the header files to the source tree.
         bundledincludedir = pjoin('zmq', 'include')
         if not os.path.exists(bundledincludedir):


### PR DESCRIPTION
More details in https://github.com/zeromq/pyzmq/issues/1160

closes #1160