### PR TITLE
Display ipc path in case of ENOENT exception

### DIFF
--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -136,6 +136,14 @@ class Socket(object):
                                 'characters (sizeof(sockaddr_un.sun_path)).'
                                 .format(path, IPC_PATH_MAX_LEN))
                 raise ZMQError(C.zmq_errno(), msg=msg)
+            elif C.zmq_errno() == errno_mod.ENOENT:
+                # py3compat: address is bytes, but msg wants str
+                if str is unicode:
+                    address = address.decode('utf-8', 'replace')
+                path = address.split('://', 1)[-1]
+                msg = ('No such file or directory for ipc path "{0}".'.format(
+                       path))
+                raise ZMQError(C.zmq_errno(), msg=msg)
             else:
                 _check_rc(rc)
 

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -27,7 +27,7 @@
 cdef extern from "pyversion_compat.h":
     pass
 
-from libc.errno cimport ENAMETOOLONG, ENOTSOCK
+from libc.errno cimport ENAMETOOLONG, ENOENT, ENOTSOCK
 from libc.string cimport memcpy
 
 from cpython cimport PyBytes_FromStringAndSize
@@ -541,6 +541,14 @@ cdef class Socket:
                                 'zmq.IPC_PATH_MAX_LEN constant can be used '
                                 'to check addr length (if it is defined).'
                                 .format(path, IPC_PATH_MAX_LEN))
+                raise ZMQError(msg=msg)
+            elif zmq_errno() == ENOENT:
+                # py3compat: address is bytes, but msg wants str
+                if str is unicode:
+                    addr = addr.decode('utf-8', 'replace')
+                path = addr.split('://', 1)[-1]
+                msg = ('No such file or directory for ipc path "{0}".'.format(
+                       path))
                 raise ZMQError(msg=msg)
         while True:
             try:

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import copy
+import errno
 import json
 import os
 import platform
@@ -406,6 +407,7 @@ class TestSocket(BaseZMQTestCase):
         invalid_path = '/foo/bar'
         with pytest.raises(zmq.ZMQError) as error:
             s.bind('ipc://{0}'.format(invalid_path))
+        assert error.value.errno == errno.ENOENT
         error_message = str(error.value)
         assert invalid_path in error_message
         assert "no such file or directory" in error_message.lower()


### PR DESCRIPTION
Useful to see right in the traceback which ipc path caused the
exception.