### PR TITLE
Make contributing.md code example py3 compatible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ The basics:
 import sys
 import zmq
 
-print "libzmq-%s" % zmq.zmq_version()
-print "pyzmq-%s" % zmq.pyzmq_version()
-print "Python-%s" % sys.version
+print("libzmq-%s" % zmq.zmq_version())
+print("pyzmq-%s" % zmq.pyzmq_version())
+print("Python-%s" % sys.version)
 ```
 
 Which will give something like:


### PR DESCRIPTION
Trivial change, while reading the docs noticed it was py2 only. This should work on both I think. Tested locally with Python 3.7.6 :+1: 