### PR TITLE
handle failed initialization in async Sockets

### DIFF
--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -149,8 +149,10 @@ class _AsyncSocket(_zmq.Socket):
         return cls(_from_socket=socket, io_loop=io_loop)
 
     def close(self, linger=None):
-        if not self.closed:
-            for event in list(chain(self._recv_futures, self._send_futures)):
+        if not self.closed and self._fd is not None:
+            for event in list(
+                chain(self._recv_futures or [], self._send_futures or [])
+            ):
                 if not event.future.done():
                     try:
                         event.future.cancel()
@@ -541,5 +543,3 @@ class _AsyncSocket(_zmq.Socket):
         if self._shadow_sock.closed:
             fd = self._fd
         self.io_loop.remove_handler(fd)
-
-


### PR DESCRIPTION
close() is called in `__del__`, which is called even if `__init__` fails

don't assume that `__init__` has completed when `close()` is called

`__del__` can be called during teardown when lots of things are being disassembled and are thus None when there's no reasonable way they should be that value.

So protect against these attributes being undefined.

hopefully closes #1424 and closes #1430