### PR TITLE
Make memoryviews created from a Frame writeable with the cython backend

### DIFF
--- a/zmq/backend/cython/message.pyx
+++ b/zmq/backend/cython/message.pyx
@@ -218,7 +218,7 @@ cdef class Frame:
         buffer.len = zmq_msg_size(&self.zmq_msg)
         
         buffer.obj = self
-        buffer.readonly = 1
+        buffer.readonly = 0
         buffer.format = "B"
         buffer.ndim = 1
         buffer.shape = &(buffer.len)

--- a/zmq/tests/test_message.py
+++ b/zmq/tests/test_message.py
@@ -318,7 +318,9 @@ class TestFrame(BaseZMQTestCase):
                 m2 = sa.recv(copy=False)
                 buf2 = memoryview(m2)
                 self.assertEqual(buf.tobytes(), null)
+                self.assertFalse(buf.readonly)
                 self.assertEqual(buf2.tobytes(), ff)
+                self.assertFalse(buf2.readonly)
                 assert type(buf) is memoryview
 
     def test_buffer_numpy(self):


### PR DESCRIPTION
Previously, `Frame.buffer` or `memoryview(Frame)` would result in a
readonly view with the cython backend. This was originally done to be
safer since concurrent sends and modifications of a Frame are unsafe.
e.g. if you modify data before a non-copying send is fully done you
would corrupt your message. However, modifying data before the send is
complete is a more general issue and making the view readonly only
protected the case where you're sending data you previously received,
but would not help when sending other arbitrary mutable data. See #1566
for more info.

Making the view writeable allows users to avoid a copy when doing things
like creating a mutable numpy array from a non-copying recv so in some
sense this is a tradeoff between speed a little bit of safety.

Resolves #1566