### PR TITLE
reduce lots of deprecation/resource warnings in tests

### DIFF
--- a/zmq/eventloop/zmqstream.py
+++ b/zmq/eventloop/zmqstream.py
@@ -24,7 +24,6 @@ using tornado.
 """
 
 import pickle
-import sys
 import warnings
 from queue import Queue
 from typing import Any, Callable, List, Optional, Sequence, Union, cast, overload
@@ -34,21 +33,22 @@ from zmq import POLLIN, POLLOUT
 from zmq._typing import Literal
 from zmq.utils import jsonapi
 
-from .ioloop import IOLoop, gen_log
+from .ioloop import gen_log
 
 try:
     import tornado.ioloop
+    from tornado.ioloop import IOLoop  # type: ignore
+except ImportError as e:
+    # fallback on deprecated bundled IOLoop
+    from .ioloop import IOLoop
+
+try:
     from tornado.stack_context import wrap as stack_context_wrap  # type: ignore
-except ImportError:
-    if "zmq.eventloop.minitornado" in sys.modules:
-        from .minitornado.stack_context import (
-            wrap as stack_context_wrap,  # type: ignore
-        )
-    else:
-        # tornado 5 deprecates stack_context,
-        # tornado 6 removes it
-        def stack_context_wrap(callback):
-            return callback
+except ImportError as e:
+    # tornado 5 deprecates stack_context,
+    # tornado 6 removes it
+    def stack_context_wrap(callback):
+        return callback
 
 
 class ZMQStream:

--- a/zmq/sugar/context.py
+++ b/zmq/sugar/context.py
@@ -84,7 +84,7 @@ class Context(ContextBase, AttributeSetter, Generic[ST]):
 
         if not self._shadow and not _exiting and not self.closed:
             self._warn_destroy_close = True
-            if warn:
+            if warn and getattr(self, "_sockets", None) is not None:
                 # warn can be None during process teardown
                 warn(
                     f"Unclosed context {self}",

--- a/zmq/tests/test_context.py
+++ b/zmq/tests/test_context.py
@@ -10,6 +10,7 @@ from queue import Queue
 from threading import Event, Thread
 from unittest import mock
 
+import pytest
 from pytest import mark
 
 import zmq
@@ -32,13 +33,13 @@ class TestContext(BaseZMQTestCase):
     def test_init(self):
         c1 = self.Context()
         assert isinstance(c1, self.Context)
-        del c1
+        c1.term()
         c2 = self.Context()
         assert isinstance(c2, self.Context)
-        del c2
+        c2.term()
         c3 = self.Context()
         assert isinstance(c3, self.Context)
-        del c3
+        c3.term()
 
     _repr_cls = "zmq.Context"
 
@@ -70,8 +71,9 @@ class TestContext(BaseZMQTestCase):
         assert c.closed
 
     def test_context_manager(self):
-        with self.Context() as ctx:
-            s = ctx.socket(zmq.PUSH)
+        with pytest.warns(ResourceWarning):
+            with self.Context() as ctx:
+                s = ctx.socket(zmq.PUSH)
         # context exit destroys sockets
         assert s.closed
         assert ctx.closed
@@ -241,6 +243,7 @@ class TestContext(BaseZMQTestCase):
                 ctx = self.Context()
                 ctx.socket(zmq.PUSH)
 
+            # can't seem to catch these with pytest.warns(ResourceWarning)
             inner()
             gc.collect()
 

--- a/zmq/tests/test_future.py
+++ b/zmq/tests/test_future.py
@@ -21,16 +21,13 @@ class TestFutureSocket(BaseZMQTestCase):
     Context = future.Context
 
     def setUp(self):
-        self.loop = IOLoop()
-        self.loop.make_current()
+        self.loop = IOLoop(make_current=False)
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
         if self.loop:
             self.loop.close(all_fds=True)
-        IOLoop.clear_current()
-        IOLoop.clear_instance()
 
     def test_socket_class(self):
         s = self.context.socket(zmq.PUSH)
@@ -312,7 +309,11 @@ class TestFutureSocket(BaseZMQTestCase):
 
     def test_close_all_fds(self):
         s = self.socket(zmq.PUB)
-        s._get_loop()
+
+        async def attach():
+            s._get_loop()
+
+        self.loop.run_sync(attach)
         self.loop.close(all_fds=True)
         self.loop = None  # avoid second close later
         assert s.closed

--- a/zmq/tests/test_monqueue.py
+++ b/zmq/tests/test_monqueue.py
@@ -44,12 +44,23 @@ class TestMonitoredQueue(BaseZMQTestCase):
 
     def teardown_device(self):
         # spawn term in a background thread
-        t = threading.Thread(target=self.device._context.term, daemon=True)
-        t.start()
+        for i in range(50):
+            # wait for device._context to be populated
+            context = getattr(self.device, "_context", None)
+            if context is not None:
+                break
+            time.sleep(0.1)
+
+        if context is not None:
+            t = threading.Thread(target=self.device._context.term, daemon=True)
+            t.start()
+
         for socket in self.sockets:
             socket.close()
-            del socket
-        t.join(timeout=5)
+
+        if context is not None:
+            t.join(timeout=5)
+
         self.device.join(timeout=5)
 
     def test_reply(self):

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -35,7 +35,7 @@ class TestSocket(BaseZMQTestCase):
         self.assertRaisesErrno(zmq.EPROTONOSUPPORT, s.connect, 'ftl://a')
         self.assertRaisesErrno(zmq.EINVAL, s.bind, 'tcp://')
         s.close()
-        del ctx
+        ctx.term()
 
     def test_context_manager(self):
         url = 'inproc://a'
@@ -126,17 +126,20 @@ class TestSocket(BaseZMQTestCase):
     def test_bind_to_random_port(self):
         # Check that bind_to_random_port do not hide useful exception
         ctx = self.Context()
-        c = ctx.socket(zmq.PUB)
+        s = ctx.socket(zmq.PUB)
         # Invalid format
         try:
-            c.bind_to_random_port('tcp:*')
+            s.bind_to_random_port('tcp:*')
         except zmq.ZMQError as e:
             assert e.errno == zmq.EINVAL
         # Invalid protocol
         try:
-            c.bind_to_random_port('rand://*')
+            s.bind_to_random_port('rand://*')
         except zmq.ZMQError as e:
             assert e.errno == zmq.EPROTONOSUPPORT
+
+        s.close()
+        ctx.term()
 
     def test_identity(self):
         s = self.context.socket(zmq.PULL)
@@ -371,7 +374,7 @@ class TestSocket(BaseZMQTestCase):
         self.assertRaisesErrno(zmq.ENOTSOCK, s.setsockopt, zmq.SUBSCRIBE, b'')
         self.assertRaisesErrno(zmq.ENOTSOCK, s.send, b'asdf')
         self.assertRaisesErrno(zmq.ENOTSOCK, s.recv)
-        del ctx
+        ctx.term()
 
     def test_attr(self):
         """set setting/getting sockopts as attributes"""

--- a/zmq/tests/test_zmqstream.py
+++ b/zmq/tests/test_zmqstream.py
@@ -3,6 +3,7 @@
 
 
 import asyncio
+from functools import partial
 from unittest import TestCase
 
 import pytest
@@ -11,7 +12,7 @@ import zmq
 
 try:
     import tornado
-    from tornado import ioloop
+    from tornado import gen, ioloop
 
     from zmq.eventloop import zmqstream
 except ImportError:
@@ -24,6 +25,8 @@ class TestZMQStream(TestCase):
             pytest.skip()
         self.context = zmq.Context()
         self.loop = ioloop.IOLoop(make_current=False)
+        if tornado and tornado.version_info < (5,):
+            self.loop.make_current()
 
         async def _make_sockets():
             self.push = zmqstream.ZMQStream(self.context.socket(zmq.PUSH))
@@ -38,7 +41,11 @@ class TestZMQStream(TestCase):
     def tearDown(self):
         if self._timeout_task:
             self._timeout_task.cancel()
-            self.loop.run_sync(lambda: asyncio.wait_for(self._timeout_task, timeout=10))
+
+            async def wait():
+                await gen.with_timeout(self.loop.time() + 1, self._timeout_task)
+
+            self.loop.run_sync(wait)
         self.loop.close(all_fds=True)
         self.context.term()
 
@@ -47,14 +54,17 @@ class TestZMQStream(TestCase):
 
         async def sleep_timeout():
             try:
-                await asyncio.sleep(timeout)
+                await gen.sleep(timeout)
             except asyncio.CancelledError:
                 return
             timed_out[:] = ['timed out']
             self.loop.stop()
 
         def make_timeout_task():
-            self._timeout_task = asyncio.ensure_future(sleep_timeout())
+            if tornado.version_info < (5,):
+                self.loop.add_callback(sleep_timeout)
+            else:
+                self._timeout_task = asyncio.ensure_future(sleep_timeout())
 
         self.loop.run_sync(make_timeout_task)
         self.loop.start()
@@ -76,8 +86,9 @@ class TestZMQStream(TestCase):
             assert msg == sent
             self.loop.stop()
 
-        self.loop.add_callback(lambda: self.push.send_multipart(sent))
-        self.loop.add_callback(lambda: self.pull.on_recv(callback))
+        self.loop.run_sync(partial(self.push.send_multipart, sent))
+        self.loop.call_later(1, lambda: self.pull.on_recv(callback))
+        self.pull.on_recv(callback)
         self.run_until_timeout()
 
     def test_on_recv_wake(self):

--- a/zmq/tests/test_zmqstream.py
+++ b/zmq/tests/test_zmqstream.py
@@ -11,9 +11,9 @@ import zmq
 
 try:
     import tornado
-    from tornado import gen
+    from tornado import ioloop
 
-    from zmq.eventloop import ioloop, zmqstream
+    from zmq.eventloop import zmqstream
 except ImportError:
     tornado = None  # type: ignore
 
@@ -22,32 +22,41 @@ class TestZMQStream(TestCase):
     def setUp(self):
         if tornado is None:
             pytest.skip()
-        if asyncio:
-            asyncio.set_event_loop(asyncio.new_event_loop())
         self.context = zmq.Context()
-        self.loop = ioloop.IOLoop()
-        self.loop.make_current()
-        self.push = zmqstream.ZMQStream(self.context.socket(zmq.PUSH))
-        self.pull = zmqstream.ZMQStream(self.context.socket(zmq.PULL))
+        self.loop = ioloop.IOLoop(make_current=False)
+
+        async def _make_sockets():
+            self.push = zmqstream.ZMQStream(self.context.socket(zmq.PUSH))
+            self.pull = zmqstream.ZMQStream(self.context.socket(zmq.PULL))
+
+        self.loop.run_sync(_make_sockets)
         port = self.push.bind_to_random_port('tcp://127.0.0.1')
         self.pull.connect('tcp://127.0.0.1:%i' % port)
         self.stream = self.push
+        self._timeout_task = None
 
     def tearDown(self):
+        if self._timeout_task:
+            self._timeout_task.cancel()
+            self.loop.run_sync(lambda: asyncio.wait_for(self._timeout_task, timeout=10))
         self.loop.close(all_fds=True)
         self.context.term()
-        ioloop.IOLoop.clear_current()
 
     def run_until_timeout(self, timeout=10):
         timed_out = []
 
-        @gen.coroutine
-        def sleep_timeout():
-            yield gen.sleep(timeout)
+        async def sleep_timeout():
+            try:
+                await asyncio.sleep(timeout)
+            except asyncio.CancelledError:
+                return
             timed_out[:] = ['timed out']
             self.loop.stop()
 
-        self.loop.add_callback(lambda: sleep_timeout())
+        def make_timeout_task():
+            self._timeout_task = asyncio.ensure_future(sleep_timeout())
+
+        self.loop.run_sync(make_timeout_task)
         self.loop.start()
         assert not timed_out
 
@@ -68,7 +77,7 @@ class TestZMQStream(TestCase):
             self.loop.stop()
 
         self.loop.add_callback(lambda: self.push.send_multipart(sent))
-        self.pull.on_recv(callback)
+        self.loop.add_callback(lambda: self.pull.on_recv(callback))
         self.run_until_timeout()
 
     def test_on_recv_wake(self):


### PR DESCRIPTION
Tests aren't doing anything wrong, but they are exercising deprecated functionality (as they should).