### PR TITLE
Support for building the extension with statically linked libzmq

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -4,8 +4,9 @@
 # skip_check_zmq = True # skip checking zmq verson (if it doesn't work for some reason)
 # libzmq_extension = True # force building libzmq as an extension (same as --zmq=bundled)
 # no_libzmq_extension = True # prevent fallback on building libzmq as an extension if regular build fails
-[build_ext]
+# use_static_zmq = False # Force usage of static libzmq. Right now it does not work with version autodetection so you should also set skip_check_zmq to True
 
+[build_ext]
 # Edit these to add any paths you need to include (e.g. where libzmq is defined)
 library_dirs = /usr/local/lib
 include_dirs = /usr/local/include

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ for idx, arg in enumerate(list(sys.argv)):
         configure_idx = idx
     elif arg == 'fetch_libzmq':
         fetch_idx = idx
-    
+
     if arg.startswith('--zmq='):
         sys.argv.pop(idx)
         if configure_idx < 0:
@@ -187,7 +187,7 @@ def check_pkgconfig():
 
 def _add_rpath(settings, path):
     """Add rpath to settings
-    
+
     Implemented here because distutils runtime_library_dirs doesn't do anything on darwin
     """
     if sys.platform == 'darwin':
@@ -202,11 +202,11 @@ def settings_from_prefix(prefix=None, bundle_libzmq_dylib=False):
     settings['include_dirs'] = []
     settings['library_dirs'] = []
     settings['runtime_library_dirs'] = []
-    settings['extra_link_args'] = [] 
-    
+    settings['extra_link_args'] = []
+
     if sys.platform.startswith('win'):
         settings['libraries'].append(libzmq_name)
-        
+
         if prefix:
             settings['include_dirs'] += [pjoin(prefix, 'include')]
             settings['library_dirs'] += [pjoin(prefix, 'lib')]
@@ -261,7 +261,7 @@ def settings_from_prefix(prefix=None, bundle_libzmq_dylib=False):
             for path in settings['library_dirs']:
                 _add_rpath(settings, os.path.abspath(path))
     info(settings)
-    
+
     return settings
 
 class LibZMQVersionError(Exception):
@@ -275,11 +275,11 @@ class Configure(build_ext):
     """Configure command adapted from h5py"""
 
     description = "Discover ZMQ version and features"
-    
+
     user_options = build_ext.user_options + [
         ('zmq=', None, "libzmq install prefix"),
         ('build-base=', 'b', "base directory for build library"), # build_base from build
-        
+
     ]
     def initialize_options(self):
         build_ext.initialize_options(self)
@@ -295,7 +295,7 @@ class Configure(build_ext):
         if self.zmq is not None:
             merge(self.config, config_from_prefix(self.zmq))
         self.init_settings_from_config()
-    
+
     def save_config(self, name, cfg):
         """write config to JSON"""
         save_config(name, cfg, self.build_base)
@@ -306,7 +306,7 @@ class Configure(build_ext):
         build_lib_utils = os.path.join(self.build_lib, 'zmq', 'utils')
         if os.path.exists(build_lib_utils):
             save_config(name, cfg, build_lib_utils)
-    
+
     def init_settings_from_config(self):
         """set up compiler settings, based on config"""
         cfg = self.config
@@ -326,7 +326,7 @@ class Configure(build_ext):
             settings = bundled_settings(self.debug)
         else:
             settings = settings_from_prefix(cfg['zmq_prefix'], self.bundle_libzmq_dylib)
-        
+
         if 'have_sys_un_h' not in cfg:
             # don't link against anything when checking for sys/un.h
             minus_zmq = copy.deepcopy(settings)
@@ -347,12 +347,15 @@ class Configure(build_ext):
 
             self.save_config('config', cfg)
 
-        if cfg['have_sys_un_h']:
-            settings['define_macros'] = [('HAVE_SYS_UN_H', 1)]
-
         settings.setdefault('define_macros', [])
+        if cfg['have_sys_un_h']:
+            settings['define_macros'].append(('HAVE_SYS_UN_H', 1))
+
         if cfg.get('zmq_draft_api'):
             settings['define_macros'].append(('ZMQ_BUILD_DRAFT_API', 1))
+
+        if cfg['use_static_zmq']:
+            settings['define_macros'].append(('ZMQ_STATIC', '1'))
 
         # include internal directories
         settings.setdefault('include_dirs', [])
@@ -363,13 +366,18 @@ class Configure(build_ext):
         )]
         if sys.platform.startswith('win') and sys.version_info < (3, 3):
             settings['include_dirs'].insert(0, pjoin('buildutils', 'include_win32'))
-        
+
+        settings.setdefault('libraries', [])
+        # Explicitly link dependencies, not necessary if zmq is dynamic
+        if sys.platform.startswith('win'):
+            settings['libraries'].extend(('ws2_32', 'iphlpapi', 'advapi32'))
+
         for ext in self.distribution.ext_modules:
             if ext.name.startswith('zmq.lib'):
                 continue
             for attr, value in settings.items():
                 setattr(ext, attr, value)
-        
+
         self.compiler_settings = settings
         self.save_config('compiler', settings)
 
@@ -382,7 +390,7 @@ class Configure(build_ext):
             if not self.config['zmq_prefix'] and not os.path.exists(local_dll):
                 fatal("ZMQ directory must be specified on Windows via setup.cfg"
                 " or 'python setup.py configure --zmq=/path/to/zeromq2'")
-            
+
             try:
                 shutil.copy(pjoin(self.config['zmq_prefix'], 'lib', libzmq_name + '.dll'), local_dll)
             except Exception:
@@ -406,7 +414,7 @@ class Configure(build_ext):
             return compiler
         else:
             return compiler.compiler_type
-    
+
     @property
     def cross_compiling(self):
         return self.config['bdist_egg'].get('plat-name', sys.platform) != sys.platform
@@ -433,7 +441,7 @@ class Configure(build_ext):
         zmq_prefix = cfg['zmq_prefix']
         detected = self.test_build(zmq_prefix, self.compiler_settings)
         # now check the libzmq version
-        
+
         vers = tuple(detected['vers'])
         vs = v_str(vers)
         if cfg['allow_legacy_libzmq']:
@@ -447,9 +455,9 @@ class Configure(build_ext):
             if zmq_prefix:
                 msg.append("    ZMQ_PREFIX=%s" % zmq_prefix)
             if vers >= min_legacy_zmq:
-                
+
                 msg.append("    Explicitly allow legacy zmq by specifying `--zmq=/zmq/prefix`")
-            
+
             raise LibZMQVersionError('\n'.join(msg))
         if vers < min_good_zmq:
             msg = [
@@ -480,23 +488,23 @@ class Configure(build_ext):
                     warn("Could not copy " + libzmq_name + " into zmq/, which is usually necessary on Windows."
                     "Please specify zmq prefix via configure --zmq=/path/to/zmq or copy "
                     + libzmq_name + " into zmq/ manually.")
-    
+
     def bundle_libzmq_extension(self):
         bundledir = "bundled"
         ext_modules = self.distribution.ext_modules
         if ext_modules and any(m.name == 'zmq.libzmq' for m in ext_modules):
             # I've already been run
             return
-        
+
         line()
         info("Using bundled libzmq")
-        
+
         # fetch sources for libzmq extension:
         if not os.path.exists(bundledir):
             os.makedirs(bundledir)
-        
+
         fetch_libzmq(bundledir)
-        
+
         stage_platform_hpp(pjoin(bundledir, 'zeromq'))
 
         sources = [pjoin('buildutils', 'initlibzmq.c')]
@@ -563,7 +571,7 @@ class Configure(build_ext):
                 libzmq.define_macros.append(('ZMQ_HAVE_MINGW32', 1))
 
             # And things like sockets come from libraries that must be named.
-            libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32', 'iphlpapi'])
+            libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32'])
 
             # bundle MSCVP redist
             if self.config['bundle_msvcp']:
@@ -603,6 +611,11 @@ class Configure(build_ext):
                 else:
                     info("ok")
 
+                if pypy:
+                    # seem to need explicit libstdc++ on linux + pypy
+                    # not sure why
+                    libzmq.libraries.append("stdc++")
+
         # copy the header files to the source tree.
         bundledincludedir = pjoin('zmq', 'include')
         if not os.path.exists(bundledincludedir):
@@ -619,11 +632,12 @@ class Configure(build_ext):
         self.init_settings_from_config()
         self.save_config('config', self.config)
 
+
     def fallback_on_bundled(self):
         """Couldn't build, fallback after waiting a while"""
-        
+
         line()
-        
+
         warn('\n'.join([
         "Couldn't find an acceptable libzmq on the system.",
         "",
@@ -638,7 +652,7 @@ class Configure(build_ext):
         "      or specify zmq's location with `--zmq=/usr/local`",
         "",
         ]))
-        
+
         info('\n'.join([
             "You can skip all this detection/waiting nonsense if you know",
             "you want pyzmq to bundle libzmq as an extension by passing:",
@@ -649,17 +663,17 @@ class Configure(build_ext):
             "unless you interrupt me (^C) in the next 10 seconds...",
             "",
         ]))
-        
+
         for i in range(10,0,-1):
             sys.stdout.write('\r%2i...' % i)
             sys.stdout.flush()
             time.sleep(1)
-        
+
         info("")
-        
+
         return self.bundle_libzmq_extension()
-        
-    
+
+
     def test_build(self, prefix, settings):
         """do a test build ob libzmq"""
         self.create_tempdir()
@@ -675,31 +689,31 @@ class Configure(build_ext):
             detected = detect_zmq(self.tempdir, compiler=self.compiler_type, **settings)
         finally:
             self.erase_tempdir()
-        
+
         info("    ZMQ version detected: %s" % v_str(detected['vers']))
-        
+
         return detected
-    
+
 
     def finish_run(self):
         self.save_config('config', self.config)
         line()
-    
+
     def run(self):
         cfg = self.config
-        
+
         if cfg['libzmq_extension']:
             self.bundle_libzmq_extension()
             self.finish_run()
             return
-        
+
         # When cross-compiling and zmq is given explicitly, we can't testbuild
         # (as we can't testrun the binary), we assume things are alright.
         if cfg['skip_check_zmq'] or self.cross_compiling:
             warn("Skipping zmq version check")
             self.finish_run()
             return
-        
+
         zmq_prefix = cfg['zmq_prefix']
         # There is no available default on Windows, so start with fallback unless
         # zmq was given explicitly, or libzmq extension was explicitly prohibited.
@@ -709,10 +723,10 @@ class Configure(build_ext):
             self.fallback_on_bundled()
             self.finish_run()
             return
-        
+
         if zmq_prefix and self.bundle_libzmq_dylib and not sys.platform.startswith('win'):
             copy_and_patch_libzmq(zmq_prefix, libzmq_name+lib_ext)
-        
+
         # first try with given config or defaults
         try:
             self.check_zmq_version()
@@ -724,7 +738,7 @@ class Configure(build_ext):
         else:
             self.finish_run()
             return
-        
+
         # try fallback on /usr/local on *ix if no prefix is given
         if not zmq_prefix and not sys.platform.startswith('win'):
             info("Failed with default libzmq, trying again with /usr/local")
@@ -743,32 +757,32 @@ class Configure(build_ext):
                 # settings for the extensions with /usr/local prefix
                 self.finish_run()
                 return
-        
+
         # finally, fallback on bundled
-        
+
         if cfg['no_libzmq_extension']:
             fatal("Falling back on bundled libzmq,"
             " but config has explicitly prohibited building the libzmq extension."
             )
-        
+
         self.fallback_on_bundled()
-        
+
         self.finish_run()
 
 
 class FetchCommand(Command):
     """Fetch libzmq sources, that's it."""
-    
+
     description = "Fetch libzmq sources into bundled/zeromq"
-    
+
     user_options = [ ]
-    
+
     def initialize_options(self):
         pass
-    
+
     def finalize_options(self):
         pass
-    
+
     def run(self):
         # fetch sources for libzmq extension:
         bundledir = "bundled"
@@ -780,7 +794,7 @@ class FetchCommand(Command):
         fetch_libzmq(bundledir)
         for tarball in glob(pjoin(bundledir, '*.tar.gz')):
             os.remove(tarball)
-        
+
 
 
 class TestCommand(Command):
@@ -795,7 +809,7 @@ class TestCommand(Command):
 
     def finalize_options(self):
         pass
-    
+
     def run(self):
         """Run the test suite with py.test"""
         # crude check for inplace build:
@@ -807,7 +821,7 @@ class TestCommand(Command):
             "You must build pyzmq with 'python setup.py build_ext --inplace' for 'python setup.py test' to work.",
             "If you did build pyzmq in-place, then this is a real error."]))
             sys.exit(1)
-        
+
         info("Testing pyzmq-%s with libzmq-%s" % (zmq.pyzmq_version(), zmq.zmq_version()))
         p = Popen([sys.executable, '-m', 'pytest', '-v', os.path.join('zmq', 'tests')])
         p.wait()
@@ -815,44 +829,44 @@ class TestCommand(Command):
 
 class GitRevisionCommand(Command):
     """find the current git revision and add it to zmq.sugar.version.__revision__"""
-    
+
     description = "Store current git revision in version.py"
-    
+
     user_options = [ ]
-    
+
     def initialize_options(self):
         self.version_py = pjoin('zmq','sugar','version.py')
-    
+
     def run(self):
         try:
             p = Popen('git log -1'.split(), stdin=PIPE, stdout=PIPE, stderr=PIPE)
         except IOError:
             warn("No git found, skipping git revision")
             return
-        
+
         if p.wait():
             warn("checking git branch failed")
             info(p.stderr.read())
             return
-        
+
         line = p.stdout.readline().decode().strip()
         if not line.startswith('commit'):
             warn("bad commit line: %r" % line)
             return
-        
+
         rev = line.split()[-1]
-        
+
         # now that we have the git revision, we can apply it to version.py
         with open(self.version_py) as f:
             lines = f.readlines()
-        
+
         for i,line in enumerate(lines):
             if line.startswith('__revision__'):
                 lines[i] = "__revision__ = '%s'\n"%rev
                 break
         with open(self.version_py, 'w') as f:
             f.writelines(lines)
-    
+
     def finalize_options(self):
         pass
 
@@ -873,25 +887,25 @@ class CleanCommand(Command):
     def run(self):
         _clean_me = []
         _clean_trees = []
-        
+
         for d in ('build', 'dist', 'conf'):
             if os.path.exists(d):
                 _clean_trees.append(d)
-        
+
         for root, dirs, files in os.walk('buildutils'):
             if any(root.startswith(pre) for pre in _clean_trees):
                 continue
             for f in files:
                 if os.path.splitext(f)[-1] == '.pyc':
                     _clean_me.append(pjoin(root, f))
-            
+
             if '__pycache__' in dirs:
                 _clean_trees.append(pjoin(root, '__pycache__'))
 
         for root, dirs, files in os.walk('zmq'):
             if any(root.startswith(pre) for pre in _clean_trees):
                 continue
-            
+
             for f in files:
                 if os.path.splitext(f)[-1] in ('.pyc', '.so', '.o', '.pyd', '.json'):
                     _clean_me.append(pjoin(root, f))
@@ -899,19 +913,19 @@ class CleanCommand(Command):
             for d in dirs:
                 if d == '__pycache__':
                     _clean_trees.append(pjoin(root, d))
-        
+
         # remove generated cython files
         if self.all:
             for root, dirs, files in os.walk(pjoin('zmq', 'backend', 'cython')):
                  if os.path.splitext(f)[-1] == '.c':
                      _clean_me.append(pjoin(root, f))
-        
+
         bundled = glob(pjoin('zmq', 'libzmq*'))
         _clean_me.extend([ b for b in bundled if b not in _clean_me ])
-        
+
         bundled_headers = glob(pjoin('zmq', 'include', '*.h'))
         _clean_me.extend([ h for h in bundled_headers if h not in _clean_me])
-        
+
         for clean_me in _clean_me:
             print("removing %s" % clean_me)
             try:
@@ -950,7 +964,7 @@ class CheckSDist(sdist):
 
 class CheckingBuildExt(build_ext):
     """Subclass build_ext to get clearer report if Cython is necessary."""
-    
+
     def check_cython_extensions(self, extensions):
         for ext in extensions:
           for src in ext.sources:
@@ -959,22 +973,22 @@ class CheckingBuildExt(build_ext):
                 Cython >= %s is required to compile pyzmq from a development branch.
                 Please install Cython or download a release package of pyzmq.
                 """ % (src, min_cython_version))
-    
+
     def build_extensions(self):
         self.check_cython_extensions(self.extensions)
         self.check_extensions_list(self.extensions)
-        
+
         if self.compiler.compiler_type == 'mingw32':
             customize_mingw(self.compiler)
-        
+
         for ext in self.extensions:
             self.build_extension(ext)
-    
+
     def build_extension(self, ext):
         build_ext.build_extension(self, ext)
         ext_path = self.get_ext_fullpath(ext.name)
         patch_lib_paths(ext_path, self.compiler.library_dirs)
-    
+
     def run(self):
         # check version, to prevent confusing undefined constant errors
         self.distribution.run_command('configure')
@@ -983,16 +997,16 @@ class CheckingBuildExt(build_ext):
 
 class ConstantsCommand(Command):
     """Rebuild templated files for constants
-    
+
     To be run after adding new constants to `utils/constant_names`.
     """
     user_options = []
     def initialize_options(self):
-        return 
-    
+        return
+
     def finalize_options(self):
         pass
-    
+
     def run(self):
         from buildutils.constants import render_constants
         render_constants()
@@ -1054,17 +1068,17 @@ except Exception:
     cython = False
     suffix = '.c'
     cmdclass['build_ext'] = CheckingBuildExt
-    
+
     class MissingCython(Command):
-        
+
         user_options = []
-        
+
         def initialize_options(self):
             pass
-        
+
         def finalize_options(self):
             pass
-        
+
         def run(self):
             try:
                 import Cython
@@ -1078,38 +1092,38 @@ except Exception:
                         "found: %s" % (min_cython_version, cv or Cython)
                     )
     cmdclass['cython'] = MissingCython
-    
+
 else:
-    
+
     suffix = '.pyx'
-    
+
     class CythonCommand(build_ext_c):
         """Custom distutils command subclassed from Cython.Distutils.build_ext
-        to compile pyx->c, and stop there. All this does is override the 
+        to compile pyx->c, and stop there. All this does is override the
         C-compile method build_extension() with a no-op."""
-        
+
         description = "Compile Cython sources to C"
-        
+
         def build_extension(self, ext):
             pass
 
     class zbuild_ext(build_ext_c):
-        
+
         def build_extensions(self):
             if self.compiler.compiler_type == 'mingw32':
                 customize_mingw(self.compiler)
             return build_ext_c.build_extensions(self)
-        
+
         def build_extension(self, ext):
             build_ext_c.build_extension(self, ext)
             ext_path = self.get_ext_fullpath(ext.name)
             patch_lib_paths(ext_path, self.compiler.library_dirs)
-        
+
         def run(self):
             self.distribution.run_command('configure')
-            
+
             return build_ext_c.run(self)
-    
+
     cmdclass['cython'] = CythonCommand
     cmdclass['build_ext'] =  zbuild_ext
 
@@ -1140,7 +1154,7 @@ if pypy:
     bld_ext = cmdclass['build_ext']
     class pypy_build_ext(bld_ext):
         """hack to build pypy extension only after building bundled libzmq
-        
+
         otherwise it will fail when libzmq is bundled.
         """
         def build_extensions(self):
@@ -1165,7 +1179,7 @@ if pypy:
             finally:
                 sys.path.pop(0)
 
-    
+
     # How many build_ext subclasses is this? 5? Gross.
     cmdclass['build_ext'] = pypy_build_ext
 

--- a/setup.py
+++ b/setup.py
@@ -572,7 +572,7 @@ class Configure(build_ext):
                 libzmq.define_macros.append(('ZMQ_HAVE_MINGW32', 1))
 
             # And things like sockets come from libraries that must be named.
-            libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32'])
+            libzmq.libraries.extend(['rpcrt4', 'ws2_32', 'advapi32', 'iphlpapi'])
 
             # bundle MSCVP redist
             if self.config['bundle_msvcp']:

--- a/setup.py
+++ b/setup.py
@@ -354,7 +354,8 @@ class Configure(build_ext):
         if cfg.get('zmq_draft_api'):
             settings['define_macros'].append(('ZMQ_BUILD_DRAFT_API', 1))
 
-        if cfg['use_static_zmq']:
+        use_static_zmq = cfg.get('use_static_zmq', 'False').upper()
+        if use_static_zmq in ('TRUE', '1'):
             settings['define_macros'].append(('ZMQ_STATIC', '1'))
 
         # include internal directories


### PR DESCRIPTION
Support for building the extension with statically linked libzmq.
Added missing extension dependencies on win32 (libzmq dependencies,
must be explicitly set for static builds).
[TODO] libzmq version autodetection does not work with static libzmq