### PR TITLE
Remove very outdated Cython compatibility measures

### DIFF
--- a/zmq/backend/cython/error.pyx
+++ b/zmq/backend/cython/error.pyx
@@ -23,23 +23,17 @@
 # Imports
 #-----------------------------------------------------------------------------
 
-# allow const char*
-cdef extern from *:
-    ctypedef char* const_char_ptr "const char*"
-
+from cpython.version cimport PY_MAJOR_VERSION
 from .libzmq cimport zmq_strerror, zmq_errno as zmq_errno_c
-
-from zmq.utils.strtypes import bytes
 
 def strerror(int errno):
     """strerror(errno)
 
     Return the error string given the error number.
     """
-    cdef const_char_ptr str_e
-    # char * will be a bytes object:
+    # This is a const char *
     str_e = zmq_strerror(errno)
-    if str is bytes:
+    if PY_MAJOR_VERSION <= 2:
         # Python 2: str is bytes, so we already have the right type
         return str_e
     else:

--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -27,10 +27,6 @@
 # Import the C header files
 #-----------------------------------------------------------------------------
 
-cdef extern from *:
-    ctypedef void* const_void_ptr "const void *"
-    ctypedef char* const_char_ptr "const char *"
-
 # were it not for Windows,
 # we could cimport these from libc.stdint
 cdef extern from "zmq_compat.h":
@@ -46,7 +42,7 @@ cdef extern from "zmq.h" nogil:
     ctypedef int fd_t "ZMQ_FD_T"
     
     enum: errno
-    char *zmq_strerror (int errnum)
+    const char *zmq_strerror (int errnum)
     int zmq_errno()
 
     void *zmq_ctx_new ()
@@ -75,8 +71,8 @@ cdef extern from "zmq.h" nogil:
     int zmq_msg_more (zmq_msg_t *msg)
     int zmq_msg_get (zmq_msg_t *msg, int option)
     int zmq_msg_set (zmq_msg_t *msg, int option, int optval)
-    const_char_ptr zmq_msg_gets (zmq_msg_t *msg, const_char_ptr property)
-    int zmq_has (const_char_ptr capability)
+    const char *zmq_msg_gets (zmq_msg_t *msg, const char *property)
+    int zmq_has (const char *capability)
 
     void *zmq_socket (void *context, int type)
     int zmq_close (void *s)
@@ -90,7 +86,7 @@ cdef extern from "zmq.h" nogil:
     int zmq_socket_monitor (void *s, char *addr, int flags)
     
     # send/recv
-    int zmq_sendbuf (void *s, const_void_ptr buf, size_t n, int flags)
+    int zmq_sendbuf (void *s, const void *buf, size_t n, int flags)
     int zmq_recvbuf (void *s, void *buf, size_t n, int flags)
 
     ctypedef struct zmq_pollitem_t:
@@ -108,10 +104,10 @@ cdef extern from "zmq.h" nogil:
     int zmq_curve_public (char *z85_public_key, char *z85_secret_key)
 
     # 4.2 draft
-    int zmq_join (void *s, const_char_ptr group)
-    int zmq_leave (void *s, const_char_ptr group)
+    int zmq_join (void *s, const char *group)
+    int zmq_leave (void *s, const char *group)
 
-    int zmq_msg_set_routing_id(zmq_msg_t *msg, uint32_t routing_id);
-    uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
-    int zmq_msg_set_group(zmq_msg_t *msg, const_char_ptr group);
-    const_char_ptr zmq_msg_group(zmq_msg_t *msg);
+    int zmq_msg_set_routing_id(zmq_msg_t *msg, uint32_t routing_id)
+    uint32_t zmq_msg_routing_id(zmq_msg_t *msg)
+    int zmq_msg_set_group(zmq_msg_t *msg, const char *group)
+    const char *zmq_msg_group(zmq_msg_t *msg)

--- a/zmq/backend/cython/message.pyx
+++ b/zmq/backend/cython/message.pyx
@@ -61,7 +61,6 @@ except (ImportError, AttributeError):
 import zmq
 from zmq.error import _check_version
 from .checkrc cimport _check_rc
-from zmq.utils.strtypes import bytes,unicode,basestring
 
 #-----------------------------------------------------------------------------
 # Code
@@ -347,7 +346,6 @@ cdef class Frame:
         """
         cdef int rc
         cdef uint32_t routing_id
-        cdef const_char_ptr buf
 
         if option == 'routing_id':
             routing_id = value
@@ -357,8 +355,7 @@ cdef class Frame:
         elif option == 'group':
             if isinstance(value, unicode):
                 value = value.encode('utf8')
-            buf = value
-            rc = zmq_msg_set_group(&self.zmq_msg, buf)
+            rc = zmq_msg_set_group(&self.zmq_msg, value)
             _check_rc(rc)
             return
 
@@ -387,7 +384,6 @@ cdef class Frame:
         cdef char *property_c = NULL
         cdef Py_ssize_t property_len_c = 0
         cdef uint32_t routing_id
-        cdef const_char_ptr buf
 
         # zmq_msg_get
         if isinstance(option, int):

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -39,7 +39,6 @@ from zmq.utils.buffers cimport asbuffer_r, viewfromobject_r
 from .libzmq cimport (
     fd_t,
     int64_t,
-    const_char_ptr,
 
     zmq_errno,
 
@@ -105,7 +104,6 @@ import zmq
 from zmq.backend.cython import constants
 from .checkrc cimport _check_rc
 from zmq.error import ZMQError, ZMQBindError, InterruptedSystemCall, _check_version
-from zmq.utils.strtypes import bytes,unicode,basestring
 
 #-----------------------------------------------------------------------------
 # Code
@@ -699,8 +697,7 @@ cdef class Socket:
             raise RuntimeError("libzmq must be built with draft support")
         if isinstance(group, unicode):
             group = group.encode('utf8')
-        cdef const_char_ptr c_group = group
-        cdef int rc = zmq_join(self.handle, c_group)
+        cdef int rc = zmq_join(self.handle, group)
         _check_rc(rc)
 
     def leave(self, group):
@@ -717,8 +714,7 @@ cdef class Socket:
         _check_version((4,2), "RADIO-DISH")
         if not zmq.has('draft'):
             raise RuntimeError("libzmq must be built with draft support")
-        cdef const_char_ptr c_group = group
-        cdef int rc = zmq_leave(self.handle, c_group)
+        cdef int rc = zmq_leave(self.handle, group)
         _check_rc(rc)
         
 

--- a/zmq/backend/cython/utils.pyx
+++ b/zmq/backend/cython/utils.pyx
@@ -22,10 +22,9 @@
 from .libzmq cimport (
     zmq_curve_keypair,
     zmq_curve_public,
-    zmq_has, const_char_ptr,
+    zmq_has,
 )
 from zmq.error import ZMQError, _check_rc, _check_version
-from zmq.utils.strtypes import unicode
 
 def has(capability):
     """Check for zmq capability by name (e.g. 'ipc', 'curve')

--- a/zmq/utils/buffers.pxd
+++ b/zmq/utils/buffers.pxd
@@ -67,10 +67,9 @@ cdef extern from "Python.h":
 
 # Python 2 buffer interface (legacy)
 cdef extern from "Python.h":
-    ctypedef void const_void "const void"
     Py_ssize_t Py_END_OF_BUFFER
     int PyObject_CheckReadBuffer(object)
-    int PyObject_AsReadBuffer (object, const_void **, Py_ssize_t *) except -1
+    int PyObject_AsReadBuffer (object, const void **, Py_ssize_t *) except -1
     int PyObject_AsWriteBuffer(object, void **, Py_ssize_t *) except -1
     
     object PyBuffer_FromMemory(void *ptr, Py_ssize_t s)
@@ -168,7 +167,7 @@ cdef inline object asbuffer(object ob, int writable, int format,
         if writable:
             PyObject_AsWriteBuffer(ob, &bptr, &blen)
         else:
-            PyObject_AsReadBuffer(ob, <const_void **>&bptr, &blen)
+            PyObject_AsReadBuffer(ob, <const void **>&bptr, &blen)
         if format:
             try: # numpy.ndarray
                 dtype = ob.dtype


### PR DESCRIPTION
1. Remove imports of `bytes`, `unicode` and `basestring`. Cython knows about these classes, regardless of Python version. This is actually an optimization, since Cython optimizes those as builtins but not when imported.

2. Remove typedefs for adding `const`. Cython has supported that for a long time now, there is no need anymore for such hacks.

3. Remove a few redundant assignments (only in code that I was changing anyway). Generally, there is no need for an explicit assignment
```
cdef const char *buf = python_bytes_object
```
to convert bytes to `const char *`.