### PR TITLE
Modernize usage of readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+formats: all
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+python:
+  # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 cython>=0.29
 gevent
-tornado
+pygments==2.4.2
 sphinx>=3.0.4
+tornado

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-cython>=0.25
-sphinx>=1.7
+cython>=0.29
 gevent
+tornado
+sphinx>=3.0.4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,6 +108,9 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# List of Sphinx warnings that will not be raised
+suppress_warnings = ['epub.unknown_project_files']
+
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -383,6 +383,7 @@ class Socket(SocketBase, AttributeSetter):
             If the send does not succeed for any reason (including
             if NOBLOCK is set and the outgoing queue is full).
 
+
         .. versionchanged:: 17.0
 
             DRAFT support for routing_id and group arguments.


### PR DESCRIPTION
This PR fixes #1299; Please compare [official one](https://pyzmq.readthedocs.io/en/latest/api/zmq.html#zmq.curve_public) and [my testing one](https://sakurai-youhei-pyzmq.readthedocs.io/en/latest/api/zmq.html#zmq.curve_public). It's most probably fixed by upgrade of sphinx.

P.S. 1 - This PR would also improve something related to #1334 as [mine](https://sakurai-youhei-pyzmq.readthedocs.io/en/latest/changelog.html) has already listed 19.0.1 while [official one](https://pyzmq.readthedocs.io/en/latest/changelog.html) is still missing it.

P.S. 2 - Because `fail_on_warning: true` is configured through `.readthedocs.yml`, it'd be worth participating readthedocs's beta program for [Autobuild Documentation for Pull Requests](https://docs.readthedocs.io/en/stable/guides/autobuild-docs-for-pull-requests.html).
