### PR TITLE
close underlying socket in `socket.__dealloc__`

### DIFF
--- a/zmq/backend/cython/socket.pxd
+++ b/zmq/backend/cython/socket.pxd
@@ -41,6 +41,7 @@ cdef class Socket:
     cdef public bint _closed    # bool property for a closed socket.
     cdef public int copy_threshold # threshold below which pyzmq will always copy messages
     cdef int _pid               # the pid of the process which created me (for fork safety)
+    cdef void _c_close(self)    # underlying close of zmq socket
 
     # cpdef methods for direct-cython access:
     cpdef object send(self, object data, int flags=*, copy=*, track=*)


### PR DESCRIPTION
`socket.__del__` may not be called during process gc, but dealloc will.

new asyncio implementation in 17.0 seems to affect how likely this is to occur

closes #1167