### PR TITLE
OBS CI: use link_package instead of branch_package

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,5 +1,5 @@
 workflow:
   steps:
-    - branch_package:
+    - link_package:
         source_project: network:messaging:zeromq:git-draft
         source_package: pyzmq


### PR DESCRIPTION
It should keep the same settings as the source, thus skipping disabled builds