### PR TITLE
Safer cinit in Context

### DIFF
--- a/zmq/backend/cython/context.pyx
+++ b/zmq/backend/cython/context.pyx
@@ -29,12 +29,12 @@ cdef class Context:
         The number of IO threads.
     """
 
-    # no-op for the signature
-    def __init__(self, io_threads=1, shadow=0):
-        pass
-
-    def __cinit__(self, int io_threads=1, size_t shadow=0):
+    def __cinit__(self, *args, **kwargs):
         self.handle = NULL
+        self._pid = 0
+        self._shadow = False
+
+    def __init__(self, int io_threads=1, size_t shadow=0):
         if shadow:
             self.handle = <void *>shadow
             self._shadow = True

--- a/zmq/tests/test_ext.py
+++ b/zmq/tests/test_ext.py
@@ -1,0 +1,34 @@
+"""tests for extending pyzmq"""
+
+import zmq
+
+
+class CustomSocket(zmq.Socket):
+    custom_attr: int
+
+    def __init__(self, context, socket_type, custom_attr: int = 0):
+        super().__init__(context, socket_type)
+        self.custom_attr = custom_attr
+
+
+class CustomContext(zmq.Context):
+    extra_arg: str
+    _socket_class = CustomSocket
+
+    def __init__(self, extra_arg: str = 'x'):
+        super().__init__()
+        self.extra_arg = extra_arg
+
+
+def test_custom_context():
+    ctx = CustomContext('s')
+    assert isinstance(ctx, CustomContext)
+
+    assert ctx.extra_arg == 's'
+    s = ctx.socket(zmq.PUSH, custom_attr=10)
+    assert isinstance(s, CustomSocket)
+    assert s.custom_attr == 10
+    assert s.context is ctx
+    assert s.type == zmq.PUSH
+    s.close()
+    ctx.term()


### PR DESCRIPTION
Matches what we do in Socket for the same reason - most logic is actually in `__init__`, not `__cinit__`. This leaves subclasses to be more flexible with their signatures.

closes #1717 