### PR TITLE
ResourceWarnings

### DIFF
--- a/zmq/sugar/context.py
+++ b/zmq/sugar/context.py
@@ -63,9 +63,10 @@ class Context(ContextBase, AttributeSetter):
 
         if not self._shadow and not _exiting and not self.closed:
             warnings.warn(
-                f"Implicitly terminating {self}. Make sure to call Context.term().",
+                f"unclosed context {self}",
                 ResourceWarning,
                 stacklevel=2,
+                source=self,
             )
             self.term()
 
@@ -259,7 +260,9 @@ class Context(ContextBase, AttributeSetter):
         """
         if self.closed:
             raise ZMQError(ENOTSUP)
-        s = self._socket_class(self, socket_type, **kwargs)
+        s = self._socket_class(  # set PYTHONTRACEMALLOC=2 to get the calling frame
+            self, socket_type, **kwargs
+        )
         for opt, value in self.sockopts.items():
             try:
                 s.setsockopt(opt, value)

--- a/zmq/sugar/context.py
+++ b/zmq/sugar/context.py
@@ -9,6 +9,7 @@ import os
 from threading import Lock
 from typing import TypeVar, Type
 from weakref import WeakSet
+import warnings
 
 from zmq.backend import Context as ContextBase
 from . import constants
@@ -60,7 +61,12 @@ class Context(ContextBase, AttributeSetter):
         # Calling locals() here conceals issue #1167 on Windows CPython 3.5.4.
         locals()
 
-        if not self._shadow and not _exiting:
+        if not self._shadow and not _exiting and not self.closed:
+            warnings.warn(
+                f"Implicitly terminating {self}. Make sure to call Context.term().",
+                ResourceWarning,
+                stacklevel=2,
+            )
             self.term()
 
     _repr_cls = "zmq.Context"

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -93,7 +93,12 @@ class Socket(SocketBase, AttributeSetter):
             self._type_name = socket_types.get(socket_type, str(socket_type))
 
     def __del__(self):
-        if not self._shadow:
+        if not self._shadow and not self.closed:
+            warnings.warn(
+                f"Implicitly closing {self}. Make sure to call Socket.close().",
+                ResourceWarning,
+                stacklevel=2,
+            )
             self.close()
 
     _repr_cls = "zmq.Socket"

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -95,9 +95,10 @@ class Socket(SocketBase, AttributeSetter):
     def __del__(self):
         if not self._shadow and not self.closed:
             warnings.warn(
-                f"Implicitly closing {self}. Make sure to call Socket.close().",
+                f"unclosed socket {self}",
                 ResourceWarning,
                 stacklevel=2,
+                source=self,
             )
             self.close()
 


### PR DESCRIPTION
add resource warnings to track down unclosed sockets/contexts:

Example:

```python
import tracemalloc
import zmq
import warnings


def f():
    ctx = zmq.Context()
    s = ctx.socket(zmq.PUSH)

def main():
    f()

if __name__ == "__main__":
    tracemalloc.start(2)
    warnings.simplefilter('default')
    main()
```

gives:

```python
testresource.py:12: ResourceWarning: unclosed socket <zmq.Socket(zmq.PUSH) at 0x109be3160>
  f()
Object allocated at (most recent call last):
  File "testresource.py", lineno 8
    s = ctx.socket(zmq.PUSH)
  File "dev/zmq/pyzmq/zmq/sugar/context.py", lineno 263
    s = self._socket_class(  # set PYTHONTRACEMALLOC=2 to get the calling frame
testresource.py:12: ResourceWarning: unclosed context <zmq.Context() at 0x1096590e0>
  f()
Object allocated at (most recent call last):
  File "testresource.py", lineno 12
    f()
  File "testresource.py", lineno 7
    ctx = zmq.Context()
```