### PR TITLE
explicitly avoid sharing context instances across eventloop Context classes

### DIFF
--- a/zmq/asyncio/__init__.py
+++ b/zmq/asyncio/__init__.py
@@ -65,6 +65,9 @@ class Context(_zmq.Context):
     """Context for creating asyncio-compatible Sockets"""
     _socket_class = Socket
 
+    # avoid sharing instance with base Context class
+    _instance = None
+
 
 class ZMQEventLoop(SelectorEventLoop):
     """DEPRECATED: AsyncIO eventloop using zmq_poll.

--- a/zmq/eventloop/future.py
+++ b/zmq/eventloop/future.py
@@ -57,12 +57,15 @@ class Socket(_AsyncTornado, _AsyncSocket):
 Poller._socket_class = Socket
 
 class Context(_zmq.Context):
-    
+
+    # avoid sharing instance with base Context class
+    _instance = None
+
     io_loop = None
     @staticmethod
     def _socket_class(self, socket_type):
         return Socket(self, socket_type, io_loop=self.io_loop)
-    
+
     def __init__(self, *args, **kwargs):
         io_loop = kwargs.pop('io_loop', None)
         super(Context, self).__init__(*args, **kwargs)

--- a/zmq/green/core.py
+++ b/zmq/green/core.py
@@ -262,7 +262,7 @@ class _Socket(_original_Socket):
             self.__in_recv_multipart = False
             self.__state_changed()
         return msg
-    
+
     def get(self, opt):
         """trigger state_changed on getsockopt(EVENTS)"""
         if opt in TIMEOS:
@@ -271,7 +271,7 @@ class _Socket(_original_Socket):
         if opt == zmq.EVENTS:
             self.__state_changed()
         return optval
-    
+
     def set(self, opt, val):
         """set socket option"""
         if opt in TIMEOS:
@@ -285,3 +285,6 @@ class _Context(_original_Context):
     Ensures that the greened Socket above is used in calls to `socket`.
     """
     _socket_class = _Socket
+
+    # avoid sharing instance with base Context class
+    _instance = None

--- a/zmq/tests/asyncio/_test_asyncio.py
+++ b/zmq/tests/asyncio/_test_asyncio.py
@@ -46,6 +46,22 @@ class TestAsyncIOSocket(BaseZMQTestCase):
         assert isinstance(s, zaio.Socket)
         s.close()
 
+    def test_instance_subclass_first(self):
+        actx = zmq.asyncio.Context.instance()
+        ctx = zmq.Context.instance()
+        ctx.term()
+        actx.term()
+        assert type(ctx) is zmq.Context
+        assert type(actx) is zmq.asyncio.Context
+
+    def test_instance_subclass_second(self):
+        ctx = zmq.Context.instance()
+        actx = zmq.asyncio.Context.instance()
+        ctx.term()
+        actx.term()
+        assert type(ctx) is zmq.Context
+        assert type(actx) is zmq.asyncio.Context
+
     def test_recv_multipart(self):
         @asyncio.coroutine
         def test():

--- a/zmq/tests/test_future.py
+++ b/zmq/tests/test_future.py
@@ -37,6 +37,22 @@ class TestFutureSocket(BaseZMQTestCase):
         assert isinstance(s, future.Socket)
         s.close()
 
+    def test_instance_subclass_first(self):
+        actx = self.Context.instance()
+        ctx = zmq.Context.instance()
+        ctx.term()
+        actx.term()
+        assert type(ctx) is zmq.Context
+        assert type(actx) is self.Context
+
+    def test_instance_subclass_second(self):
+        ctx = zmq.Context.instance()
+        actx = self.Context.instance()
+        ctx.term()
+        actx.term()
+        assert type(ctx) is zmq.Context
+        assert type(actx) is self.Context
+
     def test_recv_multipart(self):
         @gen.coroutine
         def test():


### PR DESCRIPTION
default inheritance is to share, so that a custom Context can replace the global instance, but don't do so for our eventloop instances.

closes #940
closes #1172