### PR TITLE
update draft install instructions

### DIFF
--- a/docs/source/draft.rst
+++ b/docs/source/draft.rst
@@ -8,7 +8,7 @@ As of libzmq-4.2, this includes the CLIENT-SERVER and RADIO-DISH patterns.
 
 Because these APIs are explicitly unstable,
 pyzmq does not support them by default,
-and pyzmq binaries (wheels) will not be built with DRAFT API suport.
+and pyzmq binaries (wheels) will not be built with DRAFT API support.
 However, pyzmq-17 can be built with draft socket support,
 as long as you compile pyzmq yourself with a special flag.
 
@@ -16,8 +16,8 @@ To install libzmq with draft support:
 
 .. sourcecode:: bash
 
-    export ZMQ_VERSION=4.2.2
-    export PREFIX=/usr/local
+    ZMQ_VERSION=4.3.4
+    PREFIX=/usr/local
 
     wget https://github.com/zeromq/libzmq/releases/download/v${ZMQ_VERSION}/zeromq-${ZMQ_VERSION}.tar.gz -O libzmq.tar.gz
     tar -xzf libzmq.tar.gz
@@ -30,15 +30,15 @@ And to install pyzmq with draft support:
 
 .. sourcecode:: bash
 
-    pip install -v --pre pyzmq \
-      --install-option=--enable-drafts \
-      --install-option=--zmq=${PREFIX}
+    export ZMQ_PREFIX=${PREFIX}
+    export ZMQ_DRAFT_API=1
+    pip install -v --no-binary pyzmq --pre pyzmq
 
-By specifying ``--install-option``, pip knows to not install wheels, and will compile pyzmq from source.
+By specifying ``--no-binary pyzmq``, pip knows to not install wheels, and will compile pyzmq from source.
 
-The ``--zmq=$PREFIX`` part is only necessary if libzmq is installed somewhere not on the default search path.
+The ``ZMQ_PREFIX=$PREFIX`` part is only necessary if libzmq is installed somewhere not on the default search path.
 If libzmq is installed in :file:`/usr/local` or similar,
-only the ``--enable-drafts`` install option is required.
+only the ``ZMQ_ENABLE_DRAFTS`` option is required.
 
 There are examples of the CLIENT-SERVER and RADIO-DISH patterns in the :file:`examples/draft`
 directory of the pyzmq repository.

--- a/examples/draft/install.sh
+++ b/examples/draft/install.sh
@@ -3,7 +3,7 @@
 # example script for installing libzmq and pyzmq with draft support
 
 # 1. install libzmq with draft enabled
-export ZMQ_VERSION=4.2.2
+export ZMQ_VERSION=4.3.4
 export PREFIX=${PREFIX:-/usr/local}
 export PYZMQ=${PYZMQ:-pyzmq}
 
@@ -20,11 +20,12 @@ make -j && make install
 # which do not have draft support
 
 echo "installing ${PYZMQ}"
-pip install -v --pre ${PYZMQ} \
-  --install-option=--enable-drafts \
-  --install-option=--zmq=${PREFIX}
+export ZMQ_PREFIX=${PREFIX}
+export ZMQ_DRAFT_API=1
 
-cat << END | python
+pip install -v --no-binary pyzmq --pre ${PYZMQ}
+
+cat << END | python3
 import sys
 import zmq
 print('python: %s' % sys.executable)


### PR DESCRIPTION
install-option doesn't work with latest pip, use env instead

closes #1500