### PR TITLE
fallback on $PATH to locate bundled DLLs on windows

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,11 @@ Changes in PyZMQ
 This is a coarse summary of changes in pyzmq versions.
 For a full changelog, consult the `git log <https://github.com/zeromq/pyzmq/commits>`_.
 
+22.0.2
+======
+
+- Add workaround for bug in DLL loading for Windows wheels with conda Python >= 3.8
+
 22.0.1
 ======
 


### PR DESCRIPTION
os.add_dll_directory doesn't seem to work with conda+Windows+CPython >= 3.8

workaround conda-forge bug https://github.com/conda-forge/python-feedstock/issues/444

closes #1496 

