### PR TITLE
Use weakref.finalize to fix issue with warnings.warn being None during shutdown.

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -8,6 +8,7 @@ import errno
 import pickle
 import random
 import sys
+import weakref
 from typing import (
     Any,
     Callable,
@@ -33,7 +34,6 @@ from zmq.utils import jsonapi
 from ..constants import SocketOption, SocketType, _OptType
 from .attrsettr import AttributeSetter
 from .poll import Poller
-import weakref
 
 try:
     DEFAULT_PROTOCOL = pickle.DEFAULT_PROTOCOL

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -33,6 +33,7 @@ from zmq.utils import jsonapi
 from ..constants import SocketOption, SocketType, _OptType
 from .attrsettr import AttributeSetter
 from .poll import Poller
+import weakref
 
 try:
     DEFAULT_PROTOCOL = pickle.DEFAULT_PROTOCOL
@@ -107,8 +108,9 @@ class Socket(SocketBase, AttributeSetter, Generic[ST]):
                 self._type_name = str(socket_type)
             else:
                 self._type_name = stype.name
+        weakref.finalize(self, lambda x: x._exp_del(), self)
 
-    def __del__(self):
+    def _exp_del(self):
         if not self._shadow and not self.closed:
             warn(
                 f"unclosed socket {self}",


### PR DESCRIPTION
I ran into an issue where the warnings.warn was None so the call will generate an exception (which is then ignored since it is in a __del__).  I think this is based on some other package we were using that made that change during shutdown.  This change to use finalize instead lets the finalizer run earlier before the change to warn.