### PR TITLE
optimize async sends

### DIFF
--- a/zmq/sugar/attrsettr.py
+++ b/zmq/sugar/attrsettr.py
@@ -8,16 +8,19 @@
 from . import constants
 
 class AttributeSetter(object):
-    
+
     def __setattr__(self, key, value):
         """set zmq options by attribute"""
-        
+
+        if key in self.__dict__:
+            object.__setattr__(self, key, value)
+            return
         # regular setattr only allowed for class-defined attributes
-        for obj in [self] + self.__class__.mro():
+        for obj in self.__class__.mro():
             if key in obj.__dict__:
                 object.__setattr__(self, key, value)
                 return
-        
+
         upper_key = key.upper()
         try:
             opt = getattr(constants, upper_key)
@@ -27,11 +30,11 @@ class AttributeSetter(object):
             )
         else:
             self._set_attr_opt(upper_key, opt, value)
-    
+
     def _set_attr_opt(self, name, opt, value):
         """override if setattr should do something other than call self.set"""
         self.set(opt, value)
-    
+
     def __getattr__(self, key):
         """get zmq options by attribute"""
         upper_key = key.upper()
@@ -47,6 +50,6 @@ class AttributeSetter(object):
     def _get_attr_opt(self, name, opt):
         """override if getattr should do something other than call self.get"""
         return self.get(opt)
-    
+
 
 __all__ = ['AttributeSetter']

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -114,7 +114,7 @@ class Socket(SocketBase, AttributeSetter):
     #-------------------------------------------------------------------------
     # Hooks for sockopt completion
     #-------------------------------------------------------------------------
-    
+
     def __dir__(self):
         keys = dir(self.__class__)
         for collection in (
@@ -125,18 +125,21 @@ class Socket(SocketBase, AttributeSetter):
         ):
             keys.extend(collection)
         return keys
-    
+
     #-------------------------------------------------------------------------
     # Getting/Setting options
     #-------------------------------------------------------------------------
     setsockopt = SocketBase.set
     getsockopt = SocketBase.get
-    
+
     def __setattr__(self, key, value):
         """Override to allow setting zmq.[UN]SUBSCRIBE even though we have a subscribe method"""
+        if key in self.__dict__:
+            object.__setattr__(self, key, value)
+            return
         _key = key.lower()
         if _key in ('subscribe', 'unsubscribe'):
-            
+
             if isinstance(value, unicode):
                 value = value.encode('utf8')
             if _key == 'subscribe':


### PR DESCRIPTION
- small optimizations of attribute-access in zmq.sugar
- use lower-level `.get` calls instead of attribute-access convenience APIs in internal code
- reduce unnecessary checks of zmq.EVENTS
- optimize optimistic async sends

The main change here is in the behavior of async sends that would resolve immediately where DONTWAIT is not given. If no sends are already waiting, a send is attempted immediately, with DONTWAIT (this was already the behavior if the caller passed DONTWAIT explicitly). Only if that send fails does the full async machinery kick in.

The benefit comes from skipping the check for zmq.EVENTS prior to send. Actually blocking sends will take a little longer, since they will attempt and fail to send (with EAGAIN), before being scheduled on the eventloop when the socket is ready.

closes #1209