### PR TITLE
Fix license name (Lesser GNU GPL --> GNU Lesser GPL)

### DIFF
--- a/zmq/backend/cython/_device.pyx
+++ b/zmq/backend/cython/_device.pyx
@@ -6,7 +6,7 @@
 #    This file is part of pyzmq.
 #
 #    pyzmq is free software; you can redistribute it and/or modify it under
-#    the terms of the Lesser GNU General Public License as published by
+#    the terms of the GNU Lesser General Public License as published by
 #    the Free Software Foundation; either version 3 of the License, or
 #    (at your option) any later version.
 #
@@ -15,7 +15,7 @@
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    Lesser GNU General Public License for more details.
 #
-#    You should have received a copy of the Lesser GNU General Public License
+#    You should have received a copy of the GNU Lesser General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 


### PR DESCRIPTION
Just trying to satisfy the license classifiers out there - this license is actually named "GNU Lesser General Public License", not "Lesser GNU General Public License".