### PR TITLE
Fix conversion from 'zmq_fd_t' to 'int', possible loss of data

### DIFF
--- a/zmq/backend/cython/libzmq.pxd
+++ b/zmq/backend/cython/libzmq.pxd
@@ -96,7 +96,7 @@ cdef extern from "zmq.h" nogil:
 
     ctypedef struct zmq_pollitem_t:
         void *socket
-        int fd
+        fd_t fd
         short events
         short revents
 


### PR DESCRIPTION
Compiling pyzmq-22.0.3 with Cython-0.29.23 and Visual Studio 2017 on 64-bit Python, I get the following warning:
```
zmq\backend\cython\_poll.c(2871): warning C4244: 'function': conversion from 'zmq_fd_t' to 'int', possible loss of data
```
The relevant cythonized code is:
```C
      /* "zmq/backend/cython/_poll.pyx":149
 *                 s = sockets[i][0]
 *             else:
 *                 s = pollitems[i].fd             # <<<<<<<<<<<<<<
 *             results.append((s, revents))
 * 
 */
      /*else*/ {
        __pyx_t_7 = __Pyx_PyInt_From_int((__pyx_v_pollitems[__pyx_v_i]).fd); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 149, __pyx_L1_error)
        __Pyx_GOTREF(__pyx_t_7);
        __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_7);
        __pyx_t_7 = 0;
      }
      __pyx_L51:;
```
This PR uses the `ZMQ_FD_T` type for `fd` so Cython can generate correct C code.