### PR TITLE
better support working with Windows releases of libzmq

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,7 +102,13 @@ jobs:
             name: win32
             architecture: x86
             cibw:
-              build: "*win32"
+              build: "cp*win32"
+
+          - os: windows-2016
+            name: win32-pypy
+            architecture: x86
+            cibw:
+              build: "pp*win32"
 
           - os: windows-2019
             name: win_amd64
@@ -118,6 +124,14 @@ jobs:
         with:
           python-version: "3.8"
           architecture: ${{ matrix.architecture }}
+
+      - name: set Windows extra env
+        uses: combined
+        shell: bash
+        if: name == 'win32-pypy'
+        run: |
+          echo 'CIBW_ENVIRONMENT_WINDOWS="ZMQ_PREFIX=bundled"' >> "$GITHUB_ENV"
+          echo 'CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=' >> "$GITHUB_ENV"
 
       - name: install dependencies
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,6 +8,7 @@ on:
       - buildutils/**
       - .github/workflows/wheels.yml
       - tools/install_libzmq.sh
+      - zmq/utils/*.h
 
 env:
   cython: "0.29.21"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,7 +63,13 @@ jobs:
 
       CIBW_ENVIRONMENT_MACOS: "ZMQ_PREFIX=/usr/local"
       CIBW_ENVIRONMENT_LINUX: "ZMQ_PREFIX=/usr/local"
-      CIBW_ENVIRONMENT_WINDOWS: "PYZMQ_BUNDLE_CRT=1"
+      CIBW_ENVIRONMENT_WINDOWS: "ZMQ_PREFIX=libzmq-dll"
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+        delvewheel repair
+        --add-path=C:/libzmq-dll
+        --no-dll=vcruntime140.dll
+        --wheel-dir={dest_dir}
+        {wheel}
 
       CIBW_TEST_REQUIRES: "pytest"
       CIBW_TEST_COMMAND: "pytest -vsx --pyargs zmq.tests.test_wheel"
@@ -94,11 +100,13 @@ jobs:
 
           - os: windows-2019
             name: win32
+            architecture: x86
             cibw:
               build: "*win32"
 
           - os: windows-2019
             name: win_amd64
+            architecture: x64
             cibw:
               build: "*win_amd64"
 
@@ -109,10 +117,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
+          architecture: ${{ matrix.architecture }}
 
       - name: install dependencies
         run: |
-          pip install --upgrade pip wheel
+          pip install --upgrade setuptools pip wheel
           pip install cibuildwheel=="${{ env.cibuildwheel }}" cython=="${{ env.cython }}"
 
       - name: install mac dependencies
@@ -124,6 +133,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           pip install auditwheel
+
+      - name: install windows dependencies
+        if: startsWith(matrix.os, 'win')
+        run: |
+          pip install delvewheel
+          python setup.py fetch_libzmq --dll
+          xcopy /i libzmq-dll C:\\libzmq-dll
 
       - name: show environment
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      CIBW_BUILD_VERBOSITY: "1"
       CIBW_BEFORE_ALL_MACOS: 'bash tools/install_libzmq.sh'
       CIBW_BEFORE_ALL_LINUX: 'bash tools/install_libzmq.sh'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,12 +104,12 @@ jobs:
             cibw:
               build: "cp*win32"
 
-          - os: windows-2016
-            name: win32-pypy
-            architecture: x86
-            cibw:
-              build: "pp*win32"
-
+#           - os: windows-2016
+#             name: win32-pypy
+#             architecture: x86
+#             cibw:
+#               build: "pp*win32"
+#
           - os: windows-2019
             name: win_amd64
             architecture: x64
@@ -125,14 +125,14 @@ jobs:
           python-version: "3.8"
           architecture: ${{ matrix.architecture }}
 
-      - name: set Windows extra env
-        uses: combined
-        shell: bash
-        if: name == 'win32-pypy'
-        run: |
-          echo 'CIBW_ENVIRONMENT_WINDOWS="ZMQ_PREFIX=bundled"' >> "$GITHUB_ENV"
-          echo 'CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=' >> "$GITHUB_ENV"
-
+#       - name: set Windows extra env
+#         uses: combined
+#         shell: bash
+#         if: name == 'win32-pypy'
+#         run: |
+#           echo 'CIBW_ENVIRONMENT_WINDOWS="ZMQ_PREFIX=bundled"' >> "$GITHUB_ENV"
+#           echo 'CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=' >> "$GITHUB_ENV"
+#
       - name: install dependencies
         run: |
           pip install --upgrade setuptools pip wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,12 +91,12 @@ jobs:
               build: "cp38* cp39*"
               manylinux_image: manylinux2010
 
-          - os: windows-2016
+          - os: windows-2019
             name: win32
             cibw:
               build: "*win32"
 
-          - os: windows-2016
+          - os: windows-2019
             name: win_amd64
             cibw:
               build: "*win_amd64"

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build
 dist
 conf
 bundled
+libzmq-dll
 *.egg-info
 *.so
 *.pyd

--- a/buildutils/_cffi.c
+++ b/buildutils/_cffi.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "pyversion_compat.h"
 #include "mutex.h"
 #include "ipcmaxlen.h"
 #include "zmq_compat.h"

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -11,18 +11,13 @@
 
 import os
 import shutil
-import stat
-import sys
 import tarfile
 import hashlib
+import platform
+import zipfile
 from subprocess import Popen, PIPE
 
-try:
-    # py2
-    from urllib2 import urlopen
-except ImportError:
-    # py3
-    from urllib.request import urlopen
+from urllib.request import urlopen
 
 from .msg import fatal, debug, info, warn
 
@@ -34,6 +29,7 @@ pjoin = os.path.join
 
 bundled_version = (4, 3, 3)
 vs = '%i.%i.%i' % bundled_version
+x, y, z = bundled_version
 libzmq = "zeromq-%s.tar.gz" % vs
 libzmq_url = "https://github.com/zeromq/libzmq/releases/download/v{vs}/{libzmq}".format(
     vs=vs,
@@ -45,6 +41,21 @@ libzmq_checksum = (
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)
+
+vcversion = 140
+
+if platform.architecture()[0] == '64bit':
+    msarch = '-x64'
+else:
+    msarch = ''
+
+libzmq_dll = f"libzmq-v{vcversion}{msarch}-{x}_{y}_{z}.zip"
+libzmq_dll_url = f"https://dl.bintray.com/zeromq/generic/{libzmq_dll}"
+
+libzmq_dll_checksum = {
+    "libzmq-v140-x64-4_3_3.zip": "sha256:ed7ed0235e1af1dbb7cc481e3be4a187f04a259b5bbe5ae8da1279365839d400",
+    "libzmq-v140-4_3_3.zip": "sha256:3b683f983a875c2fa0f6a5ec5a362f420cb5d8fbab63cc74f1c23584c298e26b",
+}.get(libzmq_dll)
 
 # -----------------------------------------------------------------------------
 # Utilities
@@ -169,44 +180,23 @@ def stage_platform_hpp(zmqroot):
     shutil.copy(pjoin(platform_dir, 'platform.hpp'), platform_hpp)
 
 
-def copy_and_patch_libzmq(ZMQ, libzmq):
-    """copy libzmq into source dir, and patch it if necessary.
+def fetch_libzmq_dll(savedir):
+    """Download binary release of libzmq for windows
 
-    This command is necessary prior to running a bdist on Linux or OS X.
+    vcversion specifies the MSVC runtime version to use
     """
-    if sys.platform.startswith('win'):
-        return
-    # copy libzmq into zmq for bdist
-    local = localpath('zmq', libzmq)
-    if not ZMQ and not os.path.exists(local):
-        fatal(
-            "Please specify zmq prefix via `setup.py configure --zmq=/path/to/zmq` "
-            "or copy libzmq into zmq/ manually prior to running bdist."
-        )
-    try:
-        # resolve real file through symlinks
-        lib = os.path.realpath(pjoin(ZMQ, 'lib', libzmq))
-        print("copying %s -> %s" % (lib, local))
-        shutil.copy(lib, local)
-    except Exception:
-        if not os.path.exists(local):
-            fatal(
-                "Could not copy libzmq into zmq/, which is necessary for bdist. "
-                "Please specify zmq prefix via `setup.py configure --zmq=/path/to/zmq` "
-                "or copy libzmq into zmq/ manually."
-            )
 
-    if sys.platform == 'darwin':
-        # chmod u+w on the lib,
-        # which can be user-read-only for some reason
-        mode = os.stat(local).st_mode
-        os.chmod(local, mode | stat.S_IWUSR)
-        # patch install_name on darwin, instead of using rpath
-        cmd = ['install_name_tool', '-id', '@loader_path/../%s' % libzmq, local]
-        try:
-            p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-        except OSError:
-            fatal("install_name_tool not found, cannot patch libzmq for bundling.")
-        out, err = p.communicate()
-        if p.returncode:
-            fatal("Could not patch bundled libzmq install_name: %s" % err, p.returncode)
+    dest = pjoin(savedir, 'zmq.h')
+    if os.path.exists(dest):
+        info("already have %s" % dest)
+        return
+    path = fetch_archive(
+        savedir, libzmq_dll_url, fname=libzmq_dll, checksum=libzmq_dll_checksum
+    )
+    archive = zipfile.ZipFile(path)
+    to_extract = []
+    for name in archive.namelist():
+        if not name.endswith(".exe"):
+            to_extract.append(name)
+    archive.extractall(savedir, members=to_extract)
+    archive.close()

--- a/buildutils/config.py
+++ b/buildutils/config.py
@@ -157,9 +157,21 @@ def discover_settings(conf_base=None):
         'bundle_msvcp': None,
         'build_ext': {},
         'bdist_egg': {},
+        'win_ver': None,
     }
     if sys.platform.startswith('win'):
         settings['have_sys_un_h'] = False
+        # target Windows version, sets WINVER, _WIN32_WINNT macros
+        # see https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt for reference
+        # see https://github.com/python/cpython/blob/v3.9.1/PC/pyconfig.h#L137-L159
+        # for CPython's own values
+        if sys.version_info >= (3, 9):
+            # CPython 3.9 targets Windows 8 (0x0602)
+            settings["win_ver"] = "0x0602"
+        else:
+            # older Python, target Windows 7 (0x0601)
+            # CPython itself targets Vista (0x0600)
+            settings["win_ver"] = "0x0601"
 
     if conf_base:
         # lowest priority

--- a/buildutils/config.py
+++ b/buildutils/config.py
@@ -120,7 +120,7 @@ def config_from_prefix(prefix):
         settings['libzmq_extension'] = True
         settings['no_libzmq_extension'] = False
     else:
-        settings['zmq_prefix'] = prefix
+        settings['zmq_prefix'] = os.path.abspath(prefix)
         settings['libzmq_extension'] = False
         settings['no_libzmq_extension'] = True
         settings['allow_legacy_libzmq'] = True  # explicit zmq prefix allows legacy

--- a/buildutils/detect.py
+++ b/buildutils/detect.py
@@ -129,7 +129,12 @@ def detect_zmq(basedir, compiler=None, **compiler_attrs):
     efile = test_compilation(cfile, compiler=cc, **compiler_attrs)
     patch_lib_paths(efile, cc.library_dirs)
 
-    rc, so, se = get_output_error([efile])
+    # add library dirs to %PATH% for windows
+    env = os.environ.copy()
+    if sys.platform.startswith("win"):
+        env["PATH"] = os.pathsep.join([env["PATH"]] + cc.library_dirs)
+
+    rc, so, se = get_output_error([efile], env=env)
     if rc:
         msg = "Error running version detection script:\n%s\n%s" % (so, se)
         logging.error(msg)

--- a/buildutils/templates/zmq_constants.h
+++ b/buildutils/templates/zmq_constants.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef _PYZMQ_CONSTANT_DEFS
 #define _PYZMQ_CONSTANT_DEFS
 

--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,13 @@ class Configure(build_ext):
         if cfg['have_sys_un_h']:
             settings['define_macros'].append(('HAVE_SYS_UN_H', 1))
 
+        if cfg['win_ver']:
+            # set target minimum Windows version
+            settings['define_macros'].extend([
+                ('WINVER', cfg['win_ver']),
+                ('_WIN32_WINNT', cfg['win_ver']),
+            ])
+
         if cfg.get('zmq_draft_api'):
             settings['define_macros'].append(('ZMQ_BUILD_DRAFT_API', 1))
 

--- a/zmq/backend/cffi/message.py
+++ b/zmq/backend/cffi/message.py
@@ -146,7 +146,9 @@ class Frame(maybe_bufferable):
         for Frames created by recv
         """
         if self._data is None:
-            self._data = ffi.buffer(C.zmq_msg_data(self.zmq_msg), C.zmq_msg_size(self.zmq_msg))
+            self._data = ffi.buffer(
+                C.zmq_msg_data(self.zmq_msg), C.zmq_msg_size(self.zmq_msg)
+            )
         if self._buffer is None:
             self._buffer = memoryview(self._data)
 

--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -27,6 +27,11 @@
 # Import the C header files
 #-----------------------------------------------------------------------------
 
+# common includes, such as zmq compat, pyversion_compat
+# make sure we load pyversion compat in every Cython module
+cdef extern from "pyversion_compat.h":
+    pass
+
 # were it not for Windows,
 # we could cimport these from libc.stdint
 cdef extern from "zmq_compat.h":

--- a/zmq/tests/test_wheel.py
+++ b/zmq/tests/test_wheel.py
@@ -25,5 +25,13 @@ def test_bundle_msvcp():
     import zmq
 
     zmq_dir = os.path.abspath(os.path.dirname(zmq.__file__))
-    dlls = sorted([name for name in os.listdir(zmq_dir) if name.endswith(".dll")])
-    assert dlls == ["concrt140.dll", "msvcp140.dll"]
+    # pyzmq.libs is *next to* zmq itself
+    pyzmq_lib_dir = os.path.join(zmq_dir, os.pardir, "pyzmq.libs")
+    dlls = sorted([name for name in os.listdir(pyzmq_lib_dir) if name.endswith(".dll")])
+    print(dlls)
+    assert "vcruntime140.dll" not in dlls
+    for expected in ["concrt140.dll", "msvcp140.dll"]:
+        assert expected in dlls
+
+    assert any(dll.startswith("libzmq") for dll in dlls)
+    assert any(dll.startswith("libsodium") for dll in dlls)

--- a/zmq/utils/getpid_compat.h
+++ b/zmq/utils/getpid_compat.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifdef _WIN32
     #include <process.h>
     #define getpid _getpid

--- a/zmq/utils/ipcmaxlen.h
+++ b/zmq/utils/ipcmaxlen.h
@@ -8,6 +8,8 @@ Distributed under the terms of the New BSD License.  The full license is in
 the file COPYING.BSD, distributed as part of this software.
  */
 
+#pragma once
+
 #if defined(HAVE_SYS_UN_H)
 #include "sys/un.h"
 int get_ipc_path_max_len(void) {

--- a/zmq/utils/pyversion_compat.h
+++ b/zmq/utils/pyversion_compat.h
@@ -1,5 +1,17 @@
 #include "Python.h"
 
+// default to Python's own target Windows version(s)
+// override by setting WINVER, _WIN32_WINNT, (maybe also NTDDI_VERSION?) macros
+#ifdef Py_WINVER
+  #ifndef WINVER
+    #define WINVER Py_WINVER
+  #endif
+  #ifndef _WIN32_WINNT
+    #define _WIN32_WINNT Py_WINVER
+  #endif
+#endif
+
+
 #if PY_VERSION_HEX < 0x02070000
     #define PyMemoryView_FromBuffer(info) (PyErr_SetString(PyExc_NotImplementedError, \
                     "new buffer interface is not available"), (PyObject *)NULL)

--- a/zmq/utils/zmq_compat.h
+++ b/zmq/utils/zmq_compat.h
@@ -5,6 +5,8 @@
 //  the file COPYING.BSD, distributed as part of this software.
 //-----------------------------------------------------------------------------
 
+#pragma once
+
 #if defined(_MSC_VER)
 #define pyzmq_int64_t __int64
 #define pyzmq_uint32_t unsigned __int32
@@ -110,4 +112,3 @@
     #define zmq_socket_monitor(s, addr, flags) _missing
 
 #endif
-

--- a/zmq/utils/zmq_constants.h
+++ b/zmq/utils/zmq_constants.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef _PYZMQ_CONSTANT_DEFS
 #define _PYZMQ_CONSTANT_DEFS
 


### PR DESCRIPTION
- detect libzmq name with libzmq_name*.dll (matches libzmq-v140-mt-...dll)
- include zmq-prefix in search path instead of assuming `include/lib`  subdirs(Windows releases have single
flat include+lib directory)
- remove our own external-libzmq-dll-bundling hacks (rely on delvewheel to bundle
non-extension libzmq)
- add vcruntime-redist to %PATH% if found to ensure it's loaded
- fetch_libzmq --dll fetches Windows dll release
- build Windows wheels with public vc140 releases of libzmq
  instead of as an Extension.
  This means Windows wheels will have libsodium instead of tweetnacl
- set WINVER (maybe doesn't fix anything, at least I couldn't get it to)
- build on windows-2019

closes #1476
closes #1475