### PR TITLE
Make Socket connect() and bind() context managers

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -131,9 +131,9 @@ class Socket(SocketBase, AttributeSetter):
             self.addr = addr
             self.bind = bind
             if self.bind:
-                SocketBase.bind(self.sock, addr)
+                SocketBase.bind(self.sock, self.addr)
             else:
-                SocketBase.connect(self.sock, addr)
+                SocketBase.connect(self.sock, self.addr)
 
         def __enter__(self):
             return self.sock

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -127,7 +127,10 @@ class Socket(SocketBase, AttributeSetter):
 
     @contextmanager
     def _connect_cm(self, addr):
-        """Context manager to disconnect on exit"""
+        """Context manager to disconnect on exit
+        
+        .. versionadded:: 20.0
+        """
         try:
             yield
         finally:
@@ -135,7 +138,10 @@ class Socket(SocketBase, AttributeSetter):
 
     @contextmanager
     def _bind_cm(self, addr):
-        """Context manager to unbind on exit"""
+        """Context manager to unbind on exit
+        
+        .. versionadded:: 20.0
+        """
         try:
             yield
         finally:
@@ -159,8 +165,10 @@ class Socket(SocketBase, AttributeSetter):
             for example 'tcp://127.0.0.1:5555'. Protocols supported include
             tcp, udp, pgm, epgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
+            
+        .. versionadded:: 20.0
         """
-        SocketBase.bind(self, addr)
+        super().bind(addr)
         return self._bind_cm(addr)
 
     def connect(self, addr):
@@ -177,8 +185,10 @@ class Socket(SocketBase, AttributeSetter):
             for example 'tcp://127.0.0.1:5555'. Protocols supported are
             tcp, upd, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
+            
+        .. versionadded:: 20.0
         """
-        SocketBase.connect(self, addr)
+        super().connect(addr)
         return self._connect_cm(addr)
 
     #-------------------------------------------------------------------------

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -75,6 +75,7 @@ class TestSocket(BaseZMQTestCase):
                     a.send(msg, flags=zmq.DONTWAIT)
                 with pytest.raises(zmq.Again):
                     b.recv(flags=zmq.DONTWAIT)
+                a.unbind(url)
             # Test bind() context manager
             with ctx.socket(zmq.PUSH) as a, ctx.socket(zmq.PULL) as b:
                 # unbind() just stops accepting of new connections, so we have to disconnect to test that

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -59,6 +59,39 @@ class TestSocket(BaseZMQTestCase):
             self.assertEqual(a.closed, True)
         self.assertEqual(ctx.closed, True)
 
+    def test_connectbind_context_managers(self):
+        url = 'inproc://a'
+        msg = b'hi'
+        with self.Context() as ctx:
+            # Test connect() context manager
+            with ctx.socket(zmq.PUSH) as a, ctx.socket(zmq.PULL) as b:
+                a.bind(url)
+                with b.connect(url):
+                    a.send(msg)
+                    rcvd = self.recv(b)
+                    self.assertEqual(rcvd, msg)
+                # b should now be disconnected, so sending and receiving don't work
+                with pytest.raises(zmq.Again):
+                    a.send(msg, flags=zmq.DONTWAIT)
+                with pytest.raises(zmq.Again):
+                    b.recv(flags=zmq.DONTWAIT)
+            # Test bind() context manager
+            with ctx.socket(zmq.PUSH) as a, ctx.socket(zmq.PULL) as b:
+                # unbind() just stops accepting of new connections, so we have to disconnect to test that
+                # unbind happened.
+                with a.bind(url):
+                    b.connect(url)
+                    a.send(msg)
+                    rcvd = self.recv(b)
+                    self.assertEqual(rcvd, msg)
+                    b.disconnect(url)
+                b.connect(url)
+                # Since a is unbound from url, b is not connected to anything
+                with pytest.raises(zmq.Again):
+                    a.send(msg, flags=zmq.DONTWAIT)
+                with pytest.raises(zmq.Again):
+                    b.recv(flags=zmq.DONTWAIT)
+
     def test_dir(self):
         ctx = self.Context()
         s = ctx.socket(zmq.PUB)


### PR DESCRIPTION
My attempt at addressing #1436 as suggested not adding new methods but extending `connect()` and `bind()` to make them return context managers that automatically disconnect/unbind.

~~I couldn't use `contextlib.contextmanager` because that wouldn't do the connecting or binding when used outside of a `with` block, so instead I created a small connect/bind context manager class and turned `connect` and `bind` into factory functions. I copied (and amended) the docstrings for `connect` and `bind` from their respective Cython versions.~~