### PR TITLE
Introducing load meta data option for load_certificate method

### DIFF
--- a/zmq/auth/certs.py
+++ b/zmq/auth/certs.py
@@ -107,10 +107,11 @@ def load_certificate(filename, load_metadata=False):
             if line.startswith(b'#'):
                 continue
             if load_metadata and line.startswith(b'metadata'):
-                while not (line := next(f)).startswith(b'curve'):
-                    k = line.split(b"=", 1)[0].strip(b' \t\'"\r\n').decode()
-                    v = line.split(b"=", 1)[1].strip(b' \t\'"\r\n').decode()
+                line = next(f)
+                while not line.startswith(b'curve'):
+                    k, v = [element.strip(b' \t\'"\r\n').decode() for element in line.split(b"=", 1)]
                     metadata[k] = v
+                    line = next(f)
             if line.startswith(b'public-key'):
                 public_key = line.split(b"=", 1)[1].strip(b' \t\'"')
             if line.startswith(b'secret-key'):


### PR DESCRIPTION
Figured, that the option to extract the metadata from a certificate was missing. Merging this should not cause any compatibility issues and extends the usablity of certificate metadata.

NOTE: This is only compatible with Python >=3.8, since the [Walrus Operator](https://stackoverflow.com/questions/50297704/syntax-and-assignment-expressions-what-and-why) was used. If you wish more compatibility, I can push those changes to this PR too. 