### PR TITLE
remove term/close from cython dealloc

### DIFF
--- a/zmq/backend/cython/context.pyx
+++ b/zmq/backend/cython/context.pyx
@@ -55,15 +55,6 @@ cdef class Context:
         self.closed = False
         self._pid = getpid()
 
-    def __dealloc__(self):
-        """don't touch members in dealloc, just cleanup allocations"""
-        cdef int rc
-
-        # we can't call object methods in dealloc as it
-        # might already be partially deleted
-        if not self._shadow:
-            self._term()
-
     @property
     def underlying(self):
         """The address of the underlying libzmq context"""

--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -336,14 +336,6 @@ cdef class Socket:
         self._shadow = False
         self.context = None
 
-    def __dealloc__(self):
-        """remove from context's list
-
-        But be careful that context might not exist if called during gc
-        """
-        if self.handle != NULL and not self._shadow and getpid() == self._pid:
-            self._c_close()
-
     @property
     def underlying(self):
         """The address of the underlying libzmq socket"""


### PR DESCRIPTION
auto close&term are implemented in `__del__` in sugar wrappers, which are more reliable when called.

when `__del__` is skipped, e.g. in process teardown, don't trust dealloc to work as context may be deallocated before sockets, because:

1. when `__del__` is called, `__dealloc__` is redundant, and
2. when `__del__` is *not* called, `__dealloc__` ordering cannot be trusted, and wrong order results in process hang on exit


dealloc's random ordering makes things prone to hang on process teardown, a longstanding issue that doesn't seem solvable.

closes #1413