### PR TITLE
Fix parsing README.md unicode char handling during setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
 #-----------------------------------------------------------------------------
 #  Copyright (C) PyZMQ Developers
 #  Distributed under the terms of the Modified BSD License.
@@ -24,6 +26,7 @@ import sys
 import time
 import errno
 import platform
+import codecs
 from traceback import print_exc
 
 # whether any kind of bdist is happening
@@ -1236,8 +1239,7 @@ def find_packages():
 #-----------------------------------------------------------------------------
 # Main setup
 #-----------------------------------------------------------------------------
-
-with open("README.md") as f:
+with codecs.open('README.md', 'r', 'utf-8') as f:
     long_desc = f.read()
 
 setup_args = dict(


### PR DESCRIPTION
While installing lates `pyzmq` on `CentOS 7`, I get the following error:
```
Collecting pyzmq>=17 (from notebook->jupyter)
  Downloading https://files.pythonhosted.org/packages/64/8d/78975da77627fd863c08e8ea3c7cebce7e51bed2936be5118de6b0050638/pyzmq-18.0.0.tar.gz (1.2MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-rv3k_yvp/pyzmq/setup.py", line 1241, in <module>
        long_desc = f.read()
      File "/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 29: ordinal not in range(128)
    
    ----------------------------------------
[91mCommand "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-rv3k_yvp/pyzmq/
[0m[91mYou are using pip version 18.1, however version 19.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```