### PR TITLE
Regen platform.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ venv
 htmlcov
 coverage.xml
 env
+.eggs

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -193,7 +193,14 @@ def stage_platform_hpp(zmqroot):
             elif sys.platform.startswith('linux-armv'):
                 platform_dir = pjoin(HERE, 'include_linux-armv')
             else:
-                platform_dir = pjoin(HERE, 'include_linux')
+                # check for musl (alpine)
+                from packaging import tags
+
+                if any('musllinux' in tag.platform for tag in tags.sys_tags()):
+                    info("Detected musllinux (likely alpine)")
+                    platform_dir = pjoin(HERE, 'include_linux-musl')
+                else:
+                    platform_dir = pjoin(HERE, 'include_linux')
         else:
             return
 

--- a/buildutils/include_freebsd/platform.hpp
+++ b/buildutils/include_freebsd/platform.hpp
@@ -54,6 +54,9 @@
 /* Define to 1 if you have the <ifaddrs.h> header file. */
 #define HAVE_IFADDRS_H 1
 
+/* if_nametoindex is available */
+#define HAVE_IF_NAMETOINDEX 1
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
@@ -178,7 +181,7 @@
 #define PACKAGE_NAME "zeromq"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "zeromq 4.3.3"
+#define PACKAGE_STRING "zeromq 4.3.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "zeromq"
@@ -187,7 +190,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.3"
+#define PACKAGE_VERSION "4.3.4"
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -199,7 +202,7 @@
 #define TIME_WITH_SYS_TIME 1
 
 /* Version number of package */
-#define VERSION "4.3.3"
+#define VERSION "4.3.4"
 
 /* Enable militant API assertions */
 /* #undef ZMQ_ACT_MILITANT */
@@ -238,11 +241,11 @@
 /* Whether EFD_CLOEXEC is defined and functioning. */
 /* #undef ZMQ_HAVE_EVENTFD_CLOEXEC */
 
-/* Have FreeBSD OS */
+/* Have DragonFly OS */
 #define ZMQ_HAVE_FREEBSD 1
 
 /* Whether getrandom is supported. */
-/* #undef ZMQ_HAVE_GETRANDOM */
+#define ZMQ_HAVE_GETRANDOM 1
 
 /* Have GNU/Hurd OS */
 /* #undef ZMQ_HAVE_GNU */
@@ -293,7 +296,7 @@
 /* #undef ZMQ_HAVE_PTHREAD_SETNAME_1 */
 
 /* Whether pthread_setname_np() has 2 arguments */
-/* #undef ZMQ_HAVE_PTHREAD_SETNAME_2 */
+#define ZMQ_HAVE_PTHREAD_SETNAME_2 1
 
 /* Whether pthread_setname_np() has 3 arguments */
 /* #undef ZMQ_HAVE_PTHREAD_SETNAME_3 */
@@ -321,6 +324,12 @@
 
 /* Have SO_PEERCRED socket option */
 /* #undef ZMQ_HAVE_SO_PEERCRED */
+
+/* Whether SO_PRIORITY is supported. */
+/* #undef ZMQ_HAVE_SO_PRIORITY */
+
+/* strlcpy is available */
+#define ZMQ_HAVE_STRLCPY 1
 
 /* Whether TCP_KEEPALIVE is supported. */
 /* #undef ZMQ_HAVE_TCP_KEEPALIVE */

--- a/buildutils/include_linux-musl/platform.hpp
+++ b/buildutils/include_linux-musl/platform.hpp
@@ -2,7 +2,7 @@
 /* src/platform.hpp.in.  Generated from configure.ac by autoheader.  */
 
 /* Define to 1 if you have the `accept4' function. */
-/* #undef HAVE_ACCEPT4 */
+#define HAVE_ACCEPT4 1
 
 /* Define to 1 if you have the <alloca.h> header file. */
 #define HAVE_ALLOCA_H 1
@@ -25,7 +25,7 @@
 
 /* Define to 1 if you have the declaration of `SO_PEERCRED', and to 0 if you
    don't. */
-#define HAVE_DECL_SO_PEERCRED 0
+#define HAVE_DECL_SO_PEERCRED 1
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
@@ -34,7 +34,7 @@
 #define HAVE_ERRNO_H 1
 
 /* Define to 1 if you have the `fork' function. */
-#define HAVE_FORK 1
+/* #undef HAVE_FORK */
 
 /* Define to 1 if you have the `freeifaddrs' function. */
 #define HAVE_FREEIFADDRS 1
@@ -79,7 +79,7 @@
 /* #undef HAVE_LIBRPCRT4 */
 
 /* Define to 1 if you have the `rt' library (-lrt). */
-/* #undef HAVE_LIBRT */
+#define HAVE_LIBRT 1
 
 /* Define to 1 if you have the `socket' library (-lsocket). */
 /* #undef HAVE_LIBSOCKET */
@@ -97,7 +97,7 @@
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `memset' function. */
-#define HAVE_MEMSET 1
+/* #undef HAVE_MEMSET */
 
 /* Define to 1 if you have the `mkdtemp' function. */
 #define HAVE_MKDTEMP 1
@@ -139,7 +139,7 @@
 #define HAVE_STRNLEN 1
 
 /* Define to 1 if you have the <sys/eventfd.h> header file. */
-/* #undef HAVE_SYS_EVENTFD_H */
+#define HAVE_SYS_EVENTFD_H 1
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
 #define HAVE_SYS_SOCKET_H 1
@@ -236,16 +236,16 @@
 /* #undef ZMQ_HAVE_DRAGONFLY */
 
 /* Have eventfd extension */
-/* #undef ZMQ_HAVE_EVENTFD */
+#define ZMQ_HAVE_EVENTFD 1
 
 /* Whether EFD_CLOEXEC is defined and functioning. */
-/* #undef ZMQ_HAVE_EVENTFD_CLOEXEC */
+#define ZMQ_HAVE_EVENTFD_CLOEXEC 1
 
 /* Have DragonFly OS */
 /* #undef ZMQ_HAVE_FREEBSD */
 
 /* Whether getrandom is supported. */
-/* #undef ZMQ_HAVE_GETRANDOM */
+#define ZMQ_HAVE_GETRANDOM 1
 
 /* Have GNU/Hurd OS */
 /* #undef ZMQ_HAVE_GNU */
@@ -266,7 +266,7 @@
 /* #undef ZMQ_HAVE_LIBBSD */
 
 /* Have Linux OS */
-/* #undef ZMQ_HAVE_LINUX */
+#define ZMQ_HAVE_LINUX 1
 
 /* Have LOCAL_PEERCRED socket option */
 /* #undef ZMQ_HAVE_LOCAL_PEERCRED */
@@ -287,22 +287,22 @@
 /* #undef ZMQ_HAVE_OPENPGM */
 
 /* Have DarwinOSX OS */
-#define ZMQ_HAVE_OSX 1
+/* #undef ZMQ_HAVE_OSX */
 
 /* Whether O_CLOEXEC is defined and functioning. */
 #define ZMQ_HAVE_O_CLOEXEC 1
 
 /* Whether pthread_setname_np() has 1 argument */
-#define ZMQ_HAVE_PTHREAD_SETNAME_1 1
+/* #undef ZMQ_HAVE_PTHREAD_SETNAME_1 */
 
 /* Whether pthread_setname_np() has 2 arguments */
-/* #undef ZMQ_HAVE_PTHREAD_SETNAME_2 */
+#define ZMQ_HAVE_PTHREAD_SETNAME_2 1
 
 /* Whether pthread_setname_np() has 3 arguments */
 /* #undef ZMQ_HAVE_PTHREAD_SETNAME_3 */
 
 /* Whether pthread_setaffinity_np() exists */
-/* #undef ZMQ_HAVE_PTHREAD_SET_AFFINITY */
+#define ZMQ_HAVE_PTHREAD_SET_AFFINITY 1
 
 /* Whether pthread_set_name_np() exists */
 /* #undef ZMQ_HAVE_PTHREAD_SET_NAME */
@@ -311,34 +311,34 @@
 /* #undef ZMQ_HAVE_QNXNTO */
 
 /* Whether SOCK_CLOEXEC is defined and functioning. */
-/* #undef ZMQ_HAVE_SOCK_CLOEXEC */
+#define ZMQ_HAVE_SOCK_CLOEXEC 1
 
 /* Have Solaris OS */
 /* #undef ZMQ_HAVE_SOLARIS */
 
 /* Whether SO_BINDTODEVICE is supported. */
-/* #undef ZMQ_HAVE_SO_BINDTODEVICE */
+#define ZMQ_HAVE_SO_BINDTODEVICE 1
 
 /* Whether SO_KEEPALIVE is supported. */
 #define ZMQ_HAVE_SO_KEEPALIVE 1
 
 /* Have SO_PEERCRED socket option */
-/* #undef ZMQ_HAVE_SO_PEERCRED */
+#define ZMQ_HAVE_SO_PEERCRED 1
 
 /* Whether SO_PRIORITY is supported. */
-/* #undef ZMQ_HAVE_SO_PRIORITY */
+#define ZMQ_HAVE_SO_PRIORITY 1
 
 /* strlcpy is available */
 #define ZMQ_HAVE_STRLCPY 1
 
 /* Whether TCP_KEEPALIVE is supported. */
-#define ZMQ_HAVE_TCP_KEEPALIVE 1
+/* #undef ZMQ_HAVE_TCP_KEEPALIVE */
 
 /* Whether TCP_KEEPCNT is supported. */
 #define ZMQ_HAVE_TCP_KEEPCNT 1
 
 /* Whether TCP_KEEPIDLE is supported. */
-/* #undef ZMQ_HAVE_TCP_KEEPIDLE */
+#define ZMQ_HAVE_TCP_KEEPIDLE 1
 
 /* Whether TCP_KEEPINTVL is supported. */
 #define ZMQ_HAVE_TCP_KEEPINTVL 1
@@ -365,13 +365,13 @@
 /* #undef ZMQ_IOTHREAD_POLLER_USE_DEVPOLL */
 
 /* Use 'epoll' I/O thread polling system */
-/* #undef ZMQ_IOTHREAD_POLLER_USE_EPOLL */
+#define ZMQ_IOTHREAD_POLLER_USE_EPOLL 1
 
 /* Use 'epoll' I/O thread polling system with CLOEXEC */
-/* #undef ZMQ_IOTHREAD_POLLER_USE_EPOLL_CLOEXEC */
+#define ZMQ_IOTHREAD_POLLER_USE_EPOLL_CLOEXEC 1
 
 /* Use 'kqueue' I/O thread polling system */
-#define ZMQ_IOTHREAD_POLLER_USE_KQUEUE 1
+/* #undef ZMQ_IOTHREAD_POLLER_USE_KQUEUE */
 
 /* Use 'poll' I/O thread polling system */
 /* #undef ZMQ_IOTHREAD_POLLER_USE_POLL */

--- a/buildutils/include_linux/platform.hpp
+++ b/buildutils/include_linux/platform.hpp
@@ -54,6 +54,9 @@
 /* Define to 1 if you have the <ifaddrs.h> header file. */
 #define HAVE_IFADDRS_H 1
 
+/* if_nametoindex is available */
+#define HAVE_IF_NAMETOINDEX 1
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
@@ -178,7 +181,7 @@
 #define PACKAGE_NAME "zeromq"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "zeromq 4.3.3"
+#define PACKAGE_STRING "zeromq 4.3.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "zeromq"
@@ -187,7 +190,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.3"
+#define PACKAGE_VERSION "4.3.4"
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -199,7 +202,7 @@
 #define TIME_WITH_SYS_TIME 1
 
 /* Version number of package */
-#define VERSION "4.3.3"
+#define VERSION "4.3.4"
 
 /* Enable militant API assertions */
 /* #undef ZMQ_ACT_MILITANT */
@@ -321,6 +324,12 @@
 
 /* Have SO_PEERCRED socket option */
 #define ZMQ_HAVE_SO_PEERCRED 1
+
+/* Whether SO_PRIORITY is supported. */
+#define ZMQ_HAVE_SO_PRIORITY 1
+
+/* strlcpy is available */
+/* #undef ZMQ_HAVE_STRLCPY */
 
 /* Whether TCP_KEEPALIVE is supported. */
 /* #undef ZMQ_HAVE_TCP_KEEPALIVE */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
 [tool.black]
 skip-string-normalization = true
 exclude = "zmq/eventloop/minitornado|docs/source/conf.py"
+
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "packaging",
+    "cffi; implementation_name == 'pypy'",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1392,11 +1392,12 @@ setup_args = dict(
     ],
     setup_requires=[
         "cffi; implementation_name == 'pypy'",
+        "packaging",
     ],
 )
 if not os.path.exists(os.path.join("zmq", "backend", "cython", "socket.c")):
     setup_args["setup_requires"].append(
-        f"cython>={min_cython_version}; implementation_name == 'cpython'"
+        f"cython>={min_cython_version}; implementation_name == 'cpython'",
     )
 
 setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ from os.path import splitext, basename, join as pjoin
 from subprocess import Popen, PIPE, check_call, CalledProcessError
 
 # local script imports:
+sys.path.insert(0, os.path.dirname(__file__))
+
 from buildutils import (
     discover_settings,
     v_str,
@@ -503,7 +505,7 @@ class Configure(build_ext):
             if vers >= min_legacy_zmq:
 
                 msg.append(
-                    "    Explicitly allow legacy zmq by specifying `--zmq=/zmq/prefix`"
+                    "    Explicitly allow legacy zmq by specifying `ZMQ_PREFIX=/zmq/prefix`"
                 )
 
             raise LibZMQVersionError('\n'.join(msg))
@@ -537,7 +539,7 @@ class Configure(build_ext):
             local_dll = localpath('zmq', libzmq_name + '.dll')
             if not zmq_prefix and not os.path.exists(local_dll):
                 fatal(
-                    "ZMQ directory must be specified on Windows via setup.cfg or 'python setup.py configure --zmq=/path/to/libzmq'"
+                    "ZMQ directory must be specified on Windows via setup.cfg or 'ZMQ_PREFIX=/path/to/libzmq' env"
                 )
 
     def bundle_libzmq_extension(self):
@@ -691,10 +693,10 @@ class Configure(build_ext):
                     "    * A development version of Python is installed (including headers)",
                     "    * A development version of ZMQ >= %s is installed (including headers)"
                     % v_str(min_good_zmq),
-                    "    * If ZMQ is not in a default location, supply the argument --zmq=<path>",
+                    "    * If ZMQ is not in a default location, specify the env  ZMQ_PREFIX=<path>",
                     "    * If you did recently install ZMQ to a default location,",
                     "      try rebuilding the ld cache with `sudo ldconfig`",
-                    "      or specify zmq's location with `--zmq=/usr/local`",
+                    "      or specify zmq's location with `ZMQ_PREFIX=/usr/local`",
                     "",
                 ]
             )
@@ -706,7 +708,7 @@ class Configure(build_ext):
                     "You can skip all this detection/waiting nonsense if you know",
                     "you want pyzmq to bundle libzmq as an extension by passing:",
                     "",
-                    "    `--zmq=bundled`",
+                    "    `ZMQ_PREFIX=bundled`",
                     "",
                     "I will now try to build libzmq as a Python extension",
                     "unless you interrupt me (^C) in the next 10 seconds...",


### PR DESCRIPTION
- fixes `strlcpy` detection on alpine, freebsd (closes #1510)
- populate build-system in pyproject.toml (requires packaging for musl detection)
- update recommendation to use `ZMQ_PREFIX=` instead of `--zmq=` since recent pip ignores `--install-option`