### PR TITLE
add aarch64, sdist to release action

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,7 +183,18 @@ jobs:
         with:
           python-versions: ${{ matrix.tag }}
           build-requirements: "cython==${{ env.cython }}"
-          system-packages: zeromq-devel
+          pip-wheel-args: "-v -w ./dist --no-deps"
+          # what we really want is:
+          # system-packages: zeromq-devel
+          # but zeromq-devel not available on aarch64 by default...
+          # it is is epel7, but can't load that early enough
+          # loading rpms by full url seems to work, but we need to specify
+          # all dependencies to do so
+          system-packages: >
+            https://download-ib01.fedoraproject.org/pub/epel/7/aarch64/Packages/z/zeromq-devel-4.1.4-6.el7.aarch64.rpm
+            https://download-ib01.fedoraproject.org/pub/epel/7/aarch64/Packages/z/zeromq-4.1.4-6.el7.aarch64.rpm
+            https://download-ib01.fedoraproject.org/pub/epel/7/aarch64/Packages/l/libsodium-1.0.18-1.el7.aarch64.rpm
+            https://download-ib01.fedoraproject.org/pub/epel/7/aarch64/Packages/o/openpgm-5.2.122-2.el7.aarch64.rpm
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Build wheels
+name: Release
 
 on:
   push:
@@ -12,8 +12,46 @@ on:
 env:
   cython: "0.29.21"
   cibuildwheel: "1.6.4"
+  TWINE_NONINTERACTIVE: "1"
 
 jobs:
+  sdist:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: install dependencies
+        run: |
+          pip install --upgrade pip build
+          pip install cython=="${{ env.cython }}"
+
+      - name: build sdist
+        run: |
+          python setup.py fetch_libzmq
+          python setup.py cython
+          python -m build --sdist .
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: sdist
+          path: "dist/*.tar.gz"
+          if-no-files-found: error
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install twine
+          twine upload --skip-existing dist/*.tar.gz
+
   wheel:
     runs-on: ${{ matrix.os }}
 
@@ -89,11 +127,6 @@ jobs:
         run: |
           pip freeze
 
-      - name: register qemu for aarch64
-        if: matrix.arch == 'aarch64'
-        run: |
-          docker run --rm --privileged hypriot/qemu-register:v4.2.0 "${{ matrix.arch }}"
-
       - name: list target wheels
         run: |
           python -m cibuildwheel . --print-build-identifiers
@@ -112,10 +145,57 @@ jobs:
           path: "wheelhouse/*"
           if-no-files-found: error
 
-      - name: install twine
+      - name: Publish wheels to PyPI
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          pip install --upgrade twine
+          pip install twine
+          twine upload --skip-existing wheelhouse/*
+
+  cross-wheels:
+    # separate build for aarch64 since cibuildwheel can't do arm on GHA fr now
+    runs-on: ubuntu-20.04
+
+    env:
+      ZMQ_PREFIX: /usr/local
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            manylinux: "2014"
+            tag: "cp37-cp37m cp38-cp38 cp39-cp39"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: register qemu
+        run: |
+          docker run --rm --privileged hypriot/qemu-register:v4.2.0
+
+      - name: Build manylinux2014 Python wheels (aarch64)
+        if: matrix.arch == 'aarch64' && matrix.manylinux == '2014'
+        # uses should really support ${{ matrix.arch }} expansion, but it doesn't
+        uses: "RalfG/python-wheels-manylinux-build@v0.3.2-manylinux2014_aarch64"
+        with:
+          python-versions: ${{ matrix.tag }}
+          build-requirements: "cython==${{ env.cython }}"
+          system-packages: zeromq-devel
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels-manylinux${{ matrix.manylinux }}_${{ matrix.arch }}
+          path: "dist/*manylinux*.whl"
+          if-no-files-found: error
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          python-version: "3.8"
 
       - name: Publish wheels to PyPI
         if: startsWith(github.ref, 'refs/tags/')
@@ -124,4 +204,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           pip install twine
-          twine upload wheelhouse/*
+          twine upload --skip-existing dist/*manylinux*.whl

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 invoke script for releasing pyzmq
 
-Must be run on macOS with Framework Python from Python.org
+Updates version.py and publishes tag
 
-usage:
+releases are built and uploaded from CI, following the published tag
 
-    invoke release 14.3.1
-
+    invoke release 21.0.0 [--upload]
 """
 
 # Copyright (C) PyZMQ Developers
@@ -40,53 +39,15 @@ pjoin = os.path.join
 
 repo = 'git@github.com:zeromq/pyzmq'
 branch = os.getenv('PYZMQ_BRANCH', 'master')
-sdkroot = os.getenv("SDKROOT")
-if not sdkroot:
-    xcode_prefix = check_output(["xcode-select", "-p"]).decode().strip()
-    # 10.9
-    sdkroot = os.path.join(xcode_prefix, "Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk")
-    if os.path.exists(sdkroot):
-        os.environ["SDKROOT"] = sdkroot
-    else:
-        print("SDK not found at %r" % sdkroot)
-        time.sleep(10)
-
-# Workaround for PyPy3 5.8
-if 'LDFLAGS' not in os.environ:
-    os.environ['LDFLAGS'] = '-undefined dynamic_lookup'
-
-# set mac deployment target
-if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
-    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
-
-# set compiler env (avoids issues with missing 'gcc-4.2' on py27, etc.)
-if 'CC' not in os.environ:
-    os.environ['CC'] = 'clang'
-
-if 'CXX' not in os.environ:
-    os.environ['CXX'] = 'clang++'
-
-_framework_py = lambda xy: "/Library/Frameworks/Python.framework/Versions/{0}/bin/python{0}".format(xy)
-py_exes = {
-    "3.9": _framework_py("3.9"),
-    "3.8": _framework_py("3.8"),
-    "3.7": _framework_py("3.7"),
-    "3.5": _framework_py("3.5"),
-    "3.6": _framework_py("3.6"),
-    "pypy3": "/usr/local/bin/pypy3",
-}
-
-default_py = "3.8"
-# all the Python versions to be built on linux
-manylinux_pys = "3.9 3.8 3.7 3.5 3.6"
 
 tmp = "/tmp"
 env_root = os.path.join(tmp, 'envs')
 repo_root = pjoin(tmp, 'pyzmq-release')
-sdist_root = pjoin(tmp, 'pyzmq-sdist')
+
 
 def _py(py):
     return py_exes[py]
+
 
 def run(cmd, **kwargs):
     """wrapper around invoke.run that accepts a Popen list"""
@@ -94,6 +55,7 @@ def run(cmd, **kwargs):
         cmd = " ".join(pipes.quote(s) for s in cmd)
     kwargs.setdefault('echo', True)
     return invoke_run(cmd, **kwargs)
+
 
 @contextmanager
 def cd(path):
@@ -105,11 +67,6 @@ def cd(path):
     finally:
         os.chdir(cwd)
 
-@task
-def check_pythons(ctx):
-    for version, exe in py_exes.items():
-        print(version, end=": ")
-        ctx.run(f"'{exe}' --version")
 
 @task
 def clone_repo(ctx, reset=False):
@@ -122,6 +79,7 @@ def clone_repo(ctx, reset=False):
             run("git pull")
     else:
         run("git clone -b %s %s %s" % (branch, repo, repo_root))
+
 
 @task
 def patch_version(ctx, vs):
@@ -151,6 +109,7 @@ def patch_version(ctx, vs):
         for line in post_lines:
             f.write(line)
 
+
 @task
 def tag(ctx, vs, push=False):
     """Make the tag (don't push)"""
@@ -162,191 +121,19 @@ def tag(ctx, vs, push=False):
             run('git push --tags')
             run('git push')
 
-def make_env(py_exe, *packages):
-    """Make a virtualenv
-
-    Assumes `which python` has the `virtualenv` package
-    """
-    py_exe = py_exes.get(py_exe, py_exe)
-
-    if not os.path.exists(env_root):
-        os.makedirs(env_root)
-
-    env = os.path.join(env_root, os.path.basename(py_exe))
-    py = pjoin(env, 'bin', 'python')
-    # new env
-    if not os.path.exists(py):
-        run('virtualenv {} -p {}'.format(
-            pipes.quote(env),
-            pipes.quote(py_exe),
-        ))
-        py = pjoin(env, 'bin', 'python')
-        run([py, '-V'])
-        install(py, 'pip', 'setuptools')
-    install(py, *packages)
-    return py
-
-def build_sdist(py, upload=False):
-    """Build sdists
-
-    Returns the path to the tarball
-    """
-    with cd(repo_root):
-        cmd = [py, 'setup.py', 'sdist']
-        run(cmd)
-        if upload:
-            run(['twine', 'upload', 'dist/*'])
-
-    return glob.glob(pjoin(repo_root, 'dist', '*.tar.gz'))[0]
-
-@task
-def sdist(ctx, vs, upload=False):
-    clone_repo(ctx)
-    tag(ctx, vs, push=upload)
-    py = make_env(default_py, 'cython', 'twine', 'certifi')
-    tarball = build_sdist(py, upload=upload)
-    return untar(tarball)
-
-def install(py, *packages):
-    run([py, '-m', 'pip', 'install', '--upgrade'] + list(packages))
 
 def vs_to_tup(vs):
     """version string to tuple"""
     return re.match(r'(\d+)\.(\d+)\.(\d+)\.?([^\.]*)$', vs).groups()
 
+
 def tup_to_vs(tup):
     """tuple to version string"""
     return '.'.join(tup)
 
-def untar(tarball):
-    if os.path.exists(sdist_root):
-        shutil.rmtree(sdist_root)
-    os.makedirs(sdist_root)
-    with cd(sdist_root):
-        run(['tar', '-xzf', tarball])
-
-    return glob.glob(pjoin(sdist_root, '*'))[0]
-
-@task
-def bdist(ctx, py, wheel=True):
-    py = make_env(py, 'wheel')
-    cmd = [py, 'setup.py']
-    if wheel:
-        cmd.append('bdist_wheel')
-    cmd.append('--zmq=bundled')
-
-    run(cmd)
-
-
-@task
-def manylinux(ctx, vs, upload=False, pythons=manylinux_pys):
-    """Build manylinux wheels with Matthew Brett's manylinux-builds"""
-    manylinux = '/tmp/manylinux-builds'
-    if not os.path.exists(manylinux):
-        with cd('/tmp'):
-            run("git clone --recursive https://github.com/minrk/manylinux-builds -b pyzmq")
-    else:
-        with cd(manylinux):
-            run("git pull")
-            run("git submodule update")
-
-    run("docker pull quay.io/pypa/manylinux1_x86_64")
-    run("docker pull quay.io/pypa/manylinux1_i686")
-    base_cmd = ' '.join([
-        "docker",
-        "run",
-        "--dns=8.8.8.8",
-        "--rm",
-        "-e",
-        "PYZMQ_VERSIONS='{}'".format(vs),
-        "-e",
-        "PYTHON_VERSIONS='{}'".format(pythons),
-        "-e",
-        "ZMQ_VERSION='{}'".format(libzmq_vs),
-        "-e",
-        "LIBSODIUM_VERSION='{}'".format(libsodium_version),
-        "-v",
-        "$PWD:/io",
-    ])
-
-    with cd(manylinux):
-        run(base_cmd +  " quay.io/pypa/manylinux1_x86_64 /io/build_pyzmqs.sh")
-        run(base_cmd +  " quay.io/pypa/manylinux1_i686 linux32 /io/build_pyzmqs.sh")
-    if upload:
-        py = make_env(default_py, 'twine')
-        run(['twine', 'upload', os.path.join(manylinux, 'wheelhouse', '*')])
-
 
 @task
 def release(ctx, vs, upload=False):
-    """Release pyzmq"""
-    # Ensure all our Pythons exist before we start:
-    for v, path in py_exes.items():
-        if not os.path.exists(path):
-            raise ValueError("Need %s at %s" % (v, path))
-
-    # start from scratch with clone and envs
-    clone_repo(ctx, reset=True)
-    if os.path.exists(env_root):
-        shutil.rmtree(env_root)
-
-    path = sdist(ctx, vs, upload=upload)
-
-    with cd(path):
-        for v in py_exes:
-            bdist(ctx, v, wheel=True)
-        if upload:
-            py = make_env(default_py, 'twine')
-            run(['twine', 'upload', 'dist/*'])
-
-    manylinux(ctx, vs, upload=upload)
-    if upload:
-        print("When AppVeyor finished building, upload artifacts with:")
-        print("  invoke appveyor-artifacts {} --upload".format(vs))
-
-
-_appveyor_api = 'https://ci.appveyor.com/api'
-_appveyor_project = 'minrk/pyzmq'
-def _appveyor_api_request(path):
-    """Make an appveyor API request"""
-    r = requests.get('{}/{}'.format(_appveyor_api, path),
-        headers={
-            # 'Authorization': 'Bearer %s' % token,
-            'Content-Type': 'application/json',
-        }
-    )
-    r.raise_for_status()
-    return r.json()
-
-
-@task
-def appveyor_artifacts(ctx, vs, dest='win-dist', upload=False):
-    """Download appveyor artifacts
-
-    If --upload is given, upload to PyPI
-    """
-    if not os.path.exists(dest):
-        os.makedirs(dest)
-
-    build = _appveyor_api_request('projects/{}/branch/v{}'.format(_appveyor_project, vs))
-    jobs = build['build']['jobs']
-    artifact_urls = []
-    for job in jobs:
-        artifacts = _appveyor_api_request('buildjobs/{}/artifacts'.format(job['jobId']))
-        artifact_urls.extend('{}/buildjobs/{}/artifacts/{}'.format(
-            _appveyor_api, job['jobId'], artifact['fileName']
-        ) for artifact in artifacts)
-    for url in artifact_urls:
-        print("Downloading {} to {}".format(url, dest))
-        fname = url.rsplit('/', 1)[-1]
-        r = requests.get(url, stream=True)
-        r.raise_for_status()
-        with open(os.path.join(dest, fname), 'wb') as f:
-            for chunk in r.iter_content(1024):
-                f.write(chunk)
-    if upload:
-        py = make_env(default_py, 'twine')
-        run(['twine', 'upload', '--skip-existing', '{}/*'.format(dest)])
-    else:
-        print("You can now upload these wheels with: ")
-        print("  twine upload {}/*".format(dest))
+    """Publish release tag of pyzmq"""
+    clone_repo(ctx)
+    tag(ctx, vs, push=upload)

--- a/zmq/sugar/version.py
+++ b/zmq/sugar/version.py
@@ -7,10 +7,10 @@
 from zmq.backend import zmq_version_info
 
 
-VERSION_MAJOR = 20
+VERSION_MAJOR = 21
 VERSION_MINOR = 0
 VERSION_PATCH = 0
-VERSION_EXTRA = ""
+VERSION_EXTRA = "dev"
 __version__ = '%i.%i.%i' % (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 
 if VERSION_EXTRA:
@@ -45,4 +45,3 @@ __all__ = ['zmq_version', 'zmq_version_info',
            'pyzmq_version','pyzmq_version_info',
            '__version__', '__revision__'
 ]
-


### PR DESCRIPTION
cc @odidev I saw your work on https://github.com/RalfG/python-wheels-manylinux-build that helped a lot!

I elected to build against the RPMs for libzmq from EPEL 7 (a more recent CentOS 7 RPM source would be great! But OpenSUSE only appears to have aarch64 rpms for zeromq on CentOS 8) because building libzmq on emulated ARM takes *forever*.

closes #1401
closes #1404 
