### PR TITLE
mark some flaky tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 # gevent wheels on mac cause Illegal Instruction
 gevent; platform_python_implementation != "PyPy" and sys_platform != "win32" and sys_platform != "darwin"
 pytest
+pytest-rerunfailures
 tornado

--- a/zmq/tests/test_poll.py
+++ b/zmq/tests/test_poll.py
@@ -192,6 +192,7 @@ class TestSelect(PollZMQTestCase):
         self.assertTrue(s1 not in rlist)
         self.assertTrue(s2 not in rlist)
 
+    @mark.flaky(reruns=3)
     def test_timeout(self):
         """make sure select timeout has the right units (seconds)."""
         s1, s2 = self.create_bound_pair(zmq.PAIR, zmq.PAIR)
@@ -235,4 +236,3 @@ if have_gevent:
             r.join()
             toc = time.time()
             self.assertTrue(toc-tic < 1)
-

--- a/zmq/tests/test_retry_eintr.py
+++ b/zmq/tests/test_retry_eintr.py
@@ -61,6 +61,7 @@ class TestEINTRSysCall(BaseZMQTestCase):
         self.assertRaises(zmq.Again, push.send, b('buf'))
         assert self.timer_fired
     
+    @mark.flaky(reruns=3)
     def test_retry_poll(self):
         x, y = self.create_bound_pair()
         poller = zmq.Poller()


### PR DESCRIPTION
github actions has a higher penalty to spurious failures because it can't restart a single job, only the whole thing (?!)

so mark known flaky tests for individual retries within a single run