### PR TITLE
Updating bundle.py for x64 Windows

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -43,12 +43,13 @@ libzmq_checksum = (
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)
 
-vcversion = 141
 
 if platform.architecture()[0] == '64bit':
     msarch = '-x64'
+    vcversion = 142
 else:
     msarch = ''
+    vcversion = 141
 
 libzmq_dll = f"libzmq-v{vcversion}{msarch}-{x}_{y}_{z}.zip"
 libzmq_dll_url = f"{download_url}/{libzmq_dll}"
@@ -58,6 +59,7 @@ libzmq_dll_checksums = {
     "libzmq-v140-x64-4_3_4.zip": "sha256:d5d75bd502d7935af3cf80734f81069be78420331c54814d0aab6d64adf450ae",
     "libzmq-v141-4_3_4.zip": "sha256:acfc997f036018b8dc8ab5b3a1d1444bba6ba5621e91c756d07cd9447db19672",
     "libzmq-v141-x64-4_3_4.zip": "sha256:4bb29d6fed20bd175a82317676c7e940356cd358b624efae8569c7ee11c45636",
+    "libzmq-v142-x64-4_3_4.zip": "sha256:61ae77d70bd55ffb85c3b30b6a4aeb40b0c69aaf492a9e691404d7f0192969e2",
 }
 
 libzmq_dll_checksum = libzmq_dll_checksums.get(libzmq_dll)


### PR DESCRIPTION
This updates bundle.py to use v142 of the libzmq dll, which appears necessary to support Windows IPC.