### PR TITLE
Updated core.py to use close() instead of cancel() on Timeout objects

### DIFF
--- a/zmq/green/core.py
+++ b/zmq/green/core.py
@@ -161,7 +161,7 @@ class _Socket(_original_Socket):
                 )
         finally:
             if timeout:
-                timeout.cancel()
+                timeout.close()
             self.__writable.set()
 
     def _wait_read(self):
@@ -199,7 +199,7 @@ class _Socket(_original_Socket):
                 )
         finally:
             if timeout:
-                timeout.cancel()
+                timeout.close()
             self.__readable.set()
 
     def send(self, data, flags=0, copy=True, track=False, **kwargs):


### PR DESCRIPTION
Timeout.close() should be used when the Timeout object will no longer be used.
https://www.gevent.org/api/gevent.timeout.html#gevent.Timeout

This fixes issue: https://github.com/zeromq/pyzmq/issues/1555

Creating to many Timeout objects without closing them causes memory to be overwritten. This was causing libzmq to assert. I do not believe this should be the correct behaviour for Timeout. I am going to open an issue on the gevent repo to inform them what I have found out.

I used gflags to enable heap debugging on python.exe to thrown an exception when memory was overridden to find this issue.
https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags-commands 


