### PR TITLE
Stop bundling libzmq with IPC support on Windows

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -44,12 +44,19 @@ HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)
 
 
+# msvc 142 builds have a problem:
+# on _some_ (unclear which!) systems due to the implementation of runtime detection of AF_UNIX
+# in 4.3.4
+vcversion = 141
+# until that's fixed, we shouldn't ship 142 builds,
+# which in turn means we can't support IPC in wheels
+
 if platform.architecture()[0] == '64bit':
     msarch = '-x64'
-    vcversion = 142
+    # vcversion = 142
 else:
     msarch = ''
-    vcversion = 141
+    # vcversion = 141
 
 libzmq_dll = f"libzmq-v{vcversion}{msarch}-{x}_{y}_{z}.zip"
 libzmq_dll_url = f"{download_url}/{libzmq_dll}"

--- a/tools/test_wheel.py
+++ b/tools/test_wheel.py
@@ -6,7 +6,6 @@ Just import things
 import os
 import platform
 import sys
-from unittest import SkipTest
 
 import pytest
 
@@ -18,10 +17,13 @@ def test_has(feature):
     if (
         feature == 'ipc'
         and sys.platform == 'win32'
-        and platform.architecture()[0] == '32bit'
+        and platform.python_implementation() == "CPython"
     ):
-        raise SkipTest("32b Windows doesn't have ipc")
-    assert zmq.has(feature)
+        # Windows wheels lack IPC
+        # pending release with https://github.com/zeromq/libzmq/pull/4422
+        assert not zmq.has(feature)
+    else:
+        assert zmq.has(feature)
 
 
 def test_simple_socket():


### PR DESCRIPTION
due to bugs in libzmq's detection of AF_UNIX that cause crashes that can't be worked around (https://github.com/zeromq/libzmq/pull/4422)

I don't love this since it's removing a feature from wheels. Building pyzmq from source should still get the same result for folks who want IPC. The alternative was to require users experiencing a crash to build from source, which I think is worse than missing a little-used feature with a buggy implementation that crashes users who don't even try to use the feature.

Need to wait for at least 4.3.5 before re-enabling 142 builds with IPC support

Should fix #1505