### PR TITLE
fix building with C++ compiler

### DIFF
--- a/zmq/utils/mutex.h
+++ b/zmq/utils/mutex.h
@@ -48,7 +48,7 @@ _mutex_finalize(mutex_t* mutex) {
 
 mutex_t*
 mutex_allocate(void) {
-    mutex_t* mutex = malloc(sizeof(mutex_t));
+    mutex_t* mutex = (mutex_t*)malloc(sizeof(mutex_t));
     _mutex_initialize(mutex);
     return mutex;
 }


### PR DESCRIPTION
implicit cast is usually not liked by C++ compilers. GCC 9.3.0 gives an error about this