### PR TITLE
Fix "AttributeError: FD attribute is write-only" in cffi backend on win_amd64

### DIFF
--- a/zmq/backend/cffi/_cdefs.h
+++ b/zmq/backend/cffi/_cdefs.h
@@ -57,12 +57,12 @@ int zmq_setsockopt(void *socket,
                    const void *option_value,
                    size_t option_len);
 
-typedef int... zmq_fd_t;
+typedef int... ZMQ_FD_T;
 
 typedef struct
 {
     void *socket;
-    zmq_fd_t fd;
+    ZMQ_FD_T fd;
     short events;
     short revents;
 } zmq_pollitem_t;

--- a/zmq/backend/cffi/_cdefs.h
+++ b/zmq/backend/cffi/_cdefs.h
@@ -56,10 +56,13 @@ int zmq_setsockopt(void *socket,
                    int option_name,
                    const void *option_value,
                    size_t option_len);
+
+typedef int... zmq_fd_t;
+
 typedef struct
 {
     void *socket;
-    int fd;
+    zmq_fd_t fd;
     short events;
     short revents;
 } zmq_pollitem_t;

--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -27,6 +27,8 @@ value_binary_data = lambda val, length: (
     ffi.sizeof('char') * length,
 )
 
+ZMQ_FD_64BIT = ffi.sizeof("zmq_fd_t") == 8
+
 IPC_PATH_MAX_LEN = C.get_ipc_path_max_len()
 
 from .message import Frame
@@ -42,9 +44,10 @@ def new_pointer_from_opt(option, length=0):
     from zmq.sugar.constants import (
         int64_sockopts,
         bytes_sockopts,
+        fd_sockopts,
     )
 
-    if option in int64_sockopts:
+    if option in int64_sockopts or (ZMQ_FD_64BIT and option in fd_sockopts):
         return new_int64_pointer()
     elif option in bytes_sockopts:
         return new_binary_data(length)
@@ -57,9 +60,10 @@ def value_from_opt_pointer(option, opt_pointer, length=0):
     from zmq.sugar.constants import (
         int64_sockopts,
         bytes_sockopts,
+        fd_sockopts,
     )
 
-    if option in int64_sockopts:
+    if option in int64_sockopts or (ZMQ_FD_64BIT and option in fd_sockopts):
         return int(opt_pointer[0])
     elif option in bytes_sockopts:
         return ffi.buffer(opt_pointer, length)[:]
@@ -71,9 +75,10 @@ def initialize_opt_pointer(option, value, length=0):
     from zmq.sugar.constants import (
         int64_sockopts,
         bytes_sockopts,
+        fd_sockopts,
     )
 
-    if option in int64_sockopts:
+    if option in int64_sockopts or (ZMQ_FD_64BIT and option in fd_sockopts):
         return value_int64_pointer(value)
     elif option in bytes_sockopts:
         return value_binary_data(value, length)

--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -27,7 +27,7 @@ value_binary_data = lambda val, length: (
     ffi.sizeof('char') * length,
 )
 
-ZMQ_FD_64BIT = ffi.sizeof("zmq_fd_t") == 8
+ZMQ_FD_64BIT = ffi.sizeof('ZMQ_FD_T') == 8
 
 IPC_PATH_MAX_LEN = C.get_ipc_path_max_len()
 


### PR DESCRIPTION
Fixes #1533.

The issue was also reported at https://stackoverflow.com/questions/67274218/error-while-choosing-pypy-as-jupyter-notebook-kernel and https://github.com/jupyter/jupyter_core/issues/226#issuecomment-847242481.

Works for me with `Python 3.7.10 (77787b8f4c49, May 15 2021, 11:51:36) [PyPy 7.3.5 with MSC v.1927 64 bit (AMD64)] on win32` and pyzmq-22.0.3 on Windows 10.0.19043.

