### PR TITLE
warn instead of raise on events callback after terminating context

### DIFF
--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -439,9 +439,13 @@ class ZMQStream(object):
         """This method is the actual handler for IOLoop, that gets called whenever
         an event on my socket is posted. It dispatches to _handle_recv, etc."""
         if not self.socket:
-            gen_log.warning("Got events for closed stream %s", fd)
+            gen_log.warning("Got events for closed stream %s", self)
             return
-        zmq_events = self.socket.EVENTS
+        try:
+            zmq_events = self.socket.EVENTS
+        except zmq.ContextTerminated:
+            gen_log.warning("Got events for stream %s after terminating context", self)
+            return
         try:
             # dispatch events:
             if zmq_events & zmq.POLLIN and self.receiving():


### PR DESCRIPTION
same as closing socket

socket could close or context could term between callback being scheduled and executed

seems to happen sometimes on Windows with the extra selector thread