### PR TITLE
Add support for zmq_proxy_steerable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1047,6 +1047,7 @@ submodules = {
             'message':[libzmq, buffers, message, checkrc, mutex],
             'socket':[context, message, socket, libzmq, buffers, checkrc],
             '_device':[libzmq, socket, context, checkrc],
+            '_proxy_steerable':[libzmq, socket, checkrc],
             '_version':[libzmq],
     },
     'devices' : {

--- a/zmq/backend/cffi/_cdefs.h
+++ b/zmq/backend/cffi/_cdefs.h
@@ -18,6 +18,10 @@ int zmq_ctx_destroy(void *context);
 int zmq_ctx_get(void *context, int opt);
 int zmq_ctx_set(void *context, int opt, int optval);
 int zmq_proxy(void *frontend, void *backend, void *capture);
+int zmq_proxy_steerable(void *frontend,
+                        void *backend,
+                        void *capture,
+                        void *control);
 int zmq_socket_monitor(void *socket, const char *addr, int events);
 
 int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);

--- a/zmq/backend/cffi/devices.py
+++ b/zmq/backend/cffi/devices.py
@@ -12,12 +12,57 @@ from .utils import _retry_sys_call
 def device(device_type, frontend, backend):
     return proxy(frontend, backend)
 
+
 def proxy(frontend, backend, capture=None):
     if isinstance(capture, Socket):
         capture = capture._zmq_socket
     else:
         capture = ffi.NULL
 
-    _retry_sys_call(C.zmq_proxy, frontend._zmq_socket, backend._zmq_socket, capture)
+    _retry_sys_call(
+            C.zmq_proxy,
+            frontend._zmq_socket,
+            backend._zmq_socket,
+            capture
+        )
 
-__all__ = ['device', 'proxy']
+
+def proxy_steerable(frontend, backend, capture=None, control=None):
+    """proxy_steerable(frontend, backend, capture, control)
+
+    Start a zeromq proxy with control flow.
+
+    .. versionadded:: libzmq-4.1
+    .. versionadded:: 17.2
+
+    Parameters
+    ----------
+    frontend : Socket
+        The Socket instance for the incoming traffic.
+    backend : Socket
+        The Socket instance for the outbound traffic.
+    capture : Socket (optional)
+        The Socket instance for capturing traffic.
+    control : Socket (optional)
+        The Socket instance for control flow.
+    """
+    if isinstance(capture, Socket):
+        capture = capture._zmq_socket
+    else:
+        capture = ffi.NULL
+
+    if isinstance(control, Socket):
+        control = control._zmq_socket
+    else:
+        control = ffi.NULL
+
+    _retry_sys_call(
+            C.zmq_proxy_steerable,
+            frontend._zmq_socket,
+            backend._zmq_socket,
+            capture,
+            control
+        )
+
+
+__all__ = ['device', 'proxy', 'proxy_steerable']

--- a/zmq/backend/cython/__init__.py
+++ b/zmq/backend/cython/__init__.py
@@ -4,11 +4,13 @@
 # Distributed under the terms of the Lesser GNU Public License (LGPL).
 
 from . import (constants, error, message, context,
-                      socket, utils, _poll, _version, _device )
+                      socket, utils, _poll, _version, _device,
+                      _proxy_steerable)
 
 __all__ = []
 for submod in (constants, error, message, context,
-               socket, utils, _poll, _version, _device):
+               socket, utils, _poll, _version, _device,
+               _proxy_steerable):
     __all__.extend(submod.__all__)
 
 from .constants import *
@@ -18,6 +20,7 @@ from .context import *
 from .socket import *
 from ._poll import *
 from .utils import *
+from ._proxy_steerable import *
 from ._device import *
 from ._version import *
 

--- a/zmq/backend/cython/_proxy_steerable.pyx
+++ b/zmq/backend/cython/_proxy_steerable.pyx
@@ -1,0 +1,63 @@
+"""Python binding for ZMQ steerable proxy function."""
+
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+from .libzmq cimport zmq_proxy_steerable
+from .socket cimport Socket as cSocket
+from .checkrc cimport _check_rc
+
+from zmq.error import InterruptedSystemCall
+
+
+def proxy_steerable(
+        cSocket frontend,
+        cSocket backend,
+        cSocket capture=None,
+        cSocket control=None,
+    ):
+    """proxy_steerable(frontend, backend, capture, control)
+
+    Start a zeromq proxy with control flow.
+
+    .. versionadded:: libzmq-4.1
+    .. versionadded:: 17.2
+
+    Parameters
+    ----------
+    frontend : Socket
+        The Socket instance for the incoming traffic.
+    backend : Socket
+        The Socket instance for the outbound traffic.
+    capture : Socket (optional)
+        The Socket instance for capturing traffic.
+    control : Socket (optional)
+        The Socket instance for control flow.
+    """
+    cdef int rc = 0
+    cdef void* capture_handle
+    if isinstance(capture, cSocket):
+        capture_handle = capture.handle
+    else:
+        capture_handle = NULL
+    if isinstance(control, cSocket):
+        control_handle = control.handle
+    else:
+        control_handle = NULL
+    while True:
+        with nogil:
+            rc = zmq_proxy_steerable(
+                    frontend.handle,
+                    backend.handle,
+                    capture_handle,
+                    control_handle
+                )
+        try:
+            _check_rc(rc)
+        except InterruptedSystemCall:
+            continue
+        else:
+            break
+    return rc
+
+__all__ = ['proxy_steerable']

--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -99,6 +99,10 @@ cdef extern from "zmq.h" nogil:
 
     int zmq_device (int device_, void *insocket_, void *outsocket_)
     int zmq_proxy (void *frontend, void *backend, void *capture)
+    int zmq_proxy_steerable (void *frontend,
+                             void *backend,
+                             void *capture,
+                             void *control)
 
     int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key)
     int zmq_curve_public (char *z85_public_key, char *z85_secret_key)

--- a/zmq/backend/select.py
+++ b/zmq/backend/select.py
@@ -10,6 +10,7 @@ public_api = [
     'Message',
     'device',
     'proxy',
+    'proxy_steerable',
     'zmq_poll',
     'strerror',
     'zmq_errno',

--- a/zmq/devices/__init__.py
+++ b/zmq/devices/__init__.py
@@ -4,13 +4,26 @@
 # Distributed under the terms of the Modified BSD License.
 
 from zmq import device
-from zmq.devices import basedevice, proxydevice, monitoredqueue, monitoredqueuedevice
+from zmq.devices import (
+    basedevice,
+    monitoredqueue,
+    monitoredqueuedevice,
+    proxydevice,
+    proxysteerabledevice,
+)
 
 from zmq.devices.basedevice import *
 from zmq.devices.proxydevice import *
+from zmq.devices.proxysteerabledevice import *
 from zmq.devices.monitoredqueue import *
 from zmq.devices.monitoredqueuedevice import *
 
 __all__ = ['device']
-for submod in (basedevice, proxydevice, monitoredqueue, monitoredqueuedevice):
+for submod in (
+    basedevice,
+    proxydevice,
+    proxysteerabledevice,
+    monitoredqueue,
+    monitoredqueuedevice
+):
     __all__.extend(submod.__all__)

--- a/zmq/devices/proxysteerabledevice.py
+++ b/zmq/devices/proxysteerabledevice.py
@@ -1,0 +1,97 @@
+"""Classes for running a steerable ZMQ proxy"""
+
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+import zmq
+from zmq.devices.proxydevice import Proxy, ThreadProxy, ProcessProxy
+
+
+class ProxySteerableBase(object):
+    """Base class for overriding methods."""
+
+    def __init__(self, in_type, out_type, mon_type=zmq.PUB, ctrl_type=None):
+        super(ProxySteerableBase, self).__init__(
+            in_type=in_type,
+            out_type=out_type,
+            mon_type=mon_type
+        )
+        self.ctrl_type = ctrl_type
+        self._ctrl_binds = []
+        self._ctrl_connects = []
+        self._ctrl_sockopts = []
+
+    def bind_ctrl(self, addr):
+        """Enqueue ZMQ address for binding on ctrl_socket.
+
+        See zmq.Socket.bind for details.
+        """
+        self._ctrl_binds.append(addr)
+
+    def connect_ctrl(self, addr):
+        """Enqueue ZMQ address for connecting on ctrl_socket.
+
+        See zmq.Socket.bind for details.
+        """
+        self._ctrl_connects.append(addr)
+
+    def setsockopt_ctrl(self, opt, value):
+        """Enqueue setsockopt(opt, value) for ctrl_socket
+
+        See zmq.Socket.setsockopt for details.
+        """
+        self._ctrl_sockopts.append((opt, value))
+
+    def _setup_sockets(self):
+        ins, outs, mons = super(ProxySteerableBase, self)._setup_sockets()
+        ctx = self._context
+        ctrls = ctx.socket(self.ctrl_type)
+
+        for opt, value in self._ctrl_sockopts:
+            ctrls.setsockopt(opt, value)
+
+        for iface in self._ctrl_binds:
+            ctrls.bind(iface)
+
+        for iface in self._ctrl_connects:
+            ctrls.connect(iface)
+
+        return ins, outs, mons, ctrls
+
+    def run_device(self):
+        ins, outs, mons, ctrls = self._setup_sockets()
+        zmq.proxy_steerable(ins, outs, mons, ctrls)
+
+
+class ProxySteerable(ProxySteerableBase, Proxy):
+    """Class for running a steerable proxy in the background.
+
+    See zmq.devices.Proxy for most of the spec.  If the control socket is not
+    NULL, the proxy supports control flow, provided by the socket.
+
+    If PAUSE is received on this socket, the proxy suspends its activities. If
+    RESUME is received, it goes on. If TERMINATE is received, it terminates
+    smoothly.  If the control socket is NULL, the proxy behave exactly as if
+    zmq.devices.Proxy had been used.
+
+    This subclass adds a <method>_ctrl version of each <method>_{in|out}
+    method, for configuring the control socket.
+    """
+    pass
+
+
+class ThreadProxySteerable(ProxySteerableBase, ThreadProxy):
+    """ProxySteerable in a Thread. See ProxySteerable for details."""
+    pass
+
+
+class ProcessProxySteerable(ProxySteerableBase, ProcessProxy):
+    """ProxySteerable in a Process. See ProxySteerable for details."""
+    pass
+
+
+__all__ = [
+    'ProxySteerable',
+    'ThreadProxySteerable',
+    'ProcessProxySteerable',
+]

--- a/zmq/tests/test_proxy_steerable.py
+++ b/zmq/tests/test_proxy_steerable.py
@@ -1,0 +1,101 @@
+# Copyright (C) PyZMQ Developers
+# Distributed under the terms of the Modified BSD License.
+
+import time
+import struct
+
+import zmq
+from zmq import devices
+from zmq.tests import BaseZMQTestCase, SkipTest, PYPY
+
+if PYPY:
+    # cleanup of shared Context doesn't work on PyPy
+    devices.Device.context_factory = zmq.Context
+
+
+class TestProxySteerable(BaseZMQTestCase):
+
+    def test_proxy_steerable(self):
+        if zmq.zmq_version_info() < (4, 1):
+            raise SkipTest("Steerable Proxies only in libzmq >= 4.1")
+        dev = devices.ThreadProxySteerable(
+            zmq.PULL,
+            zmq.PUSH,
+            zmq.PUSH,
+            zmq.PAIR
+        )
+        binder = self.context.socket(zmq.REQ)
+        iface = 'tcp://127.0.0.1'
+        port = binder.bind_to_random_port(iface)
+        port2 = binder.bind_to_random_port(iface)
+        port3 = binder.bind_to_random_port(iface)
+        port4 = binder.bind_to_random_port(iface)
+        binder.close()
+        time.sleep(0.1)
+        dev.bind_in("%s:%i" % (iface, port))
+        dev.bind_out("%s:%i" % (iface, port2))
+        dev.bind_mon("%s:%i" % (iface, port3))
+        dev.bind_ctrl("%s:%i" % (iface, port4))
+        dev.start()
+        time.sleep(0.25)
+        msg = b'hello'
+        push = self.context.socket(zmq.PUSH)
+        push.connect("%s:%i" % (iface, port))
+        pull = self.context.socket(zmq.PULL)
+        pull.connect("%s:%i" % (iface, port2))
+        mon = self.context.socket(zmq.PULL)
+        mon.connect("%s:%i" % (iface, port3))
+        ctrl = self.context.socket(zmq.PAIR)
+        ctrl.connect("%s:%i" % (iface, port4))
+        push.send(msg)
+        self.sockets.extend([push, pull, mon, ctrl])
+        self.assertEqual(msg, self.recv(pull))
+        self.assertEqual(msg, self.recv(mon))
+        ctrl.send(b'TERMINATE')
+        dev.join()
+
+    def test_proxy_steerable_statistics(self):
+        if zmq.zmq_version_info() < (4, 3):
+            raise SkipTest("STATISTICS only in libzmq >= 4.3")
+        dev = devices.ThreadProxySteerable(
+            zmq.PULL,
+            zmq.PUSH,
+            zmq.PUSH,
+            zmq.PAIR
+        )
+        binder = self.context.socket(zmq.REQ)
+        iface = 'tcp://127.0.0.1'
+        port = binder.bind_to_random_port(iface)
+        port2 = binder.bind_to_random_port(iface)
+        port3 = binder.bind_to_random_port(iface)
+        port4 = binder.bind_to_random_port(iface)
+        binder.close()
+        time.sleep(0.1)
+        dev.bind_in("%s:%i" % (iface, port))
+        dev.bind_out("%s:%i" % (iface, port2))
+        dev.bind_mon("%s:%i" % (iface, port3))
+        dev.bind_ctrl("%s:%i" % (iface, port4))
+        dev.start()
+        time.sleep(0.25)
+        msg = b'hello'
+        push = self.context.socket(zmq.PUSH)
+        push.connect("%s:%i" % (iface, port))
+        pull = self.context.socket(zmq.PULL)
+        pull.connect("%s:%i" % (iface, port2))
+        mon = self.context.socket(zmq.PULL)
+        mon.connect("%s:%i" % (iface, port3))
+        ctrl = self.context.socket(zmq.PAIR)
+        ctrl.connect("%s:%i" % (iface, port4))
+        push.send(msg)
+        self.sockets.extend([push, pull, mon, ctrl])
+        self.assertEqual(msg, self.recv(pull))
+        self.assertEqual(msg, self.recv(mon))
+        ctrl.send(b'STATISTICS')
+        stats = self.recv_multipart(ctrl)
+        stats_int = [struct.unpack("<Q", x)[0] for x in stats]
+        self.assertEqual(1, stats_int[0])
+        self.assertEqual(len(msg), stats_int[1])
+        self.assertEqual(1, stats_int[6])
+        self.assertEqual(len(msg), stats_int[7])
+        ctrl.send(b'TERMINATE')
+        dev.join()

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -72,6 +72,7 @@
 #else
     #define zmq_msg_gets(msg, prop) _missing
     #define zmq_has(capability) _missing
+    #define zmq_proxy_steerable(in, out, mon, ctrl) _missing
 #endif
 
 #if ZMQ_VERSION_MAJOR >= 3


### PR DESCRIPTION
This will add support for built-in ØMQ proxy with control flow by implementing new `ProxySteerable`, `ThreadProxySteerable` and `ProcessProxySteerable` classes.

http://api.zeromq.org/master:zmq-proxy-steerable

Also fixes #1162.