### PR TITLE
Fix bug where signals wouldn't actually interrupt recv()

### DIFF
--- a/zmq/backend/cython/checkrc.pxd
+++ b/zmq/backend/cython/checkrc.pxd
@@ -10,7 +10,12 @@ cdef inline int _check_rc(int rc) except -1:
     and raising the appropriate Exception class
     """
     cdef int errno = zmq_errno()
-    PyErr_CheckSignals()
+    cdef int signal_code = PyErr_CheckSignals()
+    if signal_code == -1:
+        # The signal handler raised an exception, e.g. SIGINT does
+        # KeyboardInterrupt by default, so make sure it gets raised and not
+        # swallowed.
+        return -1
     if rc == -1: # if rc < -1, it's a bug in libzmq. Should we warn?
         if errno == EINTR:
             from zmq.error import InterruptedSystemCall


### PR DESCRIPTION
In some cases a signal will be received while waiting in a socket's `recv()`. For example, a SIGINT may raise a KeyboardInterrupt. The way one is supposed to handle this is by calling `PyErr_CheckSignals()`, and if that returns a negative number that means an exception was raised.

See https://docs.python.org/3/c-api/exceptions.html#c.PyErr_CheckSignals for the docs.

The second part of the usage wasn't implemented, so the exception wasn't raised.

This PR fixes that. As an example of real-world impact, this should fix part of https://github.com/ipython/ipython/issues/10516, specifically the bit where e.g. `input()` was not interruptible.