### PR TITLE
Explicit link with libstdc++ under PyPy is not required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -612,11 +612,6 @@ class Configure(build_ext):
                 else:
                     info("ok")
 
-                if pypy:
-                    # seem to need explicit libstdc++ on linux + pypy
-                    # not sure why
-                    libzmq.libraries.append("stdc++")
-
         # copy the header files to the source tree.
         bundledincludedir = pjoin('zmq', 'include')
         if not os.path.exists(bundledincludedir):


### PR DESCRIPTION
This pull-request repeats #1161 because its changes were overwritten by #1175 .