### PR TITLE
build: Respect CC and other envvars when testing for timer_create()

### DIFF
--- a/buildutils/detect.py
+++ b/buildutils/detect.py
@@ -17,6 +17,7 @@ import os
 import logging
 import platform
 from distutils import ccompiler
+from distutils.sysconfig import customize_compiler
 from subprocess import Popen, PIPE
 
 from .misc import get_compiler, get_output_error
@@ -108,6 +109,7 @@ def detect_zmq(basedir, compiler=None, **compiler_attrs):
     # check if we need to link against Realtime Extensions library
     if sys.platform.startswith('linux'):
         cc = ccompiler.new_compiler(compiler=compiler)
+        customize_compiler(cc)
         cc.output_dir = basedir
         if not cc.has_function('timer_create'):
             compiler_attrs['libraries'].append('rt')

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ from distutils.ccompiler import new_compiler
 from distutils.extension import Extension
 from distutils.command.build_ext import build_ext
 from distutils.command.sdist import sdist
+from distutils.sysconfig import customize_compiler
 from distutils.version import LooseVersion as V
 
 from glob import glob
@@ -602,6 +603,7 @@ class Configure(build_ext):
 
             # check if we need to link against Realtime Extensions library
             cc = new_compiler(compiler=self.compiler_type)
+            customize_compiler(cc)
             cc.output_dir = self.build_temp
             if not sys.platform.startswith(('darwin', 'freebsd')):
                 line()


### PR DESCRIPTION
Call customize_compiler() on new compiler instances in order to make
them respect the build environment settings (CC etc.).  This is
consistent with what distutils is doing, and fixes issues when 'cc'
is a different compiler than the one used to actually build Python
extension modules.

Noticed in https://github.com/gentoo/gentoo/pull/9284