### PR TITLE
BLD: pin cython language version to 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1146,7 +1146,7 @@ ext_kwargs = {
 }
 if cython:
     # set binding so that compiled methods can be inspected
-    ext_kwargs['cython_directives'] = {'binding': True}
+    ext_kwargs['cython_directives'] = {'binding': True, 'language_level': 2}
 
 for submod, packages in submodules.items():
     for pkg in sorted(packages):


### PR DESCRIPTION
This is the language that level that cython expects in the pyx and pyd
files not the target.  Most critically, the implicit local imports are
not supported by the new default ('3str').