### PR TITLE
Call ctx.destroy() in Context.__exit__

### DIFF
--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -70,9 +70,11 @@ class TestContext(BaseZMQTestCase):
         assert c.closed
 
     def test_context_manager(self):
-        with self.Context() as c:
-            pass
-        assert c.closed
+        with self.Context() as ctx:
+            s = ctx.socket(zmq.PUSH)
+        # context exit destroys sockets
+        assert s.closed
+        assert ctx.closed
 
     def test_fail_init(self):
         self.assertRaisesErrno(zmq.EINVAL, self.Context, -1)


### PR DESCRIPTION
ensures cleanup on exit of context instead of hang in `ctx.term()`, which will wait until sockets are closed, which is not likely to happen if it hasn't happened already.

more likely the expected behavior (especially on error), but technically not safe for sockets launched into other threads (this isn't a very sensible use of `with context`, so I'm okay with that).

ResourceWarning  is shown if any sockets are to be closed this way, since it should always mean a bug in user code.

closes #1757 