### PR TITLE
bump cibuildwheel to 2.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -157,16 +157,16 @@ jobs:
               build: "cp*win32"
 
           - os: windows-2016
-            name: win32-pypy
-            architecture: x86
+            name: win-pypy
+            architecture: x64
             cibw:
-              build: "pp*win32"
+              build: "pp*win_amd64"
 
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "*win_amd64"
+              build: "cp*win_amd64"
 
     steps:
       - uses: actions/checkout@v2
@@ -179,7 +179,7 @@ jobs:
 
       - name: set Windows extra env for pypy
         shell: bash
-        if: matrix.name == 'win32-pypy'
+        if: matrix.name == 'win-pypy'
         # pypy builds libzmq as an Extension,
         # doesn't bundle dlls (requires separate vcredist install, as pypy itself seems to)
         # bundling external libzmq doesn't seem to work

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,8 +11,8 @@ on:
       - zmq/utils/*.h
 
 env:
-  cython: "0.29.21"
-  cibuildwheel: "1.9.0"
+  cython: "0.29.24"
+  cibuildwheel: "2.0.1"
   TWINE_NONINTERACTIVE: "1"
 
 jobs:
@@ -211,16 +211,6 @@ jobs:
         run: |
           pip install --upgrade setuptools pip wheel
           pip install cibuildwheel=="${{ env.cibuildwheel }}" cython=="${{ env.cython }}"
-
-      - name: install mac dependencies
-        if: startsWith(matrix.os, 'mac')
-        run: |
-          pip install delocate
-
-      - name: install linux dependencies
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          pip install auditwheel
 
       - name: install windows dependencies
         if: startsWith(matrix.os, 'win')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ flake8
 gevent; platform_python_implementation != "PyPy" and sys_platform != "win32" and sys_platform != "darwin"
 mypy; platform_python_implementation != "PyPy"
 pytest
-pytest-cov
+# pytest-cov 2.11 requires coverage 5, which still doesn't work with Cython
+pytest-cov==2.10.*
 pytest-rerunfailures
 tornado


### PR DESCRIPTION
this bumps delocate from 0.8 to 0.9, which includes adhoc code signing, which may help with freezing applications (#1561)