### PR TITLE
wheels: backport patch to avoid crashes when using CURVE security with bundled libzmq

### DIFF
--- a/tools/install_libzmq.sh
+++ b/tools/install_libzmq.sh
@@ -50,6 +50,26 @@ which ldconfig && ldconfig || true
 
 tar -xzf zeromq-${LIBZMQ_VERSION}.tar.gz
 cd zeromq-${LIBZMQ_VERSION}
+# patch CURVE crash bug https://github.com/zeromq/libzmq/issues/4241
+# FIXME: switch to `--disable-libsodium_randombytes_close`
+# when we bump bundle libzmq to 4.3.5
+
+patch -p1 <<EOF
+diff --git a/src/random.cpp b/src/random.cpp
+index 17c3537df3..12dead87ba 100644
+--- a/src/random.cpp
++++ b/src/random.cpp
+@@ -151,8 +151,6 @@ static void manage_random (bool init_)
+     if (init_) {
+         int rc = sodium_init ();
+         zmq_assert (rc != -1);
+-    } else {
+-        randombytes_close ();
+     }
+ #else
+     LIBZMQ_UNUSED (init_);
+EOF
+
 ./configure --prefix="$PREFIX" --with-libsodium
 make -j4
 make install


### PR DESCRIPTION
applies https://github.com/conda-forge/zeromq-feedstock/pull/67 (minus configuration) since pyzmq can't safely be used with CURVE without it.

Only affects libzmq bundled with pyzmq wheels on mac/linux.

Application code that needs this cleanup for some reason can call e.g.

```python
ctypes.CDLL("libsodium.dylib").randombytes_close()
```

but this should never really be required.