### PR TITLE
stop testing tornado master with py27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,7 @@ examples/security/private_keys
 wheelhouse
 .coverage
 .cache
+.pytest_cache
+win-dist
 *.pickle
 .ipynb_checkpoints

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,6 @@ matrix:
       env:
         - ZMQ=
         - TORNADO=master
-    - python: 2.7
-      env:
-        - ZMQ=
-        - TORNADO=master
     - python: 3.5
       env: ZMQ=libzmq
     - python: 3.4


### PR DESCRIPTION
tornado master has dropped support for py2