### PR TITLE
build windows wheels on windows-2016

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,12 +90,12 @@ jobs:
               build: "cp38* cp39*"
               manylinux_image: manylinux2010
 
-          - os: windows-2019
+          - os: windows-2016
             name: win32
             cibw:
               build: "*win32"
 
-          - os: windows-2019
+          - os: windows-2016
             name: win_amd64
             cibw:
               build: "*win_amd64"

--- a/setup.py
+++ b/setup.py
@@ -685,7 +685,7 @@ class Configure(build_ext):
                     vcruntime = vcvars["py_vcruntime_redist"]
                 except KeyError:
                     warn(f"platform={get_platform()}, vcvars=")
-                    pprint.pprint(vcvars, stream=sys.stderr)
+                    pprint(vcvars, stream=sys.stderr)
 
                     # fatal error if env set, warn otherwise
                     msg = fatal if os.environ.get("PYZMQ_BUNDLE_CRT") else warn


### PR DESCRIPTION
which has vs2017 instead of vs2019

vs2019-build wheels appear to be incompatible with older Windows due to missing dependencies

Possibly fixable by bundling more DLLs (e.g. with delvewheel), but possibly not (missing API-MS-WIN-CORE-HEAP-L2-1-0.DLL suggests it won't work)

should close #1472 (at least for Python >= 3.7, might need one more step to get 3.6)