### PR TITLE
Simplified sockets tracking for reliable process teardown

### DIFF
--- a/zmq/backend/cffi/context.py
+++ b/zmq/backend/cffi/context.py
@@ -4,8 +4,6 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
-import weakref
-
 from ._cffi import C, ffi
 
 from .constants import EINVAL, IO_THREADS, LINGER

--- a/zmq/sugar/context.py
+++ b/zmq/sugar/context.py
@@ -7,11 +7,7 @@
 import atexit
 import os
 from threading import Lock
-import weakref
-
-# direct reference limits garbage collection issues
-# during process teardown
-weak_ref = weakref.ref
+from weakref import WeakSet
 
 from zmq.backend import Context as ContextBase
 from . import constants
@@ -46,7 +42,7 @@ class Context(ContextBase, AttributeSetter):
         else:
             self._shadow = False
         self.sockopts = {}
-        self._sockets = set()
+        self._sockets = WeakSet()
 
     def __del__(self):
         """deleting a Context should terminate it, without trying non-threadsafe destroy"""
@@ -149,18 +145,11 @@ class Context(ContextBase, AttributeSetter):
     #-------------------------------------------------------------------------
 
     def _add_socket(self, socket):
-        ref = weak_ref(socket)
-        self._sockets.add(ref)
-        return ref
+        self._sockets.add(socket)
 
     def _rm_socket(self, socket):
-        if not self._sockets or not weak_ref:
-            # weakref.ref itself might have been garbage collected
-            # during process teardown!
-            return
-        ref = weak_ref(socket)
-        if self._sockets and ref in self._sockets:
-            self._sockets.remove(ref)
+        if self._sockets:
+            self._sockets.discard(socket)
 
     def destroy(self, linger=None):
         """Close all sockets associated with this context and then terminate
@@ -181,9 +170,8 @@ class Context(ContextBase, AttributeSetter):
             return
 
         sockets = self._sockets
-        self._sockets = set()
+        self._sockets = WeakSet()
         for s in sockets:
-            s = s()
             if s and not s.closed:
                 if linger is not None:
                     s.setsockopt(LINGER, linger)

--- a/zmq/tests/asyncio/_test_asyncio.py
+++ b/zmq/tests/asyncio/_test_asyncio.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+from multiprocessing import Process
 import os
 import sys
 
@@ -24,6 +25,33 @@ except ImportError:
 from concurrent.futures import CancelledError
 from zmq.tests import BaseZMQTestCase, SkipTest
 from zmq.tests.test_auth import TestThreadAuthentication
+
+
+class ProcessForTeardownTest(Process):
+    def __init__(self, event_loop_policy_class):
+        Process.__init__(self)
+        self.event_loop_policy_class = event_loop_policy_class
+
+    def run(self):
+        """Leave context, socket and event loop upon implicit disposal"""
+        asyncio.set_event_loop_policy(self.event_loop_policy_class())
+
+        actx = zaio.Context.instance()
+        socket = actx.socket(zmq.PAIR)
+        socket.bind_to_random_port('tcp://127.0.0.1')
+        coro = asyncio.wait_for(self.never_ending_task(socket), timeout=1)
+
+        loop = asyncio.get_event_loop()
+        try:
+            loop.run_until_complete(coro)
+        except asyncio.TimeoutError:
+            pass  # expected timeout
+        else:
+            assert False, "never_ending_task was completed unexpectedly"
+
+    @asyncio.coroutine
+    def never_ending_task(self, socket):
+        yield from socket.recv()  # never ever receive anything
 
 
 class TestAsyncIOSocket(BaseZMQTestCase):
@@ -381,6 +409,18 @@ class TestAsyncIOSocket(BaseZMQTestCase):
             s = ctx.socket(zmq.PULL)
             async_s = zaio.Socket(s)
             assert isinstance(async_s, self.socket_class)
+
+    def test_process_teardown(self):
+        event_loop_policy_class = type(asyncio.get_event_loop_policy())
+        proc = ProcessForTeardownTest(event_loop_policy_class)
+        proc.start()
+        try:
+            proc.join(10)  # starting new Python process may cost a lot
+            self.assertEqual(proc.exitcode, 0,
+                             "Python process died with code %d" % proc.exitcode
+                             if proc.exitcode else "process teardown hangs")
+        finally:
+            proc.terminate()
 
 
 class TestAsyncioAuthentication(TestThreadAuthentication):


### PR DESCRIPTION
This is PR to revise #1378.

Honestly speaking, because I found the test added through c6f414b fails with pyzmq==17.0.0 but succeeds with pyzmq==17.1.0, this PR presumably does nothing essential for #1167 but just strengthens foundation around at the #1167.