### PR TITLE
avoid threadsafety issue in Context._rm_socket

### DIFF
--- a/zmq/sugar/context.py
+++ b/zmq/sugar/context.py
@@ -180,10 +180,13 @@ class Context(ContextBase, AttributeSetter):
     # -------------------------------------------------------------------------
 
     def _add_socket(self, socket):
+        """Add a weakref to a socket for Context.destroy / reference counting"""
         self._sockets.add(socket)
 
     def _rm_socket(self, socket):
-        if self._sockets:
+        """Remove a socket for Context.destroy / reference counting"""
+        # allow _sockets to be None in case of process teardown
+        if getattr(self, "_sockets", None) is not None:
             self._sockets.discard(socket)
 
     def destroy(self, linger=None):


### PR DESCRIPTION
The `if self._sockets` check is for teardown, during which some attributes may be cleared and reset to None.

However, falsy check on a weakset checks all items, which can change size during iteration. Check directly for None or no attr instead, to avoid iteration over collection