### PR TITLE
Remove use of distutils

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,11 @@ jobs:
           sudo apt-get -y remove libzmq5 || true # workaround https://github.com/actions/virtual-environments/issues/3317
           sudo apt-get -y install libzmq3-dev libsodium-dev
 
+      - name: set $ZMQ_PREFIX
+        if: matrix.zmq
+        run: |
+          echo "ZMQ_PREFIX=${{ matrix.zmq }}" >> "$GITHUB_ENV"
+
       - name: install libzmq-dev
         if: matrix.zmq == 'head'
         run: |
@@ -154,7 +159,7 @@ jobs:
 
       - name: build pyzmq
         run: |
-          pip install -v -e . --global-option=--zmq=${{ matrix.zmq }}
+          pip install -v -e .
 
       - name: import zmq
         run: |

--- a/buildutils/misc.py
+++ b/buildutils/misc.py
@@ -67,7 +67,7 @@ def get_output_error(cmd, **kwargs):
     return result.returncode, so, se
 
 
-def locate_vcredist_dir():
+def locate_vcredist_dir(plat):
     """Locate vcredist directory and add it to $PATH
 
     Adding it to $PATH is required to run
@@ -75,16 +75,11 @@ def locate_vcredist_dir():
     """
     from setuptools import msvc
 
-    try:
-        from setuptools._distutils.util import get_platform
-    except ImportError:
-        from distutils.util import get_platform
-
-    vcvars = msvc.msvc14_get_vc_env(get_platform())
+    vcvars = msvc.msvc14_get_vc_env(plat)
     try:
         vcruntime = vcvars["py_vcruntime_redist"]
     except KeyError:
-        warn(f"platform={get_platform()}, vcvars=")
+        warn(f"platform={plat}, vcvars=")
         pprint(vcvars, stream=sys.stderr)
 
         warn(

--- a/buildutils/misc.py
+++ b/buildutils/misc.py
@@ -3,11 +3,10 @@
 # Copyright (c) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
+import copy
 import os
 import sys
 import logging
-from distutils import ccompiler
-from distutils.sysconfig import customize_compiler
 from pipes import quote
 from pprint import pprint
 from subprocess import Popen, PIPE
@@ -36,13 +35,7 @@ def customize_mingw(cc):
 
 def get_compiler(compiler, **compiler_attrs):
     """get and customize a compiler"""
-    if compiler is None or isinstance(compiler, str):
-        cc = ccompiler.new_compiler(compiler=compiler)
-        customize_compiler(cc)
-        if cc.compiler_type == 'mingw32':
-            customize_mingw(cc)
-    else:
-        cc = compiler
+    cc = copy.deepcopy(compiler)
 
     for name, val in compiler_attrs.items():
         setattr(cc, name, val)

--- a/setup.py
+++ b/setup.py
@@ -159,9 +159,15 @@ def bundled_settings(cmd):
         settings['libraries'].append('pthread')
     elif sys.platform.startswith('win'):
         # link against libzmq in build dir:
-        # Python 3.5 adds EXT_SUFFIX to libs
-        ext_suffix = get_config_var("EXT_SUFFIX")
+        if sys.version_info < (3, 9, 2):
+            # bpo-39825: EXT_SUFFIX is wrong from sysconfig prior to 3.9.2 / 3.8.7
+            import distutils.sysconfig
+
+            ext_suffix = distutils.sysconfig.get_config_var("EXT_SUFFIX")
+        else:
+            ext_suffix = get_config_var("EXT_SUFFIX")
         suffix = os.path.splitext(ext_suffix)[0]
+        print(f"DEBUG EXT_SUFFIX {suffix!r} {ext_suffix!r}")
 
         settings['libraries'].append(libzmq_name + suffix)
         settings['library_dirs'].append(pjoin(cmd.build_temp, 'buildutils'))

--- a/setup.py
+++ b/setup.py
@@ -159,22 +159,12 @@ def bundled_settings(cmd):
         settings['libraries'].append('pthread')
     elif sys.platform.startswith('win'):
         # link against libzmq in build dir:
-        plat = cmd.plat_name
-        temp = 'temp.%s-%i.%i' % (plat, sys.version_info[0], sys.version_info[1])
-        if hasattr(sys, 'gettotalrefcount'):
-            temp += '-pydebug'
-
         # Python 3.5 adds EXT_SUFFIX to libs
         ext_suffix = get_config_var("EXT_SUFFIX")
         suffix = os.path.splitext(ext_suffix)[0]
 
-        if cmd.debug:
-            release = 'Debug'
-        else:
-            release = 'Release'
-
         settings['libraries'].append(libzmq_name + suffix)
-        settings['library_dirs'].append(pjoin('build', temp, release, 'buildutils'))
+        settings['library_dirs'].append(pjoin(cmd.build_temp, 'buildutils'))
 
     return settings
 

--- a/setup.py
+++ b/setup.py
@@ -16,66 +16,58 @@
 #  pyzmq-static: <https://github.com/brandon-rhodes/pyzmq-static>
 # -----------------------------------------------------------------------------
 
-from __future__ import with_statement, print_function
-
-from contextlib import contextmanager
 import copy
+import errno
 import io
 import os
+import platform
 import shutil
 import subprocess
 import sys
 import time
-import errno
-import platform
+from contextlib import contextmanager
+from distutils.ccompiler import get_default_compiler, new_compiler
+from distutils.sysconfig import customize_compiler
+from glob import glob
+from os.path import basename
+from os.path import join as pjoin
+from os.path import splitext
+from subprocess import PIPE, CalledProcessError, Popen, check_call
+from sysconfig import get_config_var
 from traceback import print_exc
 
-try:
-    import cffi
-except ImportError:
-    cffi = None
-
 from packaging.version import Version as V
-from setuptools import setup, Command
+from setuptools import Command, setup
 from setuptools.command.bdist_egg import bdist_egg
 from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
 from setuptools.extension import Extension
 
-from distutils.ccompiler import get_default_compiler
-from distutils.ccompiler import new_compiler
-from distutils.sysconfig import customize_compiler
-from sysconfig import get_config_var
-
-from glob import glob
-from os.path import splitext, basename, join as pjoin
-
-from subprocess import Popen, PIPE, check_call, CalledProcessError
 
 # local script imports:
 sys.path.insert(0, os.path.dirname(__file__))
 
 from buildutils import (
-    discover_settings,
-    v_str,
-    save_config,
-    detect_zmq,
-    merge,
+    bundled_version,
+    compile_and_forget,
     config_from_prefix,
-    info,
-    warn,
-    fatal,
+    customize_mingw,
     debug,
+    detect_zmq,
+    discover_settings,
+    fatal,
+    fetch_libzmq,
+    fetch_libzmq_dll,
+    info,
     line,
     localpath,
     locate_vcredist_dir,
-    fetch_libzmq,
-    fetch_libzmq_dll,
-    stage_platform_hpp,
-    bundled_version,
-    customize_mingw,
-    compile_and_forget,
+    merge,
     patch_lib_paths,
+    save_config,
+    stage_platform_hpp,
+    v_str,
+    warn,
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
closes #1620

Mostly easy. Two still-undocumented migrations, which ultimately amount to the same thing: use initialized state in base classes, rather than importing the pieces of the underlying implementation.

1. use `self.plat_name` instead of `util.get_platform()`. I suspect this is just better, as in any rare cases where they disagreed, I think it should be _more_ correct now
2. pass around `self.compiler` instead of calling `distutils.ccompiler.new_compiler`. This is tricky to get access to, because we need to run `build_ext.run()` but that only configures a compiler if there's something to compile, so we have to:
   1. register an Extension that won't get compiled, so that compiler is created
   2. override build_extensions to not actually build extensions
