### PR TITLE
fix bundling msvcp on Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: run tests
         run: |
-          python -m pytest --cov zmq -m "not new_console" -v zmq/tests
+          python -m pytest --cov zmq -m "not wheel and not new_console" -v zmq/tests
 
       - name: upload coverage
         run: codecov

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -127,6 +127,11 @@ jobs:
         run: |
           pip freeze
 
+      - name: show vcvars
+        if: startsWith(matrix.os, 'win')
+        run: |
+          python tools/showvcvars.py
+
       - name: list target wheels
         run: |
           python -m cibuildwheel . --print-build-identifiers

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,15 +56,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: ${{ matrix.cibw.before_all || 'bash tools/install_libzmq.sh' }}
-      CIBW_ENVIRONMENT: ${{ matrix.cibw.environment || 'ZMQ_PREFIX=/usr/local' }}
+      CIBW_BEFORE_ALL_MACOS: 'bash tools/install_libzmq.sh'
+      CIBW_BEFORE_ALL_LINUX: 'bash tools/install_libzmq.sh'
+
+      CIBW_ENVIRONMENT_MACOS: "ZMQ_PREFIX=/usr/local"
+      CIBW_ENVIRONMENT_LINUX: "ZMQ_PREFIX=/usr/local"
+      CIBW_ENVIRONMENT_WINDOWS: "PYZMQ_BUNDLE_CRT=1"
 
       CIBW_TEST_REQUIRES: "pytest"
-      CIBW_TEST_COMMAND: "pytest --pyargs zmq.tests.test_wheel"
+      CIBW_TEST_COMMAND: "pytest -vsx --pyargs zmq.tests.test_wheel"
       CIBW_SKIP: "cp2* cp35* pp2*"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_MANYLINUX_I686_IMAGE: "${{ matrix.cibw.manylinux_image }}"
+
 
     strategy:
       fail-fast: false
@@ -89,15 +94,11 @@ jobs:
             name: win32
             cibw:
               build: "*win32"
-              before_all: "true"
-              environment: "ZMQ_PREFIX="
 
           - os: windows-2019
             name: win_amd64
             cibw:
               build: "*win_amd64"
-              before_all: "true"
-              environment: "ZMQ_PREFIX="
 
     steps:
       - uses: actions/checkout@v2

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     large: these tests use a lot of memory
     new_console: these tests create a new console
+    wheel: these tests are for installs from a wheel, not dev-installs

--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,6 @@ class Configure(build_ext):
             if os.environ.get("PYZMQ_BUNDLE_CRT") or (
                 doing_bdist
                 and self.compiler_type == "msvc"
-                and sys.version_info < (3, 9)
                 and not os.environ.get("DISTUTILS_USE_SDK")
             ):
                 cfg['bundle_msvcp'] = True
@@ -672,26 +671,28 @@ class Configure(build_ext):
 
             # bundle MSCVP redist
             if self.config['bundle_msvcp']:
-                cc = new_compiler(compiler=self.compiler_type)
-                cc.initialize()
-                # get vc_redist location via private API
+                from setuptools import msvc
+                from setuptools._distutils.util import get_platform
+
+                vcvars = msvc.msvc14_get_vc_env(get_platform())
                 try:
-                    cc._vcruntime_redist
-                except AttributeError:
+                    vcruntime = vcvars["py_vcruntime_redist"]
+                except KeyError:
                     # fatal error if env set, warn otherwise
                     msg = fatal if os.environ.get("PYZMQ_BUNDLE_CRT") else warn
-                    msg("Failed to get cc._vcruntime via private API, not bundling CRT")
-                if getattr(cc, "_vcruntime_redist", False):
-                    redist_dir, dll = os.path.split(cc._vcruntime_redist)
-                    to_bundle = [
-                        pjoin(redist_dir, dll.replace('vcruntime', name))
-                        for name in ('msvcp', 'concrt')
-                    ]
-                    for src in to_bundle:
-                        dest = localpath('zmq', basename(src))
-                        info("Copying %s -> %s" % (src, dest))
-                        # copyfile to avoid permission issues
-                        shutil.copyfile(src, dest)
+                    msg(
+                        "Failed to get py_vcruntime_redist via vcvars, not bundling MSVCP"
+                    )
+                redist_dir, dll = os.path.split(vcruntime)
+                to_bundle = [
+                    pjoin(redist_dir, dll.replace('vcruntime', name))
+                    for name in ('msvcp', 'concrt')
+                ]
+                for src in to_bundle:
+                    dest = localpath('zmq', basename(src))
+                    info("Copying %s -> %s" % (src, dest))
+                    # copyfile to avoid permission issues
+                    shutil.copyfile(src, dest)
 
         else:
             libzmq.include_dirs.append(bundledir)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ import sys
 import time
 import errno
 import platform
+from pprint import pprint
 from traceback import print_exc
 
 from setuptools import setup, Command
@@ -678,6 +679,9 @@ class Configure(build_ext):
                 try:
                     vcruntime = vcvars["py_vcruntime_redist"]
                 except KeyError:
+                    warn(f"platform={get_platform()}, vcvars=")
+                    pprint.pprint(vcvars, stream=sys.stderr)
+
                     # fatal error if env set, warn otherwise
                     msg = fatal if os.environ.get("PYZMQ_BUNDLE_CRT") else warn
                     msg(

--- a/tools/showvcvars.py
+++ b/tools/showvcvars.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import pprint
+
+from setuptools import msvc
+from setuptools._distutils.util import get_platform
+
+plat = get_platform()
+print(f"platform: {plat}")
+
+vcvars = msvc.msvc14_get_vc_env(plat)
+print("vcvars:")
+pprint.pprint(vcvars)

--- a/zmq/tests/test_wheel.py
+++ b/zmq/tests/test_wheel.py
@@ -9,6 +9,7 @@ import sys
 import pytest
 
 
+@pytest.mark.wheel
 def test_wheel():
     import zmq
 
@@ -19,6 +20,7 @@ def test_wheel():
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="only on Windows")
+@pytest.mark.wheel
 def test_bundle_msvcp():
     import zmq
 

--- a/zmq/tests/test_wheel.py
+++ b/zmq/tests/test_wheel.py
@@ -3,6 +3,11 @@
 Just import things
 """
 
+import os
+import sys
+
+import pytest
+
 
 def test_wheel():
     import zmq
@@ -11,3 +16,12 @@ def test_wheel():
     s = ctx.socket(zmq.PUSH)
     s.close()
     ctx.term()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="only on Windows")
+def test_bundle_msvcp():
+    import zmq
+
+    zmq_dir = os.path.abspath(os.path.dirname(zmq.__file__))
+    dlls = sorted([name for name in os.listdir(zmq_dir) if name.endswith(".dll")])
+    assert dlls == ["concrt140.dll", "msvcp140.dll"]


### PR DESCRIPTION
rely on setuptools msvc api to locate redist directory

closes #1467