### PR TITLE
unskip cp38 for mac wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,7 +98,6 @@ jobs:
             cibw:
               arch: universal2
               build: "cp*"
-              skip: "cp38*"
 
           - os: ubuntu-20.04
             name: manylinux-x86_64


### PR DESCRIPTION
cp38 was broken when we started, but doesn't seem to be anymore, and System Python (which nobody should ever use) is still 3.8 on macOS 12.