### PR TITLE
libzmq already bundles wepoll

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,10 +21,9 @@ include bundled/zeromq/COPYING
 graft bundled/zeromq/include
 graft bundled/zeromq/src
 graft bundled/zeromq/tweetnacl
+graft bundled/zeromq/external/wepoll
 exclude bundled/zeromq/src/Makefile*
 exclude bundled/zeromq/src/platform.hpp
-
-graft bundled/wepoll
 
 graft buildutils
 graft examples

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -39,14 +39,6 @@ libzmq_checksum = (
     "sha256:622bf650f7dab6de098c84d491052ad5a6d3e57550cd09cc259e0ab24ec83ec3"
 )
 
-wepoll_version = "v1.5.8"
-wepoll_url = (
-    f"https://github.com/piscisaureus/wepoll/archive/refs/tags/{wepoll_version}.zip"
-)
-wepoll_checksum = (
-    "sha256:2a2af790d41bff218704a7da5b28c0edbeb7db28ece2e703f33a442a7954b341"
-)
-
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)
@@ -159,9 +151,6 @@ def fetch_libzmq(savedir):
     """download and extract libzmq"""
     fetch_and_extract(
         savedir, 'zeromq', url=libzmq_url, fname=libzmq, checksum=libzmq_checksum
-    )
-    fetch_and_extract(
-        savedir, 'wepoll', url=wepoll_url, fname='wepoll.zip', checksum=wepoll_checksum
     )
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,11 @@ Changes in PyZMQ
 This is a coarse summary of changes in pyzmq versions.
 For a full changelog, consult the `git log <https://github.com/zeromq/pyzmq/commits>`_.
 
+22.2.1
+======
+
+Fix bundling of wepoll on Windows.
+
 22.2.0
 ======
 

--- a/setup.py
+++ b/setup.py
@@ -569,7 +569,7 @@ class Configure(build_ext):
         )
 
         if sys.platform.startswith("win"):  # only compile wepoll on windows...
-            sources.append(pjoin('bundled', 'wepoll', 'wepoll.c'))
+            sources.append(pjoin('bundled', 'zeromq', 'external', 'wepoll', 'wepoll.c'))
         includes = [pjoin(bundledir, 'zeromq', 'include')]
 
         if bundled_version < (4, 2, 0):


### PR DESCRIPTION
so we don't need to duplicate it, we just need to include it in sdist and point Windows compiles to it