### PR TITLE
Improve Poll documentation

### DIFF
--- a/zmq/sugar/poll.py
+++ b/zmq/sugar/poll.py
@@ -78,7 +78,7 @@ class Poller(object):
         """Poll the registered 0MQ or native fds for I/O.
         
         If there are currently events ready to be processed, this function will return immediately.
-        Otherwise, this function will return as soon as events are available or after timeout 
+        Otherwise, this function will return as soon the first event is available or after timeout 
         milliseconds have elapsed.
 
         Parameters

--- a/zmq/sugar/poll.py
+++ b/zmq/sugar/poll.py
@@ -91,10 +91,10 @@ class Poller(object):
         -------
         events : list of tuples
             The list of events that are ready to be processed.
-            This is a list of tuples of the form ``(socket, event)``, where the 0MQ Socket
+            This is a list of tuples of the form ``(socket, event_mask)``, where the 0MQ Socket
             or integer fd is the first element, and the poll event mask (POLLIN, POLLOUT) is the second.
             It is common to call ``events = dict(poller.poll())``,
-            which turns the list of tuples into a mapping of ``socket : event``.
+            which turns the list of tuples into a mapping of ``socket : event_mask``.
         """
         if timeout is None or timeout < 0:
             timeout = -1

--- a/zmq/sugar/poll.py
+++ b/zmq/sugar/poll.py
@@ -76,6 +76,10 @@ class Poller(object):
 
     def poll(self, timeout=None):
         """Poll the registered 0MQ or native fds for I/O.
+        
+        If there are currently events ready to be processed, this function will return immediately.
+        Otherwise, this function will return as soon as events are available or after timeout 
+        milliseconds have elapsed.
 
         Parameters
         ----------

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -677,7 +677,7 @@ class Socket(SocketBase, AttributeSetter):
     _poller_class = Poller
 
     def poll(self, timeout=None, flags=POLLIN):
-        """Poll the socket for an event.
+        """Poll the socket for events.
         See :class:`Poller` to wait for multiple sockets at once.
 
         Parameters

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -677,7 +677,7 @@ class Socket(SocketBase, AttributeSetter):
     _poller_class = Poller
 
     def poll(self, timeout=None, flags=POLLIN):
-        """Poll the socket for events.
+        """Poll the socket for an event.
         See :class:`Poller` to wait for multiple sockets at once.
 
         Parameters
@@ -690,9 +690,9 @@ class Socket(SocketBase, AttributeSetter):
 
         Returns
         -------
-        events : int
-            The events that are ready and waiting,
-            0 if the timeout was reached with no events.
+        event : int
+            The poll event mask (POLLIN, POLLOUT),
+            0 if the timeout was reached without an event.
         """
 
         if self.closed:

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -690,7 +690,7 @@ class Socket(SocketBase, AttributeSetter):
 
         Returns
         -------
-        event : int
+        event_mask : int
             The poll event mask (POLLIN, POLLOUT),
             0 if the timeout was reached without an event.
         """


### PR DESCRIPTION
I found the explanation of the return value for zmq.Socket.poll() to be confusing. I changed the documentation to try to eliminate this confusion. In particular, the documentation for the return value from zmq.Poller.poll() uses the word `events`, so it seemed better to refer to the value from zmq.Poller.poll() as `event`.

I also added some clarification to the documentation for zmq.Poller.poll() explaining how the timeout works. I realize this is obvious to someone familiar with the POSIX standards for select and poll. However, pyzmq might be used by people who have not done low level programming on Linux or Unix, and I feel this additional information will be useful for them. 