### PR TITLE
ensure zmq objects are mockable

### DIFF
--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -11,6 +11,10 @@ try:
     from queue import Queue
 except ImportError:
     from Queue import Queue
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 from pytest import mark
 
@@ -51,6 +55,11 @@ class TestContext(BaseZMQTestCase):
         if zmq.zmq_version_info() > (3,):
             self.assertTrue('IO_THREADS' in dir(ctx))
         ctx.term()
+
+    @mark.skipif(mock is None, reason="requires unittest.mock")
+    def test_mockable(self):
+        m = mock.Mock(spec=self.context)
+
 
     def test_term(self):
         c = self.Context()

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -11,6 +11,10 @@ import time
 import warnings
 import socket
 import sys
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 import pytest
 from pytest import mark
@@ -54,7 +58,7 @@ class TestSocket(BaseZMQTestCase):
                 self.assertEqual(b.closed, True)
             self.assertEqual(a.closed, True)
         self.assertEqual(ctx.closed, True)
-    
+
     def test_dir(self):
         ctx = self.Context()
         s = ctx.socket(zmq.PUB)
@@ -64,6 +68,12 @@ class TestSocket(BaseZMQTestCase):
         self.assertTrue('FD' in dir(s))
         s.close()
         ctx.term()
+
+    @mark.skipif(mock is None, reason="requires unittest.mock")
+    def test_mockable(self):
+        s = self.socket(zmq.SUB)
+        m = mock.Mock(spec=s)
+        s.close()
 
     def test_bind_unicode(self):
         s = self.socket(zmq.PUB)


### PR DESCRIPTION
turn EINVAL into AttributeError for write-only attributes

closes #1360