### PR TITLE
cffi: ensure Frame.bytes is bytes

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,7 +101,7 @@ jobs:
           - os: ubuntu-20.04
             name: manylinux2010
             cibw:
-              build: "cp38* cp39*"
+              build: "cp38* cp39* pp3*"
               manylinux_image: manylinux2010
 
           - os: ubuntu-20.04

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,12 @@ Changes in PyZMQ
 This is a coarse summary of changes in pyzmq versions.
 For a full changelog, consult the `git log <https://github.com/zeromq/pyzmq/commits>`_.
 
+22.0.1
+======
+
+- Fix type of ``Frame.bytes`` for non-copying recvs with CFFI backend (regression in 21.0)
+- Add manylinux wheels for pypy
+
 22.0.0
 ======
 

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -301,6 +301,7 @@ class TestFrame(BaseZMQTestCase):
                 self.assertEqual(b, null)
                 self.assertEqual(mb, null)
                 self.assertEqual(m2.bytes, ff)
+                assert type(m2.bytes) is bytes
 
     def test_buffer_numpy(self):
         """test non-copying numpy array messages"""


### PR DESCRIPTION
previously, `Frame.bytes` was returing `self._data`, which could have been any bufferable, and was in the event of a noncopying recv.

I've reproduced the ipykernel test failure and this fixes it and includes a test covering the specific case.

Closes #1478