### PR TITLE
ensure constants are in `zmq.__all__`

### DIFF
--- a/zmq/__init__.py
+++ b/zmq/__init__.py
@@ -132,12 +132,14 @@ def get_library_dirs():
 
 COPY_THRESHOLD = 65536
 DRAFT_API = backend.has("draft")
+
 __all__ = (
     [
         'get_includes',
         'COPY_THRESHOLD',
         'DRAFT_API',
     ]
+    + constants.__all__
     + sugar.__all__
     + backend.__all__
 )

--- a/zmq/__init__.pyi
+++ b/zmq/__init__.pyi
@@ -5,6 +5,7 @@ from . import backend, sugar
 COPY_THRESHOLD: int
 DRAFT_API: bool
 __version__: str
+__all__: List[str]
 
 # mypy doesn't like overwriting symbols with * so be explicit
 # about what comes from backend, not from sugar

--- a/zmq/__init__.pyi
+++ b/zmq/__init__.pyi
@@ -5,7 +5,6 @@ from . import backend, sugar
 COPY_THRESHOLD: int
 DRAFT_API: bool
 __version__: str
-__all__: List[str]
 
 # mypy doesn't like overwriting symbols with * so be explicit
 # about what comes from backend, not from sugar

--- a/zmq/green/__init__.py
+++ b/zmq/green/__init__.py
@@ -42,4 +42,5 @@ Poller = _Poller  # type: ignore
 from zmq.green.device import device  # type: ignore
 
 __all__: List[str] = []
-__all__.extend(_zmq.__all__)
+# adding `__all__` to __init__.pyi gets mypy all confused
+__all__.extend(_zmq.__all__)  # type: ignore

--- a/zmq/green/__init__.py
+++ b/zmq/green/__init__.py
@@ -28,6 +28,9 @@ before any blocking operation and the ØMQ file descriptor is polled internally
 to trigger needed events.
 """
 
+from typing import List
+
+import zmq as _zmq
 from zmq import *
 from zmq.green.core import _Context, _Socket
 from zmq.green.poll import _Poller
@@ -37,3 +40,6 @@ Socket = _Socket  # type: ignore
 Poller = _Poller  # type: ignore
 
 from zmq.green.device import device  # type: ignore
+
+__all__: List[str] = []
+__all__.extend(_zmq.__all__)

--- a/zmq/tests/test_imports.py
+++ b/zmq/tests/test_imports.py
@@ -1,65 +1,99 @@
+"""
+Test Imports - the quickest test to ensure that we haven't
+introduced version-incompatible syntax errors.
+"""
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
 # flake8: noqa: F401
 
-from unittest import TestCase
-
 import pytest
 
 
-class TestImports(TestCase):
-    """Test Imports - the quickest test to ensure that we haven't
-    introduced version-incompatible syntax errors."""
+def test_toplevel():
+    """test toplevel import"""
+    import zmq
 
-    def test_toplevel(self):
-        """test toplevel import"""
-        import zmq
 
-    def test_core(self):
-        """test core imports"""
-        from zmq import (
-            Context,
-            Frame,
-            Poller,
-            Socket,
-            constants,
-            device,
-            proxy,
-            pyzmq_version,
-            pyzmq_version_info,
-            zmq_version,
-            zmq_version_info,
-        )
+def test_core():
+    """test core imports"""
+    from zmq import (
+        Context,
+        Frame,
+        Poller,
+        Socket,
+        constants,
+        device,
+        proxy,
+        pyzmq_version,
+        pyzmq_version_info,
+        zmq_version,
+        zmq_version_info,
+    )
 
-    def test_devices(self):
-        """test device imports"""
-        import zmq.devices
-        from zmq.devices import basedevice, monitoredqueue, monitoredqueuedevice
 
-    def test_log(self):
-        """test log imports"""
-        import zmq.log
-        from zmq.log import handlers
+def test_devices():
+    """test device imports"""
+    import zmq.devices
+    from zmq.devices import basedevice, monitoredqueue, monitoredqueuedevice
 
-    def test_eventloop(self):
-        """test eventloop imports"""
-        try:
-            import tornado
-        except ImportError:
-            pytest.skip('requires tornado')
-        import zmq.eventloop
-        from zmq.eventloop import ioloop, zmqstream
 
-    def test_utils(self):
-        """test util imports"""
-        import zmq.utils
-        from zmq.utils import jsonapi, strtypes
+def test_log():
+    """test log imports"""
+    import zmq.log
+    from zmq.log import handlers
 
-    def test_ssh(self):
-        """test ssh imports"""
-        from zmq.ssh import tunnel
 
-    def test_decorators(self):
-        """test decorators imports"""
-        from zmq.decorators import context, socket
+def test_eventloop():
+    """test eventloop imports"""
+    pytest.importorskip("tornado")
+    import zmq.eventloop
+    from zmq.eventloop import ioloop, zmqstream
+
+
+def test_utils():
+    """test util imports"""
+    import zmq.utils
+    from zmq.utils import jsonapi, strtypes
+
+
+def test_ssh():
+    """test ssh imports"""
+    from zmq.ssh import tunnel
+
+
+def test_decorators():
+    """test decorators imports"""
+    from zmq.decorators import context, socket
+
+
+def test_zmq_all():
+    import zmq
+
+    for name in zmq.__all__:
+        assert hasattr(zmq, name)
+
+
+@pytest.mark.parametrize("pkgname", ["zmq", "zmq.green"])
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "RCVTIMEO",
+        "PUSH",
+        "zmq_version_info",
+        "SocketOption",
+        "device",
+        "Socket",
+        "Context",
+    ],
+)
+def test_all_exports(pkgname, attr):
+    import zmq
+
+    subpkg = pytest.importorskip(pkgname)
+    for name in zmq.__all__:
+        assert hasattr(subpkg, name)
+
+    assert attr in subpkg.__all__
+    if attr not in ("Socket", "Context", "device"):
+        assert getattr(subpkg, attr) is getattr(zmq, attr)


### PR DESCRIPTION
otherwise they won't get imported, e.g. in zmq.green

closes #1703 