### PR TITLE
Add Python 3 code in NumPy serialization example

### DIFF
--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -79,8 +79,7 @@ the array.
         """recv a numpy array"""
         md = socket.recv_json(flags=flags)
         msg = socket.recv(flags=flags, copy=copy, track=track)
-        buf = buffer(msg)  # Python 2.x
-        # buf = memoryview(msg) # Python 3.x
+        buf = memoryview(msg)
         A = numpy.frombuffer(buf, dtype=md['dtype'])
         return A.reshape(md['shape'])
 

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -79,7 +79,8 @@ the array.
         """recv a numpy array"""
         md = socket.recv_json(flags=flags)
         msg = socket.recv(flags=flags, copy=copy, track=track)
-        buf = buffer(msg)
+        buf = buffer(msg)  # Python 2.x
+        # buf = memoryview(msg) # Python 3.x
         A = numpy.frombuffer(buf, dtype=md['dtype'])
         return A.reshape(md['shape'])
 


### PR DESCRIPTION
In Python 3.x, the buffer builtin is no longer used.  Instead this is called memoryview.
Updated the example code to include both of these, with a note explaining which to use.