### PR TITLE
Improvements to finalization

### DIFF
--- a/zmq/backend/cffi/context.py
+++ b/zmq/backend/cffi/context.py
@@ -13,7 +13,7 @@ from ._cffi import lib as C
 class Context:
     _zmq_ctx = None
     _iothreads = None
-    _closed = None
+    _closed = True
     _shadow = False
 
     def __init__(self, io_threads=1, shadow=None):

--- a/zmq/backend/cffi/socket.py
+++ b/zmq/backend/cffi/socket.py
@@ -122,6 +122,8 @@ class Socket:
             if e.errno == zmq.ENOTSOCK:
                 self._closed = True
                 return True
+            elif e.errno == zmq.ETERM:
+                pass
             else:
                 raise
         return False

--- a/zmq/devices/proxydevice.py
+++ b/zmq/devices/proxydevice.py
@@ -57,6 +57,7 @@ class ProxyBase:
         ins, outs = Device._setup_sockets(self)
         ctx = self._context
         mons = ctx.socket(self.mon_type)
+        self._sockets.append(mons)
 
         # set sockopts (must be done first, in case of zmq.IDENTITY)
         for opt, value in self._mon_sockopts:

--- a/zmq/devices/proxysteerabledevice.py
+++ b/zmq/devices/proxysteerabledevice.py
@@ -54,6 +54,7 @@ class ProxySteerableBase:
         ins, outs, mons = super()._setup_sockets()
         ctx = self._context
         ctrls = ctx.socket(self.ctrl_type)
+        self._sockets.append(ctrls)
 
         for opt, value in self._ctrl_sockopts:
             ctrls.setsockopt(opt, value)

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -8,6 +8,7 @@ import errno
 import pickle
 import random
 import sys
+import weakref
 from typing import (
     Any,
     Callable,
@@ -33,7 +34,6 @@ from zmq.utils import jsonapi
 from ..constants import SocketOption, SocketType, _OptType
 from .attrsettr import AttributeSetter
 from .poll import Poller
-import weakref
 
 try:
     DEFAULT_PROTOCOL = pickle.DEFAULT_PROTOCOL

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -33,6 +33,7 @@ from zmq.utils import jsonapi
 from ..constants import SocketOption, SocketType, _OptType
 from .attrsettr import AttributeSetter
 from .poll import Poller
+import weakref
 
 try:
     DEFAULT_PROTOCOL = pickle.DEFAULT_PROTOCOL
@@ -107,8 +108,9 @@ class Socket(SocketBase, AttributeSetter, Generic[ST]):
                 self._type_name = str(socket_type)
             else:
                 self._type_name = stype.name
+        weakref.finalize(self, lambda x: x._exp_del(), self)
 
-    def __del__(self):
+    def _exp_del(self):
         if not self._shadow and not self.closed:
             warn(
                 f"unclosed socket {self}",

--- a/zmq/tests/test_monqueue.py
+++ b/zmq/tests/test_monqueue.py
@@ -1,6 +1,7 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
+import threading
 import time
 
 import zmq
@@ -42,10 +43,14 @@ class TestMonitoredQueue(BaseZMQTestCase):
         return alice, bob, mon
 
     def teardown_device(self):
+        # spawn term in a background thread
+        t = threading.Thread(target=self.device._context.term, daemon=True)
+        t.start()
         for socket in self.sockets:
             socket.close()
             del socket
-        del self.device
+        t.join(timeout=5)
+        self.device.join(timeout=5)
 
     def test_reply(self):
         alice, bob, mon = self.build_device()


### PR DESCRIPTION
includes #1769 though switches back to `__del__` and handles globals being None instead.

Further closes device sockets explicitly, and catches both ENOTSOCK and ETERM when checking if a socket is closed.