### PR TITLE
Small update/clarification to auth docs

### DIFF
--- a/zmq/auth/__init__.py
+++ b/zmq/auth/__init__.py
@@ -4,6 +4,9 @@ To run authentication in a background thread, see :mod:`zmq.auth.thread`.
 For integration with the tornado eventloop, see :mod:`zmq.auth.ioloop`.
 For integration with the asyncio event loop, see :mod:`zmq.auth.asyncio`.
 
+Authentication examples are provided in the pyzmq codebase, under 
+`/examples/security/`.
+
 .. versionadded:: 14.1
 """
 

--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -20,6 +20,21 @@ VERSION = b'1.0'
 class Authenticator(object):
     """Implementation of ZAP authentication for zmq connections.
 
+    This authenticator class does not register with an event loop. As a result,
+    you will need to manually call `handle_zap_message`::
+
+        auth = zmq.Authenticator()
+        auth.allow("127.0.0.1")
+        auth.start()
+        while True:
+            auth.handle_zap_msg(auth.zap_socket.recv_multipart()
+
+    Alternatively, you can register `auth.zap_socket` with a poller. 
+
+    Since many users will want to run ZAP in a way that does not block the
+    main thread, other authentication classes (such as :mod:`zmq.auth.thread`)
+    are provided.
+
     Note:
 
     - libzmq provides four levels of security: default NULL (which the Authenticator does

--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -29,7 +29,7 @@ class Authenticator(object):
         while True:
             auth.handle_zap_msg(auth.zap_socket.recv_multipart()
 
-    Alternatively, you can register `auth.zap_socket` with a poller. 
+    Alternatively, you can register `auth.zap_socket` with a poller.
 
     Since many users will want to run ZAP in a way that does not block the
     main thread, other authentication classes (such as :mod:`zmq.auth.thread`)


### PR DESCRIPTION
Update the Authenticator class doc to indicate, while it is usable on its own, many users will want to use the ThreadAuthenticator. 

Also provides an example of what using the base Authenticator looks like, and reference the examples included in the codebase.

closes #1593