### PR TITLE
Add Device methods to bind sockets to a random port

### DIFF
--- a/zmq/devices/proxydevice.py
+++ b/zmq/devices/proxydevice.py
@@ -25,10 +25,22 @@ class ProxyBase(object):
         """
         self._mon_binds.append(addr)
 
+    def bind_mon_to_random_port(self, addr, *args, **kwargs):
+        """Enqueue a random port on the given interface for binding on
+        mon_socket.
+
+        See zmq.Socket.bind_to_random_port for details.
+        """
+        port = self._reserve_random_port(addr, *args, **kwargs)
+
+        self.bind_mon('%s:%i' % (addr, port))
+
+        return port
+
     def connect_mon(self, addr):
         """Enqueue ZMQ address for connecting on mon_socket.
 
-        See zmq.Socket.bind for details.
+        See zmq.Socket.connect for details.
         """
         self._mon_connects.append(addr)
 

--- a/zmq/devices/proxysteerabledevice.py
+++ b/zmq/devices/proxysteerabledevice.py
@@ -28,10 +28,22 @@ class ProxySteerableBase(object):
         """
         self._ctrl_binds.append(addr)
 
+    def bind_ctrl_to_random_port(self, addr, *args, **kwargs):
+        """Enqueue a random port on the given interface for binding on
+        ctrl_socket.
+
+        See zmq.Socket.bind_to_random_port for details.
+        """
+        port = self._reserve_random_port(addr, *args, **kwargs)
+
+        self.bind_ctrl('%s:%i' % (addr, port))
+
+        return port
+
     def connect_ctrl(self, addr):
         """Enqueue ZMQ address for connecting on ctrl_socket.
 
-        See zmq.Socket.bind for details.
+        See zmq.Socket.connect for details.
         """
         self._ctrl_connects.append(addr)
 

--- a/zmq/tests/test_device.py
+++ b/zmq/tests/test_device.py
@@ -58,14 +58,9 @@ class TestDevice(BaseZMQTestCase):
         if zmq.zmq_version() in ('4.1.1', '4.0.6'):
             raise SkipTest("libzmq-%s broke single-socket devices" % zmq.zmq_version())
         dev = devices.ThreadDevice(zmq.QUEUE, zmq.REP, -1)
-        # select random port:
-        binder = self.context.socket(zmq.REQ)
-        port = binder.bind_to_random_port('tcp://127.0.0.1')
-        binder.close()
-        time.sleep(0.1)
+        port = dev.bind_in_to_random_port('tcp://127.0.0.1')
         req = self.context.socket(zmq.REQ)
         req.connect('tcp://127.0.0.1:%i'%port)
-        dev.bind_in('tcp://127.0.0.1:%i'%port)
         dev.start()
         time.sleep(.25)
         msg = b'hello'
@@ -74,14 +69,9 @@ class TestDevice(BaseZMQTestCase):
         del dev
         req.close()
         dev = devices.ThreadDevice(zmq.QUEUE, zmq.REP, -1)
-        # select random port:
-        binder = self.context.socket(zmq.REQ)
-        port = binder.bind_to_random_port('tcp://127.0.0.1')
-        binder.close()
-        time.sleep(0.1)
+        port = dev.bind_in_to_random_port('tcp://127.0.0.1')
         req = self.context.socket(zmq.REQ)
         req.connect('tcp://127.0.0.1:%i'%port)
-        dev.bind_in('tcp://127.0.0.1:%i'%port)
         dev.start()
         time.sleep(.25)
         msg = b'hello again'
@@ -120,16 +110,10 @@ class TestDevice(BaseZMQTestCase):
         if zmq.zmq_version_info() < (3,2):
             raise SkipTest("Proxies only in libzmq >= 3")
         dev = devices.ThreadProxy(zmq.PULL, zmq.PUSH, zmq.PUSH)
-        binder = self.context.socket(zmq.REQ)
         iface = 'tcp://127.0.0.1'
-        port = binder.bind_to_random_port(iface)
-        port2 = binder.bind_to_random_port(iface)
-        port3 = binder.bind_to_random_port(iface)
-        binder.close()
-        time.sleep(0.1)
-        dev.bind_in("%s:%i" % (iface, port))
-        dev.bind_out("%s:%i" % (iface, port2))
-        dev.bind_mon("%s:%i" % (iface, port3))
+        port = dev.bind_in_to_random_port(iface)
+        port2 = dev.bind_out_to_random_port(iface)
+        port3 = dev.bind_mon_to_random_port(iface)
         dev.start()
         time.sleep(0.25)
         msg = b'hello'

--- a/zmq/tests/test_monqueue.py
+++ b/zmq/tests/test_monqueue.py
@@ -171,11 +171,8 @@ class TestMonitoredQueue(BaseZMQTestCase):
         dev.setsockopt_out(zmq.LINGER, 0)
         dev.setsockopt_mon(zmq.LINGER, 0)
         
-        binder = self.context.socket(zmq.DEALER)
-        porta = binder.bind_to_random_port('tcp://127.0.0.1')
-        portb = binder.bind_to_random_port('tcp://127.0.0.1')
-        binder.close()
-        time.sleep(1)
+        porta = dev.bind_in_to_random_port('tcp://127.0.0.1')
+        portb = dev.bind_out_to_random_port('tcp://127.0.0.1')
         a = self.context.socket(zmq.DEALER)
         a.identity = b'a'
         b = self.context.socket(zmq.DEALER)
@@ -183,9 +180,7 @@ class TestMonitoredQueue(BaseZMQTestCase):
         self.sockets.extend([a, b])
         
         a.connect('tcp://127.0.0.1:%i'%porta)
-        dev.bind_in('tcp://127.0.0.1:%i'%porta)
         b.connect('tcp://127.0.0.1:%i'%portb)
-        dev.bind_out('tcp://127.0.0.1:%i'%portb)
         dev.start()
         time.sleep(1)
         if zmq.zmq_version_info() >= (3,1,0):

--- a/zmq/tests/test_proxy_steerable.py
+++ b/zmq/tests/test_proxy_steerable.py
@@ -24,18 +24,11 @@ class TestProxySteerable(BaseZMQTestCase):
             zmq.PUSH,
             zmq.PAIR
         )
-        binder = self.context.socket(zmq.REQ)
         iface = 'tcp://127.0.0.1'
-        port = binder.bind_to_random_port(iface)
-        port2 = binder.bind_to_random_port(iface)
-        port3 = binder.bind_to_random_port(iface)
-        port4 = binder.bind_to_random_port(iface)
-        binder.close()
-        time.sleep(0.1)
-        dev.bind_in("%s:%i" % (iface, port))
-        dev.bind_out("%s:%i" % (iface, port2))
-        dev.bind_mon("%s:%i" % (iface, port3))
-        dev.bind_ctrl("%s:%i" % (iface, port4))
+        port = dev.bind_in_to_random_port(iface)
+        port2 = dev.bind_out_to_random_port(iface)
+        port3 = dev.bind_mon_to_random_port(iface)
+        port4 = dev.bind_ctrl_to_random_port(iface)
         dev.start()
         time.sleep(0.25)
         msg = b'hello'
@@ -85,18 +78,11 @@ class TestProxySteerable(BaseZMQTestCase):
             zmq.PUSH,
             zmq.PAIR
         )
-        binder = self.context.socket(zmq.REQ)
         iface = 'tcp://127.0.0.1'
-        port = binder.bind_to_random_port(iface)
-        port2 = binder.bind_to_random_port(iface)
-        port3 = binder.bind_to_random_port(iface)
-        port4 = binder.bind_to_random_port(iface)
-        binder.close()
-        time.sleep(0.1)
-        dev.bind_in("%s:%i" % (iface, port))
-        dev.bind_out("%s:%i" % (iface, port2))
-        dev.bind_mon("%s:%i" % (iface, port3))
-        dev.bind_ctrl("%s:%i" % (iface, port4))
+        port = dev.bind_in_to_random_port(iface)
+        port2 = dev.bind_out_to_random_port(iface)
+        port3 = dev.bind_mon_to_random_port(iface)
+        port4 = dev.bind_ctrl_to_random_port(iface)
         dev.start()
         time.sleep(0.25)
         msg = b'hello'

--- a/zmq/tests/test_proxy_steerable.py
+++ b/zmq/tests/test_proxy_steerable.py
@@ -54,6 +54,28 @@ class TestProxySteerable(BaseZMQTestCase):
         ctrl.send(b'TERMINATE')
         dev.join()
 
+    def test_proxy_steerable_bind_to_random_with_args(self):
+        if zmq.zmq_version_info() < (4, 1):
+            raise SkipTest("Steerable Proxies only in libzmq >= 4.1")
+        dev = devices.ThreadProxySteerable(
+            zmq.PULL,
+            zmq.PUSH,
+            zmq.PUSH,
+            zmq.PAIR
+        )
+        iface = 'tcp://127.0.0.1'
+        ports = []
+        min, max = 5000, 5050
+        ports.extend([
+            dev.bind_in_to_random_port(iface, min_port=min, max_port=max),
+            dev.bind_out_to_random_port(iface, min_port=min, max_port=max),
+            dev.bind_mon_to_random_port(iface, min_port=min, max_port=max),
+            dev.bind_ctrl_to_random_port(iface, min_port=min, max_port=max)
+        ])
+        for port in ports:
+            if port < min or port > max:
+                self.fail('Unexpected port number: %i' % port)
+
     def test_proxy_steerable_statistics(self):
         if zmq.zmq_version_info() < (4, 3):
             raise SkipTest("STATISTICS only in libzmq >= 4.3")


### PR DESCRIPTION
This will add methods to bind Device sockets to a random port:
```python
dev = devices.ThreadProxy(zmq.PULL, zmq.PUSH, zmq.PUSH)
iface = 'tcp://127.0.0.1'
port1 = dev.bind_in_to_random_port(iface)
port2 = dev.bind_out_to_random_port(iface)
port3 = dev.bind_mon_to_random_port(iface)
dev.start()
```