### PR TITLE
improve test_large_send

### DIFF
--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -485,7 +485,7 @@ class TestSocket(BaseZMQTestCase):
         pub.send(b'prefixmessage')
         events = p.poll(1000)
         self.assertEqual(events, [])
-    
+
     # Travis can't handle how much memory PyPy uses on this test
     @mark.skipif(
         (
@@ -497,16 +497,30 @@ class TestSocket(BaseZMQTestCase):
         ),
         reason="only run on 64b and not on Travis."
     )
+    @mark.large
     def test_large_send(self):
+        c = os.urandom(1)
+        N = 2**31 + 1
         try:
-            buf = os.urandom(1) * (2**31 + 1)
-        except MemoryError:
-            raise SkipTest()
+            buf = c * N
+        except MemoryError as e:
+            raise SkipTest("Not enough memory: %s" % e)
         a, b = self.create_bound_pair()
-        a.send(buf, copy=False)
-        rcvd = b.recv()
-        assert rcvd == buf
-    
+        try:
+            a.send(buf, copy=False)
+            rcvd = b.recv(copy=False)
+        except MemoryError as e:
+            raise SkipTest("Not enough memory: %s" % e)
+        # sample the front and back of the received message
+        # without checking the whole content
+        # Python 2: items in memoryview are bytes
+        # Python 3: items im memoryview are int
+        byte = c if sys.version_info < (3,) else ord(c)
+        view = memoryview(rcvd)
+        assert len(view) == N
+        assert view[0] == byte
+        assert view[-1] == byte
+
     def test_custom_serialize(self):
         a, b = self.create_bound_pair(zmq.DEALER, zmq.ROUTER)
         def serialize(msg):
@@ -515,7 +529,7 @@ class TestSocket(BaseZMQTestCase):
             content = json.dumps(msg['content']).encode('utf8')
             frames.append(content)
             return frames
-        
+
         def deserialize(frames):
             identities = frames[:-1]
             content = json.loads(frames[-1].decode('utf8'))


### PR DESCRIPTION
- reduce memory requirements by calling `recv(copy=False)`
- treat MemoryError during send/recv as a skip due to insufficient memory
- give it mark.large so it's easier for test runners to skip it explicitly

closes #1181
closes #1191