### PR TITLE
fix zmqstream tests with tornado 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,19 @@ env:
 before_install:
   - sudo add-apt-repository -y ppa:anton+/dnscrypt
   - sudo apt-get update
+  - pip install --upgrade setuptools pip
   - |
+    # install libzmq, libsodium unless zmq=bundled
     if [[ $ZMQ != bundled ]]; then
       sudo apt-get install -y -qq libzmq3-dev libsodium-dev
     fi
   - |
+    # install cython unless pypy
     if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then
-      pip install -q cython --install-option="--no-cython-compile"
+      pip install cython
     fi
   - |
+    # build libzmq
     if [[ ! -z "$ZMQ" && $ZMQ != bundled ]]; then
       wget https://github.com/zeromq/$ZMQ/archive/master.zip -O libzmq.zip
       unzip libzmq.zip
@@ -39,13 +43,15 @@ before_install:
     fi
   - pip install -r test-requirements.txt
   - |
+    # install pinned tornado
     if [[ "$TORNADO" == "master" ]]; then
       pip install https://github.com/tornadoweb/tornado/archive/master.zip
-    fi
-  - |
-    if [[ "$NOTORNADO" == "1" ]]; then
+    elif [[ "$TORNADO" == "none" ]]; then
       pip uninstall -yq tornado
+    elif [[ ! -z "$TORNADO" ]]; then
+      pip install tornado==${TORNADO}
     fi
+  - pip freeze
 
 install:
   - python setup.py build_ext --inplace --zmq=$ZMQ
@@ -53,8 +59,6 @@ install:
 matrix:
   include:
     - python: pypy
-      env: ZMQ=bundled
-    - python: 3.6-dev
       env: ZMQ=bundled
     - python: 3.7
       env: ZMQ=
@@ -65,11 +69,19 @@ matrix:
     - python: 3.6
       env:
         - ZMQ=
-        - NOTORNADO=1
+        - TORNADO=none
     - python: 3.6
       env:
         - ZMQ=
         - TORNADO=master
+    - python: 3.6
+      env:
+        - ZMQ=
+        - TORNADO=4.5.*
+    - python: 2.7
+      env:
+        - ZMQ=
+        - TORNADO=4.5.*
     - python: 3.5
       env: ZMQ=libzmq
     - python: 3.4

--- a/zmq/tests/test_zmqstream.py
+++ b/zmq/tests/test_zmqstream.py
@@ -27,7 +27,8 @@ class TestZMQStream(TestCase):
         if asyncio:
             asyncio.set_event_loop(asyncio.new_event_loop())
         self.context = zmq.Context()
-        self.loop = ioloop.IOLoop.instance()
+        self.loop = ioloop.IOLoop()
+        self.loop.make_current()
         self.push = zmqstream.ZMQStream(self.context.socket(zmq.PUSH))
         self.pull = zmqstream.ZMQStream(self.context.socket(zmq.PULL))
         port = self.push.bind_to_random_port('tcp://127.0.0.1')
@@ -37,7 +38,7 @@ class TestZMQStream(TestCase):
     def tearDown(self):
         self.loop.close(all_fds=True)
         self.context.term()
-        ioloop.IOLoop.clear_instance()
+        ioloop.IOLoop.clear_current()
 
     def run_until_timeout(self, timeout=10):
         timed_out = []


### PR DESCRIPTION
create a new IOLoop for each test.

instead of calling `IOLoop.instance()`, which may return a closed object.

closes #1205