### PR TITLE
Use is_alive instead of deprecated isAlive removed in Python 3.9.

### DIFF
--- a/zmq/tests/test_ioloop.py
+++ b/zmq/tests/test_ioloop.py
@@ -84,7 +84,7 @@ class TestIOLoop(BaseZMQTestCase):
         t = Delay(loop.stop,1)
         t.start()
         loop.start()
-        if t.isAlive():
+        if t.is_alive():
             t.abort()
         else:
             self.fail("IOLoop failed to exit")


### PR DESCRIPTION
Use `is_alive` since `isAlive` was removed in Python 3.9 with https://github.com/python/cpython/pull/15225 