### PR TITLE
Make docstring match type annotation

### DIFF
--- a/zmq/sugar/poll.py
+++ b/zmq/sugar/poll.py
@@ -85,7 +85,7 @@ class Poller:
 
         Parameters
         ----------
-        timeout : float, int
+        timeout : int
             The timeout in milliseconds. If None, no `timeout` (infinite). This
             is in milliseconds to be compatible with ``select.poll()``.
 


### PR DESCRIPTION
I *think* the type annotation of `Optional[int]` is correct and the docstring of `float, int` is incorrect.  

The generated API docs use the docstring and so indicate that you can use a float or an int, but then when you use a float, you get type errors in your IDE/mypy/etc.