### PR TITLE
default ioloop to current instead of instance

### DIFF
--- a/zmq/auth/ioloop.py
+++ b/zmq/auth/ioloop.py
@@ -17,7 +17,7 @@ class IOLoopAuthenticator(Authenticator):
     def __init__(self, context=None, encoding='utf-8', log=None, io_loop=None):
         super(IOLoopAuthenticator, self).__init__(context, encoding, log)
         self.zap_stream = None
-        self.io_loop = io_loop or ioloop.IOLoop.instance()
+        self.io_loop = io_loop or ioloop.IOLoop.current()
 
     def start(self):
         """Start ZAP authentication"""

--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -105,7 +105,7 @@ class ZMQStream(object):
 
     def __init__(self, socket, io_loop=None):
         self.socket = socket
-        self.io_loop = io_loop or IOLoop.instance()
+        self.io_loop = io_loop or IOLoop.current()
         self.poller = zmq.Poller()
         self._fd = self.socket.FD
 


### PR DESCRIPTION
since this is tornado's own behavior.

Should result in no difference when using only one thread, but correct behavior when using more than one.