### PR TITLE
specify default testpaths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ markers =
     large: these tests use a lot of memory
     new_console: these tests create a new console
     wheel: these tests are for installs from a wheel, not dev-installs
+testpaths =
+    zmq/tests


### PR DESCRIPTION
so invoking pytest with no args finds the right tests

closes #1714 