### PR TITLE
#1245 Fix `setup.py build --debug` on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,6 @@ def bundled_settings(debug):
             suffix = os.path.splitext(ext_suffix)[0]
 
         if debug:
-            suffix = '_d' + suffix
             release = 'Debug'
         else:
             release = 'Release'


### PR DESCRIPTION
**Actual issue**

- `python setup.py build --debug` fails with `LINK : fatal error LNK1181: cannot open input file 'libzmq_d.cp36-win_amd64.lib'` on Windows.
- `python_d setup.py build --debug` fails with `LINK : fatal error LNK1181: cannot open input file 'libzmq_d_d.cp36-win_amd64.lib'` on Windows.

i.e. Unnecessary `_d` is added when `--debug` is speficied.

**This PR also fixes #1245**

```
python_d -m pip install --global-option build --global-option --debug https://github.com/sakurai-youhei/pyzmq/archive/bugfix/issue-1245_build_--debug_on_windows.zip
```

Above installation with python_d resolves the #1245 as below.

```
python_d -m pytest --pyargs zmq.tests

================================================= test session starts =================================================
platform win32 -- Python 3.7.7, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
==================================== 210 passed, 55 skipped, 51 warnings in 48.54s ====================================
```

