### PR TITLE
Hold a reference to `warnings.warn` for use in __del__

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -8,7 +8,7 @@ import errno
 import pickle
 import random
 import sys
-import warnings
+from warnings import warn
 from typing import (
     Any,
     Dict,
@@ -106,7 +106,7 @@ class Socket(SocketBase, AttributeSetter):
 
     def __del__(self):
         if not self._shadow and not self.closed:
-            warnings.warn(
+            warn(
                 f"unclosed socket {self}",
                 ResourceWarning,
                 stacklevel=2,
@@ -254,7 +254,7 @@ class Socket(SocketBase, AttributeSetter):
 
     @property
     def socket_type(self) -> int:
-        warnings.warn(
+        warn(
             "Socket.socket_type is deprecated, use Socket.type", DeprecationWarning
         )
         return cast(int, self.type)

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -8,7 +8,6 @@ import errno
 import pickle
 import random
 import sys
-from warnings import warn
 from typing import (
     Any,
     Dict,
@@ -22,6 +21,7 @@ from typing import (
     cast,
     overload,
 )
+from warnings import warn
 
 import zmq
 from zmq._typing import Literal
@@ -254,9 +254,7 @@ class Socket(SocketBase, AttributeSetter):
 
     @property
     def socket_type(self) -> int:
-        warn(
-            "Socket.socket_type is deprecated, use Socket.type", DeprecationWarning
-        )
+        warn("Socket.socket_type is deprecated, use Socket.type", DeprecationWarning)
         return cast(int, self.type)
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
I've been getting output like this when Python exits, similar to https://github.com/zeromq/pyzmq/issues/1356.

```
Exception ignored in: <function Socket.__del__ at 0x7f02b08ebf70>
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/zmq/sugar/socket.py", line 97, in __del__
TypeError: 'NoneType' object is not callable
```
Holding a reference to `warnings.warn`, similar to the fix for #1356, seems to resolve the problem.