### PR TITLE
build wheels with 0.29.x while we wait for 0.29.29

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,9 @@ jobs:
       - name: install dependencies
         run: |
           pip install --upgrade pip build
-          pip install cython=="${{ env.cython }}"
+          # temporary: 0.29.x while we wait for 0.29.29
+          pip install --install-option=--no-cython-compile https://github.com/cython/cython/archive/0.29.x.tar.gz
+          # pip install cython=="${{ env.cython }}"
 
       - name: build sdist
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,7 +183,7 @@ jobs:
             cibw:
               build: "cp*win32"
 
-          - os: windows-2016
+          - os: windows-2019
             name: win-pypy
             architecture: x64
             cibw:


### PR DESCRIPTION
should let a prerelease sdist work with 3.11 prereleases