### PR TITLE
hold the gil while calling zmq_curve functions

### DIFF
--- a/zmq/backend/cython/utils.pyx
+++ b/zmq/backend/cython/utils.pyx
@@ -56,8 +56,9 @@ def curve_keypair():
     cdef char[64] public_key
     cdef char[64] secret_key
     _check_version((4,0), "curve_keypair")
-    with nogil:
-        rc = zmq_curve_keypair (public_key, secret_key)
+    # see huge comment in libzmq/src/random.cpp
+    # about threadsafety of random initialization
+    rc = zmq_curve_keypair(public_key, secret_key)
     _check_rc(rc)
     return public_key, secret_key
 
@@ -86,8 +87,9 @@ def curve_public(secret_key):
     cdef char[64] public_key
     cdef char* c_secret_key = secret_key
     _check_version((4,2), "curve_public")
-    with nogil:
-        rc = zmq_curve_public (public_key, c_secret_key)
+    # see huge comment in libzmq/src/random.cpp
+    # about threadsafety of random initialization
+    rc = zmq_curve_public(public_key, c_secret_key)
     _check_rc(rc)
     return public_key[:40]
 


### PR DESCRIPTION
zmq source has some [comments](https://github.com/zeromq/libzmq/blob/v4.3.2/src/random.cpp#L68-L96) indicating pitfalls related to threadsafety

libzmq comments appear to claim to have solved this with statics and locks (not sure),
but behavior seen in #1414 suggests this may not be so.

closes #1414 (possibly also closes #1402)