### PR TITLE
Problem: build with cython < 0.29 fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1126,6 +1126,7 @@ submodules = {
 }
 
 min_cython_version = '0.20'
+cython_language_level = '3str'
 try:
     import Cython
     if V(Cython.__version__) < V(min_cython_version):
@@ -1134,6 +1135,9 @@ try:
     from Cython.Distutils import build_ext as build_ext_c
     from Cython.Distutils import Extension
     cython = True
+    # 3str was added in cython 0.29
+    if V(Cython.__version__) < V('0.29'):
+        cython_language_level = 2
 except Exception:
     cython = False
     suffix = '.c'
@@ -1205,7 +1209,7 @@ ext_kwargs = {
 }
 if cython:
     # set binding so that compiled methods can be inspected
-    ext_kwargs['cython_directives'] = {'binding': True, 'language_level': '3str'}
+    ext_kwargs['cython_directives'] = {'binding': True, 'language_level': cython_language_level}
 
 for submod, packages in submodules.items():
     for pkg in sorted(packages):

--- a/setup.py
+++ b/setup.py
@@ -1125,8 +1125,15 @@ submodules = {
     },
 }
 
-min_cython_version = '0.20'
-cython_language_level = '3str'
+if sys.version_info >= (3, 7):
+    # require cython 0.29 on Python >= 3.7
+    min_cython_version = '0.29'
+    cython_language_level = '3str'
+else:
+    # be more lenient on old versions of Python
+    min_cython_version = '0.20'
+    cython_language_level = None
+
 try:
     import Cython
     if V(Cython.__version__) < V(min_cython_version):
@@ -1135,9 +1142,10 @@ try:
     from Cython.Distutils import build_ext as build_ext_c
     from Cython.Distutils import Extension
     cython = True
-    # 3str was added in cython 0.29
-    if V(Cython.__version__) < V('0.29'):
-        cython_language_level = 2
+    # 3str was added in Cython 0.29
+    # use it if available
+    if V(Cython.__version__) >= V('0.29'):
+        cython_language_level = '3str'
 except Exception:
     cython = False
     suffix = '.c'
@@ -1209,7 +1217,9 @@ ext_kwargs = {
 }
 if cython:
     # set binding so that compiled methods can be inspected
-    ext_kwargs['cython_directives'] = {'binding': True, 'language_level': cython_language_level}
+    ext_kwargs['cython_directives'] = {'binding': True}
+    if cython_language_level:
+        ext_kwargs['cython_directives']['language_level'] = cython_language_level
 
 for submod, packages in submodules.items():
     for pkg in sorted(packages):


### PR DESCRIPTION
Solution: add backward compatibility for language_level and set it to 2
if cython doesn't support 3str