### PR TITLE
set mac deployment target to 10.9

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      MACOSX_DEPLOYMENT_TARGET: "10.9"
       CIBW_BUILD_VERBOSITY: "1"
       CIBW_BEFORE_ALL_MACOS: 'bash tools/install_libzmq.sh'
       CIBW_BEFORE_ALL_LINUX: 'bash tools/install_libzmq.sh'
@@ -77,7 +78,6 @@ jobs:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_MANYLINUX_I686_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
matches ABI tag specified in wheel

should affect bundled libzmq / libsodium builds

closes #1480