### PR TITLE
fix: avoid memory leak in case of several sockets registered to a poller

### DIFF
--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -114,6 +114,9 @@ class _AsyncPoller(_zmq.Poller):
 
 class _AsyncSocket(_zmq.Socket):
 
+
+    # Warning : these class variables are only here to allow to call super().__setattr__.
+    # They be overridden at instance initialization and not shared in the whole class
     _recv_futures = None
     _send_futures = None
     _state = 0
@@ -302,14 +305,13 @@ class _AsyncSocket(_zmq.Socket):
         Avoids delaying cleanup until the next send/recv event,
         which may never come.
         """
-        if getattr(future, '_pyzmq_popped', False):
-            return
         for f_idx, (f, kind, kwargs, _) in enumerate(event_list):
             if f is future:
                 break
         else:
             return
-        future._pyzmq_popped = True
+
+        # "future" instance is shared between sockets, but each socket has its own event list.
         event_list.remove(event_list[f_idx])
 
     def _add_recv_event(self, kind, kwargs=None, future=None):
@@ -411,7 +413,6 @@ class _AsyncSocket(_zmq.Socket):
         f = None
         while self._recv_futures:
             f, kind, kwargs, _ = self._recv_futures.popleft()
-            f._pyzmq_popped = True
             # skip any cancelled futures
             if f.done():
                 f = None
@@ -450,7 +451,6 @@ class _AsyncSocket(_zmq.Socket):
         f = None
         while self._send_futures:
             f, kind, kwargs, msg = self._send_futures.popleft()
-            f._pyzmq_popped = True
             # skip any cancelled futures
             if f.done():
                 f = None


### PR DESCRIPTION
Here a fix to manage several sockets (#1361), based on the fact each socket has its own list of Futures.
The fix no more use a flag on the shared instance of Future.