### PR TITLE
Merge pull request #1369 from chronitis/test-endian-fix

### DIFF
--- a/zmq/tests/test_proxy_steerable.py
+++ b/zmq/tests/test_proxy_steerable.py
@@ -100,7 +100,7 @@ class TestProxySteerable(BaseZMQTestCase):
         self.assertEqual(msg, self.recv(mon))
         ctrl.send(b'STATISTICS')
         stats = self.recv_multipart(ctrl)
-        stats_int = [struct.unpack("<Q", x)[0] for x in stats]
+        stats_int = [struct.unpack("=Q", x)[0] for x in stats]
         self.assertEqual(1, stats_int[0])
         self.assertEqual(len(msg), stats_int[1])
         self.assertEqual(1, stats_int[6])


### PR DESCRIPTION
Found building the debian package for pyzmq: `test_proxy_steerable_statistics` fails on big-endian platforms.

This test always unpacks the message in little-endian ordering, when I _think_ it should be native ordering. This is a one-byte fix to use native ordering, after which the tests pass on these platforms.