### PR TITLE
Problem: zmq.EVENT_ALL changes as more events are added and test fails

### DIFF
--- a/zmq/tests/test_monitor.py
+++ b/zmq/tests/test_monitor.py
@@ -26,7 +26,7 @@ class TestSocketMonitor(BaseZMQTestCase):
         s_req.bind("tcp://127.0.0.1:6666")
         # try monitoring the REP socket
         
-        s_rep.monitor("inproc://monitor.rep", zmq.EVENT_ALL)
+        s_rep.monitor("inproc://monitor.rep", zmq.EVENT_CONNECT_DELAYED | zmq.EVENT_CONNECTED | zmq.EVENT_MONITOR_STOPPED)
         # create listening socket for monitor
         s_event = self.context.socket(zmq.PAIR)
         self.sockets.append(s_event)


### PR DESCRIPTION
Solution: pin the test so that it only requests the events it's looking
for, to avoid failures when a new event is added.
As the documentation says, and as it can be expected, EVENT_ALL is a
catch-all mask that changes over time.