### PR TITLE
zmq.asyncio.rst: Modernize the code example

### DIFF
--- a/docs/source/api/zmq.asyncio.rst
+++ b/docs/source/api/zmq.asyncio.rst
@@ -24,15 +24,14 @@ and :meth:`zmq.asyncio.Poller.poll` return :class:`~.asyncio.Future` s.
 
     ctx = zmq.asyncio.Context()
 
-    @asyncio.coroutine
-    def recv_and_process():
+    async def recv_and_process():
         sock = ctx.socket(zmq.PULL)
         sock.bind(url)
-        msg = yield from sock.recv_multipart() # waits for msg to be ready
-        reply = yield from async_process(msg)
-        yield from sock.send_multipart(reply)
+        msg = await sock.recv_multipart() # waits for msg to be ready
+        reply = await async_process(msg)
+        await sock.send_multipart(reply)
 
-    asyncio.get_event_loop().run_until_complete(recv_and_process())
+    asyncio.run(recv_and_process())
 
 
 Classes


### PR DESCRIPTION
The example usage in the page was outdated and used the syntax appropriate for python 3.4.
Since python 3.5, we have the `async` and `await` keywords, and since python 3.7 we have
the `asyncio.run` function that creates a run loop and runs a single coroutine in it.