### PR TITLE
docs: fix simple typo, followig -> following

### DIFF
--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -13,7 +13,7 @@ import zmq as _zmq
 _FutureEvent = namedtuple('_FutureEvent', ('future', 'kind', 'kwargs', 'msg'))
 
 # These are incomplete classes and need a Mixin for compatibility with an eventloop
-# defining the followig attributes:
+# defining the following attributes:
 #
 # _Future
 # _READ


### PR DESCRIPTION
There is a small typo in zmq/_future.py.

Should read `following` rather than `followig`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md