### PR TITLE
Fix doc typos upd -> udp

### DIFF
--- a/zmq/backend/cython/socket.pyx
+++ b/zmq/backend/cython/socket.pyx
@@ -576,7 +576,7 @@ cdef class Socket:
         addr : str
             The address string. This has the form 'protocol://interface:port',
             for example 'tcp://127.0.0.1:5555'. Protocols supported are
-            tcp, upd, pgm, inproc and ipc. If the address is unicode, it is
+            tcp, udp, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
         """
         cdef int rc
@@ -612,7 +612,7 @@ cdef class Socket:
         addr : str
             The address string. This has the form 'protocol://interface:port',
             for example 'tcp://127.0.0.1:5555'. Protocols supported are
-            tcp, upd, pgm, inproc and ipc. If the address is unicode, it is
+            tcp, udp, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
         """
         cdef int rc
@@ -643,7 +643,7 @@ cdef class Socket:
         addr : str
             The address string. This has the form 'protocol://interface:port',
             for example 'tcp://127.0.0.1:5555'. Protocols supported are
-            tcp, upd, pgm, inproc and ipc. If the address is unicode, it is
+            tcp, udp, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
         """
         cdef int rc

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -242,7 +242,7 @@ class Socket(SocketBase, AttributeSetter):
         addr : str
             The address string. This has the form 'protocol://interface:port',
             for example 'tcp://127.0.0.1:5555'. Protocols supported are
-            tcp, upd, pgm, inproc and ipc. If the address is unicode, it is
+            tcp, udp, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
 
         """


### PR DESCRIPTION
upd visible for example on https://pyzmq.readthedocs.io/en/latest/api/zmq.html 