### PR TITLE
add Python 3.11 wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ jobs:
     parameters:
       build:
         type: string
+      skip:
+        type: string
+        default: ""
+      image:
+        type: string
+        default: quay.io/pypa/manylinux2014_aarch64
 
     machine:
       image: ubuntu-2004:2022.04.1
@@ -19,9 +25,11 @@ jobs:
       CIBW_TEST_REQUIRES: "pytest"
       CIBW_TEST_COMMAND: "pytest -vsx {package}/tools/test_wheel.py"
       CIBW_ARCHS: "aarch64"
-      CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64
+      CIBW_MANYLINUX_AARCH64_IMAGE: "<< parameters.image >>"
       CIBW_MUSLLINUX_AARCH64_IMAGE: quay.io/pypa/musllinux_1_1_aarch64
+      CIBW_SKIP: "<< parameters.skip >>"
       CIBW_BUILD: "<< parameters.build >>"
+      CIBW_PRERELEASE_PYTHONS: "1"
 
     steps:
       - checkout
@@ -76,8 +84,13 @@ workflows:
     # Inside the workflow, you define the jobs you want to run.
     jobs:
       - arm-wheels:
-          matrix:
-            parameters:
-              build:
-                - "*manylinux*"
-                - "*musllinux*"
+          name: manylinux
+          build: "*manylinux*"
+          skip: "cp311*"
+      - arm-wheels:
+          name: manylinux-cp311
+          build: "cp311*manylinux*"
+          image: manylinux_2_28
+      - arm-wheels:
+          name: musllinux
+          build: "*musllinux*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
       CIBW_ARCHS: "aarch64"
       CIBW_SKIP: "<< parameters.skip >>"
       CIBW_BUILD: "<< parameters.build >>"
-      CIBW_PRERELEASE_PYTHONS: "1"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,25 +8,13 @@ jobs:
       skip:
         type: string
         default: ""
-      image:
-        type: string
-        default: quay.io/pypa/manylinux2014_aarch64
 
     machine:
       image: ubuntu-2004:2022.04.1
     resource_class: arm.medium
 
     environment:
-      CIBW_BEFORE_ALL_LINUX: "bash tools/install_libzmq.sh"
-      CIBW_ENVIRONMENT_LINUX: >-
-        ZMQ_PREFIX=/usr/local
-        CFLAGS=-Wl,-strip-all
-        CXXFLAGS=-Wl,-strip-all
-      CIBW_TEST_REQUIRES: "pytest"
-      CIBW_TEST_COMMAND: "pytest -vsx {package}/tools/test_wheel.py"
       CIBW_ARCHS: "aarch64"
-      CIBW_MANYLINUX_AARCH64_IMAGE: "<< parameters.image >>"
-      CIBW_MUSLLINUX_AARCH64_IMAGE: quay.io/pypa/musllinux_1_1_aarch64
       CIBW_SKIP: "<< parameters.skip >>"
       CIBW_BUILD: "<< parameters.build >>"
       CIBW_PRERELEASE_PYTHONS: "1"
@@ -86,11 +74,6 @@ workflows:
       - arm-wheels:
           name: manylinux
           build: "*manylinux*"
-          skip: "cp311*"
-      - arm-wheels:
-          name: manylinux-cp311
-          build: "cp311*manylinux*"
-          image: manylinux_2_28
       - arm-wheels:
           name: musllinux
           build: "*musllinux*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,7 +78,6 @@ jobs:
       CIBW_SKIP: "${{ matrix.cibw.skip || '' }}"
       CIBW_ARCHS_LINUX: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_ARCHS_MACOS: "${{ matrix.cibw.arch || 'auto' }}"
-      CIBW_PRERELEASE_PYTHONS: "1"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,15 +102,16 @@ jobs:
               skip: "cp38*"
 
           - os: ubuntu-20.04
-            name: manylinux-cpython
+            name: manylinux-x86_64
             cibw:
-              build: "cp*manylinux*"
-              skip: "*musllinux*"
+              arch: x86_64
+              build: "*manylinux*"
 
           - os: ubuntu-20.04
-            name: manylinux-pypy
+            name: manylinux-i686
             cibw:
-              build: "pp3*manylinux*"
+              arch: i686
+              build: "*manylinux*"
 
           - os: ubuntu-20.04
             name: musllinux

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,29 +74,8 @@ jobs:
 
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.9"
-      CIBW_BUILD_VERBOSITY: "1"
-      CIBW_BEFORE_ALL_MACOS: "bash tools/install_libzmq.sh"
-      CIBW_BEFORE_ALL_LINUX: "bash tools/install_libzmq.sh"
-
-      CIBW_ENVIRONMENT_MACOS: "ZMQ_PREFIX=/usr/local"
-      CIBW_ENVIRONMENT_LINUX: >-
-        ZMQ_PREFIX=/usr/local
-        CFLAGS=-Wl,-strip-all
-        CXXFLAGS=-Wl,-strip-all
-      CIBW_ENVIRONMENT_WINDOWS: "ZMQ_PREFIX=libzmq-dll"
-      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
-        delvewheel repair
-        -v
-        --add-path=C:/libzmq-dll
-        --wheel-dir={dest_dir}
-        {wheel}
-
-      CIBW_TEST_REQUIRES: "pytest"
-      CIBW_TEST_COMMAND: "pytest -vsx {package}/tools/test_wheel.py"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "${{ matrix.cibw.skip || '' }}"
-      CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_MANYLINUX_I686_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_ARCHS_LINUX: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_ARCHS_MACOS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_PRERELEASE_PYTHONS: "1"
@@ -127,28 +106,24 @@ jobs:
             cibw:
               build: "cp36* cp37*"
               skip: "*musllinux*"
-              manylinux_image: manylinux1
 
           - os: ubuntu-20.04
             name: manylinux2010
             cibw:
-              build: "cp38* cp39* cp310* pp37* pp38*"
+              build: "cp38* cp39* pp37* pp38*"
               skip: "*musllinux*"
-              manylinux_image: manylinux2010
 
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               build: "cp310* pp39*"
               skip: "*musllinux*"
-              manylinux_image: manylinux2014
 
           - os: ubuntu-20.04
             name: manylinux_2_28
             cibw:
               build: "cp311*"
               skip: "*musllinux*"
-              manylinux_image: manylinux_2_28
               arch: x86_64
 
           - os: ubuntu-20.04
@@ -183,16 +158,6 @@ jobs:
           python-version: "3.8"
           architecture: ${{ matrix.architecture }}
 
-      - name: set Windows extra env for pypy
-        shell: bash
-        if: matrix.name == 'win-pypy'
-        # pypy builds libzmq as an Extension,
-        # doesn't bundle dlls (requires separate vcredist install, as pypy itself seems to)
-        # bundling external libzmq doesn't seem to work
-        run: |
-          echo 'CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=' >> "$GITHUB_ENV"
-          echo 'CIBW_ENVIRONMENT_WINDOWS=' >> "$GITHUB_ENV"
-
       - name: customize mac-arm-64
         if: contains(matrix.os, 'macos') && matrix.cibw.arch
         run: |
@@ -202,13 +167,6 @@ jobs:
         run: |
           pip install --upgrade setuptools pip wheel
           pip install -r tools/wheel-requirements.txt
-
-
-      - name: install windows dependencies
-        if: startsWith(matrix.os, 'win')
-        run: |
-          python setup.py fetch_libzmq --dll
-          xcopy /i libzmq-dll C:\\libzmq-dll
 
       - name: show environment
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,34 +102,20 @@ jobs:
               skip: "cp38*"
 
           - os: ubuntu-20.04
-            name: manylinux1
+            name: manylinux-cpython
             cibw:
-              build: "cp36* cp37*"
+              build: "cp*manylinux*"
               skip: "*musllinux*"
 
           - os: ubuntu-20.04
-            name: manylinux2010
+            name: manylinux-pypy
             cibw:
-              build: "cp38* cp39* pp37* pp38*"
-              skip: "*musllinux*"
+              build: "pp3*manylinux*"
 
           - os: ubuntu-20.04
-            name: manylinux2014
+            name: musllinux
             cibw:
-              build: "cp310* pp39*"
-              skip: "*musllinux*"
-
-          - os: ubuntu-20.04
-            name: manylinux_2_28
-            cibw:
-              build: "cp311*"
-              skip: "*musllinux*"
-              arch: x86_64
-
-          - os: ubuntu-20.04
-            name: musslinux
-            cibw:
-              skip: "*manylinux*"
+              build: "*musllinux*"
 
           - os: windows-2019
             name: win32

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,6 +99,7 @@ jobs:
       CIBW_MANYLINUX_I686_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_ARCHS_LINUX: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_ARCHS_MACOS: "${{ matrix.cibw.arch || 'auto' }}"
+      CIBW_PRERELEASE_PYTHONS: "1"
 
     strategy:
       fail-fast: false
@@ -118,7 +119,8 @@ jobs:
             name: mac-arm
             cibw:
               arch: universal2
-              build: "cp39* cp310*"
+              build: "cp*"
+              skip: "cp38*"
 
           - os: ubuntu-20.04
             name: manylinux1
@@ -137,10 +139,17 @@ jobs:
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
-              # cp311 will go here
               build: "cp310* pp39*"
               skip: "*musllinux*"
               manylinux_image: manylinux2014
+
+          - os: ubuntu-20.04
+            name: manylinux_2_28
+            cibw:
+              build: "cp311*"
+              skip: "*musllinux*"
+              manylinux_image: manylinux_2_28
+              arch: x86_64
 
           - os: ubuntu-20.04
             name: musslinux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,76 @@ search = 'version="{current_version}"'
 [[tool.tbump.file]]
 src = "zmq/sugar/version.py"
 search = '__version__: str = "{current_version}"'
+
+
+[tool.cibuildwheel]
+build-verbosity = "1"
+test-requires = ["pytest"]
+test-command = "pytest -vsx {package}/tools/test_wheel.py"
+
+[tool.cibuildwheel.linux]
+before-all = "bash tools/install_libzmq.sh"
+environment.ZMQ_PREFIX = "/usr/local"
+environment.CFLAGS = "-Wl,-strip-all"
+environment.CXXFLAGS = "-Wl,-strip-all"
+
+manylinux-aarch64-image = "manylinux2014"
+musllinux-aarch64-image = "musllinux_1_1"
+musllinux-i686-image = "musllinux_1_1"
+musllinux-x86_64-image = "musllinux_1_1"
+
+[tool.cibuildwheel.macos]
+before-all = "bash tools/install_libzmq.sh"
+environment.ZMQ_PREFIX = "/usr/local"
+environment.MACOSX_DEPLOYMENT_TARGET = "10.9"
+
+[tool.cibuildwheel.windows]
+before-all = [
+    "python setup.py fetch_libzmq --dll",
+    "xcopy /i libzmq-dll C:\\libzmq-dll",
+]
+
+environment.ZMQ_PREFIX = "libzmq-dll"
+repair-wheel-command = """
+    delvewheel repair \
+        -v \
+        --add-path=C:/libzmq-dll \
+        --wheel-dir={dest_dir} \
+        {wheel}
+"""
+
+# mac-arm target is 10.15
+[[tool.cibuildwheel.overrides]]
+select = "*macos*{universal2,arm64}*"
+environment.MACOSX_DEPLOYMENT_TARGET = "10.15"
+
+# manylinux1 for old Python
+[[tool.cibuildwheel.overrides]]
+select = "cp3{6,7}-*"
+manylinux-x86_64-image = "manylinux1"
+manylinux-i686-image = "manylinux1"
+
+# manylinux2010 for cp38-9, pp37-8
+[[tool.cibuildwheel.overrides]]
+select = "cp3{8,9}-* pp3{7,8}-*"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"
+
+# manylinux2014 for cp310, pp39
+[[tool.cibuildwheel.overrides]]
+select = "cp310-* pp39-*"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+
+# manylinux_2_28 for cp311
+[[tool.cibuildwheel.overrides]]
+select = "cp311-*"
+manylinux-x86_64-image = "manylinux_2_28"
+
+[[tool.cibuildwheel.overrides]]
+select = "pp*win*"
+# pypy builds libzmq as an Extension,
+# doesn't bundle dlls (requires separate vcredist install, as pypy itself seems to)
+# bundling external libzmq doesn't seem to work
+environment.ZMQ_PREFIX = ""
+repair-wheel-command = ""

--- a/tools/wheel-requirements.txt
+++ b/tools/wheel-requirements.txt
@@ -1,3 +1,3 @@
-cibuildwheel==2.8.1
-cython==0.29.30
+cibuildwheel==2.9.0
+cython==0.29.32
 delvewheel==0.0.22; sys_platform == 'win32'


### PR DESCRIPTION
behind CIBW_PRERELEASE_PYTHONS flag for now (wait for 3.11 rc)

Move most cibuildwheel config to pyproject.toml to reduce logic only in CI workflow files (reduces duplication)