### PR TITLE
make sure to close loops explicitly in test_multiple

### DIFF
--- a/zmq/tests/test_asyncio.py
+++ b/zmq/tests/test_asyncio.py
@@ -407,6 +407,7 @@ class TestAsyncIOSocket(BaseZMQTestCase):
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             loop.run_until_complete(asyncio.wait_for(test(), timeout=10))
+            loop.close()
 
     def test_shadow(self):
         async def test():


### PR DESCRIPTION
can leave references, relying on garbage collection to close. This seems to have started failing on the Windows py39 tests, with the assertion that there are no leftover `_selector` references.

I can't find any differences between 9c58836ba8e83e8c0a921965082c96098bd40533 which passed and 977d39bf5bbe55aef52983be146f6e1be85aaa08 which started failing (`pip freeze` gave identical output, Python version is identical), but this ought to fix it, I think.