### PR TITLE
default target Windows version of Python itself

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,6 +8,7 @@ on:
       - buildutils/**
       - .github/workflows/wheels.yml
       - tools/install_libzmq.sh
+      - zmq/utils/*.h
 
 env:
   cython: "0.29.21"

--- a/buildutils/_cffi.c
+++ b/buildutils/_cffi.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "pyversion_compat.h"
 #include "mutex.h"
 #include "ipcmaxlen.h"
 #include "zmq_compat.h"

--- a/buildutils/config.py
+++ b/buildutils/config.py
@@ -157,9 +157,21 @@ def discover_settings(conf_base=None):
         'bundle_msvcp': None,
         'build_ext': {},
         'bdist_egg': {},
+        'win_ver': None,
     }
     if sys.platform.startswith('win'):
         settings['have_sys_un_h'] = False
+        # target Windows version, sets WINVER, _WIN32_WINNT macros
+        # see https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt for reference
+        # see https://github.com/python/cpython/blob/v3.9.1/PC/pyconfig.h#L137-L159
+        # for CPython's own values
+        if sys.version_info >= (3, 9):
+            # CPython 3.9 targets Windows 8 (0x0602)
+            settings["win_ver"] = "0x0602"
+        else:
+            # older Python, target Windows 7 (0x0601)
+            # CPython itself targets Vista (0x0600)
+            settings["win_ver"] = "0x0601"
 
     if conf_base:
         # lowest priority

--- a/buildutils/templates/zmq_constants.h
+++ b/buildutils/templates/zmq_constants.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef _PYZMQ_CONSTANT_DEFS
 #define _PYZMQ_CONSTANT_DEFS
 

--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,13 @@ class Configure(build_ext):
         if cfg['have_sys_un_h']:
             settings['define_macros'].append(('HAVE_SYS_UN_H', 1))
 
+        if cfg['win_ver']:
+            # set target minimum Windows version
+            settings['define_macros'].extend([
+                ('WINVER', cfg['win_ver']),
+                ('_WIN32_WINNT', cfg['win_ver']),
+            ])
+
         if cfg.get('zmq_draft_api'):
             settings['define_macros'].append(('ZMQ_BUILD_DRAFT_API', 1))
 

--- a/zmq/backend/cffi/message.py
+++ b/zmq/backend/cffi/message.py
@@ -146,7 +146,9 @@ class Frame(maybe_bufferable):
         for Frames created by recv
         """
         if self._data is None:
-            self._data = ffi.buffer(C.zmq_msg_data(self.zmq_msg), C.zmq_msg_size(self.zmq_msg))
+            self._data = ffi.buffer(
+                C.zmq_msg_data(self.zmq_msg), C.zmq_msg_size(self.zmq_msg)
+            )
         if self._buffer is None:
             self._buffer = memoryview(self._data)
 

--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -27,6 +27,11 @@
 # Import the C header files
 #-----------------------------------------------------------------------------
 
+# common includes, such as zmq compat, pyversion_compat
+# make sure we load pyversion compat in every Cython module
+cdef extern from "pyversion_compat.h":
+    pass
+
 # were it not for Windows,
 # we could cimport these from libc.stdint
 cdef extern from "zmq_compat.h":

--- a/zmq/utils/getpid_compat.h
+++ b/zmq/utils/getpid_compat.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifdef _WIN32
     #include <process.h>
     #define getpid _getpid

--- a/zmq/utils/ipcmaxlen.h
+++ b/zmq/utils/ipcmaxlen.h
@@ -8,6 +8,8 @@ Distributed under the terms of the New BSD License.  The full license is in
 the file COPYING.BSD, distributed as part of this software.
  */
 
+#pragma once
+
 #if defined(HAVE_SYS_UN_H)
 #include "sys/un.h"
 int get_ipc_path_max_len(void) {

--- a/zmq/utils/pyversion_compat.h
+++ b/zmq/utils/pyversion_compat.h
@@ -1,5 +1,17 @@
 #include "Python.h"
 
+// default to Python's own target Windows version(s)
+// override by setting WINVER, _WIN32_WINNT, (maybe also NTDDI_VERSION?) macros
+#ifdef Py_WINVER
+  #ifndef WINVER
+    #define WINVER Py_WINVER
+  #endif
+  #ifndef _WIN32_WINNT
+    #define _WIN32_WINNT Py_WINVER
+  #endif
+#endif
+
+
 #if PY_VERSION_HEX < 0x02070000
     #define PyMemoryView_FromBuffer(info) (PyErr_SetString(PyExc_NotImplementedError, \
                     "new buffer interface is not available"), (PyObject *)NULL)

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -5,6 +5,8 @@
 //  the file COPYING.BSD, distributed as part of this software.
 //-----------------------------------------------------------------------------
 
+#pragma once
+
 #if defined(_MSC_VER)
 #define pyzmq_int64_t __int64
 #define pyzmq_uint32_t unsigned __int32
@@ -110,4 +112,3 @@
     #define zmq_socket_monitor(s, addr, flags) _missing
 
 #endif
-

--- a/zmq/utils/zmq_constants.h
+++ b/zmq/utils/zmq_constants.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef _PYZMQ_CONSTANT_DEFS
 #define _PYZMQ_CONSTANT_DEFS
 


### PR DESCRIPTION
inherits Py_WIN_VER from pyconfig.h by default unless specified in extra macros

Setting WIN_VER sets our target Windows version as recommended [here](https://discuss.python.org/t/specifying-supported-windows-in-wheels/6712/2).

Further discussion of WIN_VER [in MS docs](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt)

should close #1472 