### PR TITLE
migrate some tests to native async, pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ markers =
     wheel: these tests are for installs from a wheel, not dev-installs
 testpaths =
     zmq/tests
+
+# automatically run coroutine tests with asyncio
+asyncio_mode = auto

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,10 @@ flake8
 gevent; platform_python_implementation != "PyPy" and sys_platform != "win32" and sys_platform != "darwin" and python_version < "3.11"
 mypy; platform_python_implementation != "PyPy"
 pytest
+pytest-asyncio>=0.16; python_version < "3.7"
+pytest-asyncio>=0.17; python_version >= "3.7"
 # pytest-cov 2.11 requires coverage 5, which still doesn't work with Cython
 pytest-cov==2.10.*
+
 pytest-rerunfailures
 tornado

--- a/zmq/_future.py
+++ b/zmq/_future.py
@@ -633,6 +633,9 @@ class _AsyncSocket(_Async, _zmq.Socket[Future]):
     # event masking from ZMQStream
     def _handle_events(self, fd=0, events=0):
         """Dispatch IO events to _handle_recv, etc."""
+        if self._shadow_sock.closed:
+            return
+
         zmq_events = self._shadow_sock.get(EVENTS)
         if zmq_events & _zmq.POLLIN:
             self._handle_recv()

--- a/zmq/tests/__init__.py
+++ b/zmq/tests/__init__.py
@@ -6,6 +6,7 @@ import platform
 import signal
 import sys
 import time
+import warnings
 from functools import partial
 from threading import Thread
 from typing import List
@@ -91,6 +92,12 @@ class BaseZMQTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
+        if not self._is_pyzmq_test:
+            warnings.warn(
+                "zmq.tests.BaseZMQTestCase is deprecated in pyzmq 25, we recommend managing your own contexts and sockets.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
         if self.green and not have_gevent:
             raise SkipTest("requires gevent")
 

--- a/zmq/tests/conftest.py
+++ b/zmq/tests/conftest.py
@@ -1,1 +1,215 @@
 """pytest configuration and fixtures"""
+
+import asyncio
+import inspect
+import os
+import signal
+import time
+from functools import partial
+from threading import Thread
+
+try:
+    import tornado
+    from tornado import version_info
+except ImportError:
+    tornado = None
+else:
+    if version_info < (5,):
+        tornado = None
+    from tornado.ioloop import IOLoop
+
+import pytest
+
+import zmq
+import zmq.asyncio
+
+test_timeout_seconds = os.environ.get("ZMQ_TEST_TIMEOUT")
+teardown_timeout = 10
+
+
+def pytest_collection_modifyitems(items):
+    """This function is automatically run by pytest passing all collected test
+    functions.
+    We use it to add asyncio marker to all async tests and assert we don't use
+    test functions that are async generators which wouldn't make sense.
+    It is no longer required with pytest-asyncio >= 0.17
+    """
+    for item in items:
+        if inspect.iscoroutinefunction(item.obj):
+            item.add_marker('asyncio')
+        assert not inspect.isasyncgenfunction(item.obj)
+
+
+@pytest.fixture
+async def io_loop(event_loop, request):
+    """Create tornado io_loop on current asyncio event loop"""
+    if tornado is None:
+        pytest.skip()
+    io_loop = IOLoop.current()
+    assert asyncio.get_event_loop() is event_loop
+    assert io_loop.asyncio_loop is event_loop
+
+    def _close():
+        io_loop.close(all_fds=True)
+
+    request.addfinalizer(_close)
+    return io_loop
+
+
+def term_context(ctx, timeout):
+    """Terminate a context with a timeout"""
+    t = Thread(target=ctx.term)
+    t.daemon = True
+    t.start()
+    t.join(timeout=timeout)
+    if t.is_alive():
+        # reset Context.instance, so the failure to term doesn't corrupt subsequent tests
+        zmq.sugar.context.Context._instance = None
+        raise RuntimeError(
+            f"context {ctx} could not terminate, open sockets likely remain in test"
+        )
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+    # make sure selectors are cleared
+    assert dict(zmq.asyncio._selectors) == {}
+
+
+@pytest.fixture
+def sigalrm_timeout():
+    """Set timeout using SIGALRM
+
+    Avoids infinite hang in context.term for an unclean context,
+    raising an error instead.
+    """
+    if not hasattr(signal, "SIGALRM") or not test_timeout_seconds:
+        return
+
+    def _alarm_timeout(*args):
+        raise TimeoutError(f"Test did not complete in {test_timeout_seconds} seconds")
+
+    signal.signal(signal.SIGALRM, _alarm_timeout)
+    signal.alarm(test_timeout_seconds)
+
+
+@pytest.fixture
+def Context():
+    """Context class fixture
+
+    Override in modules to specify a different class (e.g. zmq.green)
+    """
+    return zmq.Context
+
+
+@pytest.fixture
+def contexts(sigalrm_timeout):
+    """Fixture to track contexts used in tests
+
+    For cleanup purposes
+    """
+    contexts = set()
+    yield contexts
+    for ctx in contexts:
+        try:
+            term_context(ctx, teardown_timeout)
+        except Exception:
+            # reset Context.instance, so the failure to term doesn't corrupt subsequent tests
+            zmq.sugar.context.Context._instance = None
+            raise
+
+
+@pytest.fixture
+def context(Context, contexts):
+    """Fixture for shared context"""
+    ctx = Context()
+    contexts.add(ctx)
+    return ctx
+
+
+@pytest.fixture
+def sockets(contexts):
+    sockets = []
+    yield sockets
+    # ensure any tracked sockets get their contexts cleaned up
+    for socket in sockets:
+        contexts.add(socket.context)
+
+    # close sockets
+    for socket in sockets:
+        socket.close(linger=0)
+
+
+@pytest.fixture
+def socket(context, sockets):
+    """Fixture to create sockets, while tracking them for cleanup"""
+
+    def new_socket(*args, **kwargs):
+        s = context.socket(*args, **kwargs)
+        sockets.append(s)
+        return s
+
+    return new_socket
+
+
+def assert_raises_errno(errno):
+    try:
+        yield
+    except zmq.ZMQError as e:
+        assert (
+            e.errno == errno
+        ), f"wrong error raised, expected {zmq.ZMQError(errno)} got {zmq.ZMQError(e.errno)}"
+    else:
+        pytest.fail(f"Expected {zmq.ZMQError(errno)}, no error raised")
+
+
+def recv(socket, *, timeout=5, flags=0, multipart=False, **kwargs):
+    """call recv[_multipart] in a way that raises if there is nothing to receive"""
+    if zmq.zmq_version_info() >= (3, 1, 0):
+        # zmq 3.1 has a bug, where poll can return false positives,
+        # so we wait a little bit just in case
+        # See LIBZMQ-280 on JIRA
+        time.sleep(0.1)
+
+    r, w, x = zmq.select([socket], [], [], timeout=timeout)
+    assert r, "Should have received a message"
+    kwargs['flags'] = zmq.DONTWAIT | kwargs.get('flags', 0)
+
+    recv = socket.recv_multipart if multipart else socket.recv
+    return recv(flags=flags, **kwargs)
+
+
+recv_multipart = partial(recv, multipart=True)
+
+
+@pytest.fixture
+def create_bound_pair(socket):
+    def create_bound_pair(type1=zmq.PAIR, type2=zmq.PAIR, interface='tcp://127.0.0.1'):
+        """Create a bound socket pair using a random port."""
+        s1 = socket(type1)
+        s1.linger = 0
+        port = s1.bind_to_random_port(interface)
+        s2 = socket(type2)
+        s2.linger = 0
+        s2.connect(f'{interface}:{port}')
+        return s1, s2
+
+    return create_bound_pair
+
+
+@pytest.fixture
+def bound_pair(create_bound_pair):
+    return create_bound_pair()
+
+
+@pytest.fixture
+def push_pull(create_bound_pair):
+    return create_bound_pair(zmq.PUSH, zmq.PULL)
+
+
+@pytest.fixture
+def dealer_router(create_bound_pair):
+    return create_bound_pair(zmq.DEALER, zmq.ROUTER)

--- a/zmq/tests/test_asyncio.py
+++ b/zmq/tests/test_asyncio.py
@@ -14,9 +14,332 @@ from pytest import mark
 
 import zmq
 import zmq.asyncio as zaio
-from zmq.auth.asyncio import AsyncioAuthenticator
-from zmq.tests import BaseZMQTestCase
-from zmq.tests.test_auth import TestThreadAuthentication
+
+
+@pytest.fixture
+def Context(event_loop):
+    return zaio.Context
+
+
+def test_socket_class(context):
+    with context.socket(zmq.PUSH) as s:
+        assert isinstance(s, zaio.Socket)
+
+
+def test_instance_subclass_first(context):
+    actx = zmq.asyncio.Context.instance()
+    ctx = zmq.Context.instance()
+    ctx.term()
+    actx.term()
+    assert type(ctx) is zmq.Context
+    assert type(actx) is zmq.asyncio.Context
+
+
+def test_instance_subclass_second(context):
+    with zmq.Context.instance() as ctx:
+        assert type(ctx) is zmq.Context
+        with zmq.asyncio.Context.instance() as actx:
+            assert type(actx) is zmq.asyncio.Context
+
+
+async def test_recv_multipart(context, create_bound_pair):
+    a, b = create_bound_pair(zmq.PUSH, zmq.PULL)
+    f = b.recv_multipart()
+    assert not f.done()
+    await a.send(b"hi")
+    recvd = await f
+    assert recvd == [b"hi"]
+
+
+async def test_recv(create_bound_pair):
+    a, b = create_bound_pair(zmq.PUSH, zmq.PULL)
+    f1 = b.recv()
+    f2 = b.recv()
+    assert not f1.done()
+    assert not f2.done()
+    await a.send_multipart([b"hi", b"there"])
+    recvd = await f2
+    assert f1.done()
+    assert f1.result() == b"hi"
+    assert recvd == b"there"
+
+
+@mark.skipif(not hasattr(zmq, "RCVTIMEO"), reason="requires RCVTIMEO")
+async def test_recv_timeout(push_pull):
+    a, b = push_pull
+    b.rcvtimeo = 100
+    f1 = b.recv()
+    b.rcvtimeo = 1000
+    f2 = b.recv_multipart()
+    with pytest.raises(zmq.Again):
+        await f1
+    await a.send_multipart([b"hi", b"there"])
+    recvd = await f2
+    assert f2.done()
+    assert recvd == [b"hi", b"there"]
+
+
+@mark.skipif(not hasattr(zmq, "SNDTIMEO"), reason="requires SNDTIMEO")
+async def test_send_timeout(socket):
+    s = socket(zmq.PUSH)
+    s.sndtimeo = 100
+    with pytest.raises(zmq.Again):
+        await s.send(b"not going anywhere")
+
+
+async def test_recv_string(push_pull):
+    a, b = push_pull
+    f = b.recv_string()
+    assert not f.done()
+    msg = "πøøπ"
+    await a.send_string(msg)
+    recvd = await f
+    assert f.done()
+    assert f.result() == msg
+    assert recvd == msg
+
+
+async def test_recv_json(push_pull):
+    a, b = push_pull
+    f = b.recv_json()
+    assert not f.done()
+    obj = dict(a=5)
+    await a.send_json(obj)
+    recvd = await f
+    assert f.done()
+    assert f.result() == obj
+    assert recvd == obj
+
+
+async def test_recv_json_cancelled(push_pull):
+    a, b = push_pull
+    f = b.recv_json()
+    assert not f.done()
+    f.cancel()
+    # cycle eventloop to allow cancel events to fire
+    await asyncio.sleep(0)
+    obj = dict(a=5)
+    await a.send_json(obj)
+    # CancelledError change in 3.8 https://bugs.python.org/issue32528
+    if sys.version_info < (3, 8):
+        with pytest.raises(CancelledError):
+            recvd = await f
+    else:
+        with pytest.raises(asyncio.exceptions.CancelledError):
+            recvd = await f
+    assert f.done()
+    # give it a chance to incorrectly consume the event
+    events = await b.poll(timeout=5)
+    assert events
+    await asyncio.sleep(0)
+    # make sure cancelled recv didn't eat up event
+    f = b.recv_json()
+    recvd = await asyncio.wait_for(f, timeout=5)
+    assert recvd == obj
+
+
+async def test_recv_pyobj(push_pull):
+    a, b = push_pull
+    f = b.recv_pyobj()
+    assert not f.done()
+    obj = dict(a=5)
+    await a.send_pyobj(obj)
+    recvd = await f
+    assert f.done()
+    assert f.result() == obj
+    assert recvd == obj
+
+
+async def test_custom_serialize(create_bound_pair):
+    def serialize(msg):
+        frames = []
+        frames.extend(msg.get("identities", []))
+        content = json.dumps(msg["content"]).encode("utf8")
+        frames.append(content)
+        return frames
+
+    def deserialize(frames):
+        identities = frames[:-1]
+        content = json.loads(frames[-1].decode("utf8"))
+        return {
+            "identities": identities,
+            "content": content,
+        }
+
+    a, b = create_bound_pair(zmq.DEALER, zmq.ROUTER)
+
+    msg = {
+        "content": {
+            "a": 5,
+            "b": "bee",
+        }
+    }
+    await a.send_serialized(msg, serialize)
+    recvd = await b.recv_serialized(deserialize)
+    assert recvd["content"] == msg["content"]
+    assert recvd["identities"]
+    # bounce back, tests identities
+    await b.send_serialized(recvd, serialize)
+    r2 = await a.recv_serialized(deserialize)
+    assert r2["content"] == msg["content"]
+    assert not r2["identities"]
+
+
+async def test_custom_serialize_error(dealer_router):
+    a, b = dealer_router
+
+    msg = {
+        "content": {
+            "a": 5,
+            "b": "bee",
+        }
+    }
+    with pytest.raises(TypeError):
+        await a.send_serialized(json, json.dumps)
+
+    await a.send(b"not json")
+    with pytest.raises(TypeError):
+        await b.recv_serialized(json.loads)
+
+
+async def test_recv_dontwait(push_pull):
+    push, pull = push_pull
+    f = pull.recv(zmq.DONTWAIT)
+    with pytest.raises(zmq.Again):
+        await f
+    await push.send(b"ping")
+    await pull.poll()  # ensure message will be waiting
+    f = pull.recv(zmq.DONTWAIT)
+    assert f.done()
+    msg = await f
+    assert msg == b"ping"
+
+
+async def test_recv_cancel(push_pull):
+    a, b = push_pull
+    f1 = b.recv()
+    f2 = b.recv_multipart()
+    assert f1.cancel()
+    assert f1.done()
+    assert not f2.done()
+    await a.send_multipart([b"hi", b"there"])
+    recvd = await f2
+    assert f1.cancelled()
+    assert f2.done()
+    assert recvd == [b"hi", b"there"]
+
+
+async def test_poll(push_pull):
+    a, b = push_pull
+    f = b.poll(timeout=0)
+    await asyncio.sleep(0)
+    assert f.result() == 0
+
+    f = b.poll(timeout=1)
+    assert not f.done()
+    evt = await f
+
+    assert evt == 0
+
+    f = b.poll(timeout=1000)
+    assert not f.done()
+    await a.send_multipart([b"hi", b"there"])
+    evt = await f
+    assert evt == zmq.POLLIN
+    recvd = await b.recv_multipart()
+    assert recvd == [b"hi", b"there"]
+
+
+async def test_poll_base_socket(sockets):
+    ctx = zmq.Context()
+    url = "inproc://test"
+    a = ctx.socket(zmq.PUSH)
+    b = ctx.socket(zmq.PULL)
+    sockets.extend([a, b])
+    a.bind(url)
+    b.connect(url)
+
+    poller = zaio.Poller()
+    poller.register(b, zmq.POLLIN)
+
+    f = poller.poll(timeout=1000)
+    assert not f.done()
+    a.send_multipart([b"hi", b"there"])
+    evt = await f
+    assert evt == [(b, zmq.POLLIN)]
+    recvd = b.recv_multipart()
+    assert recvd == [b"hi", b"there"]
+
+
+async def test_poll_on_closed_socket(push_pull):
+    a, b = push_pull
+
+    f = b.poll(timeout=1)
+    b.close()
+
+    # The test might stall if we try to await f directly so instead just make a few
+    # passes through the event loop to schedule and execute all callbacks
+    for _ in range(5):
+        await asyncio.sleep(0)
+        if f.cancelled():
+            break
+    assert f.cancelled()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Windows does not support polling on files",
+)
+async def test_poll_raw():
+    p = zaio.Poller()
+    # make a pipe
+    r, w = os.pipe()
+    r = os.fdopen(r, "rb")
+    w = os.fdopen(w, "wb")
+
+    # POLLOUT
+    p.register(r, zmq.POLLIN)
+    p.register(w, zmq.POLLOUT)
+    evts = await p.poll(timeout=1)
+    evts = dict(evts)
+    assert r.fileno() not in evts
+    assert w.fileno() in evts
+    assert evts[w.fileno()] == zmq.POLLOUT
+
+    # POLLIN
+    p.unregister(w)
+    w.write(b"x")
+    w.flush()
+    evts = await p.poll(timeout=1000)
+    evts = dict(evts)
+    assert r.fileno() in evts
+    assert evts[r.fileno()] == zmq.POLLIN
+    assert r.read(1) == b"x"
+    r.close()
+    w.close()
+
+
+def test_multiple_loops(push_pull):
+    a, b = push_pull
+
+    async def test():
+        await a.send(b'buf')
+        msg = await b.recv()
+        assert msg == b'buf'
+
+    for i in range(3):
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(asyncio.wait_for(test(), timeout=10))
+        loop.close()
+
+
+def test_shadow():
+    with zmq.Context() as ctx:
+        s = ctx.socket(zmq.PULL)
+        async_s = zaio.Socket(s)
+        assert isinstance(async_s, zaio.Socket)
+        assert async_s.underlying == s.underlying
+        assert async_s.type == s.type
 
 
 class ProcessForTeardownTest(Process):
@@ -42,460 +365,10 @@ class ProcessForTeardownTest(Process):
             loop.close()
 
 
-class TestAsyncIOSocket(BaseZMQTestCase):
-    Context = zaio.Context
-
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-        self.loop.close()
-        # verify cleanup of references to selectors
-        assert zaio._selectors == {}
-        if 'zmq._asyncio_selector' in sys.modules:
-            assert zmq._asyncio_selector._selector_loops == set()
-
-    def test_socket_class(self):
-        s = self.context.socket(zmq.PUSH)
-        assert isinstance(s, zaio.Socket)
-        s.close()
-
-    def test_instance_subclass_first(self):
-        actx = zmq.asyncio.Context.instance()
-        ctx = zmq.Context.instance()
-        ctx.term()
-        actx.term()
-        assert type(ctx) is zmq.Context
-        assert type(actx) is zmq.asyncio.Context
-
-    def test_instance_subclass_second(self):
-        ctx = zmq.Context.instance()
-        actx = zmq.asyncio.Context.instance()
-        ctx.term()
-        actx.term()
-        assert type(ctx) is zmq.Context
-        assert type(actx) is zmq.asyncio.Context
-
-    def test_recv_multipart(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = b.recv_multipart()
-            assert not f.done()
-            await a.send(b"hi")
-            recvd = await f
-            assert recvd == [b"hi"]
-
-        self.loop.run_until_complete(test())
-
-    def test_recv(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f1 = b.recv()
-            f2 = b.recv()
-            assert not f1.done()
-            assert not f2.done()
-            await a.send_multipart([b"hi", b"there"])
-            recvd = await f2
-            assert f1.done()
-            assert f1.result() == b"hi"
-            assert recvd == b"there"
-
-        self.loop.run_until_complete(test())
-
-    @mark.skipif(not hasattr(zmq, "RCVTIMEO"), reason="requires RCVTIMEO")
-    def test_recv_timeout(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            b.rcvtimeo = 100
-            f1 = b.recv()
-            b.rcvtimeo = 1000
-            f2 = b.recv_multipart()
-            with self.assertRaises(zmq.Again):
-                await f1
-            await a.send_multipart([b"hi", b"there"])
-            recvd = await f2
-            assert f2.done()
-            assert recvd == [b"hi", b"there"]
-
-        self.loop.run_until_complete(test())
-
-    @mark.skipif(not hasattr(zmq, "SNDTIMEO"), reason="requires SNDTIMEO")
-    def test_send_timeout(self):
-        async def test():
-            s = self.socket(zmq.PUSH)
-            s.sndtimeo = 100
-            with self.assertRaises(zmq.Again):
-                await s.send(b"not going anywhere")
-
-        self.loop.run_until_complete(test())
-
-    def test_recv_string(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = b.recv_string()
-            assert not f.done()
-            msg = "πøøπ"
-            await a.send_string(msg)
-            recvd = await f
-            assert f.done()
-            assert f.result() == msg
-            assert recvd == msg
-
-        self.loop.run_until_complete(test())
-
-    def test_recv_json(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = b.recv_json()
-            assert not f.done()
-            obj = dict(a=5)
-            await a.send_json(obj)
-            recvd = await f
-            assert f.done()
-            assert f.result() == obj
-            assert recvd == obj
-
-        self.loop.run_until_complete(test())
-
-    def test_recv_json_cancelled(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = b.recv_json()
-            assert not f.done()
-            f.cancel()
-            # cycle eventloop to allow cancel events to fire
-            await asyncio.sleep(0)
-            obj = dict(a=5)
-            await a.send_json(obj)
-            # CancelledError change in 3.8 https://bugs.python.org/issue32528
-            if sys.version_info < (3, 8):
-                with pytest.raises(CancelledError):
-                    recvd = await f
-            else:
-                with pytest.raises(asyncio.exceptions.CancelledError):
-                    recvd = await f
-            assert f.done()
-            # give it a chance to incorrectly consume the event
-            events = await b.poll(timeout=5)
-            assert events
-            await asyncio.sleep(0)
-            # make sure cancelled recv didn't eat up event
-            f = b.recv_json()
-            recvd = await asyncio.wait_for(f, timeout=5)
-            assert recvd == obj
-
-        self.loop.run_until_complete(test())
-
-    def test_recv_pyobj(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = b.recv_pyobj()
-            assert not f.done()
-            obj = dict(a=5)
-            await a.send_pyobj(obj)
-            recvd = await f
-            assert f.done()
-            assert f.result() == obj
-            assert recvd == obj
-
-        self.loop.run_until_complete(test())
-
-    def test_custom_serialize(self):
-        def serialize(msg):
-            frames = []
-            frames.extend(msg.get("identities", []))
-            content = json.dumps(msg["content"]).encode("utf8")
-            frames.append(content)
-            return frames
-
-        def deserialize(frames):
-            identities = frames[:-1]
-            content = json.loads(frames[-1].decode("utf8"))
-            return {
-                "identities": identities,
-                "content": content,
-            }
-
-        async def test():
-            a, b = self.create_bound_pair(zmq.DEALER, zmq.ROUTER)
-
-            msg = {
-                "content": {
-                    "a": 5,
-                    "b": "bee",
-                }
-            }
-            await a.send_serialized(msg, serialize)
-            recvd = await b.recv_serialized(deserialize)
-            assert recvd["content"] == msg["content"]
-            assert recvd["identities"]
-            # bounce back, tests identities
-            await b.send_serialized(recvd, serialize)
-            r2 = await a.recv_serialized(deserialize)
-            assert r2["content"] == msg["content"]
-            assert not r2["identities"]
-
-        self.loop.run_until_complete(test())
-
-    def test_custom_serialize_error(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.DEALER, zmq.ROUTER)
-
-            msg = {
-                "content": {
-                    "a": 5,
-                    "b": "bee",
-                }
-            }
-            with pytest.raises(TypeError):
-                await a.send_serialized(json, json.dumps)
-
-            await a.send(b"not json")
-            with pytest.raises(TypeError):
-                await b.recv_serialized(json.loads)
-
-        self.loop.run_until_complete(test())
-
-    def test_recv_dontwait(self):
-        async def test():
-            push, pull = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = pull.recv(zmq.DONTWAIT)
-            with self.assertRaises(zmq.Again):
-                await f
-            await push.send(b"ping")
-            await pull.poll()  # ensure message will be waiting
-            f = pull.recv(zmq.DONTWAIT)
-            assert f.done()
-            msg = await f
-            assert msg == b"ping"
-
-        self.loop.run_until_complete(test())
-
-    def test_recv_cancel(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f1 = b.recv()
-            f2 = b.recv_multipart()
-            assert f1.cancel()
-            assert f1.done()
-            assert not f2.done()
-            await a.send_multipart([b"hi", b"there"])
-            recvd = await f2
-            assert f1.cancelled()
-            assert f2.done()
-            assert recvd == [b"hi", b"there"]
-
-        self.loop.run_until_complete(test())
-
-    def test_poll(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-            f = b.poll(timeout=0)
-            await asyncio.sleep(0)
-            assert f.result() == 0
-
-            f = b.poll(timeout=1)
-            assert not f.done()
-            evt = await f
-
-            assert evt == 0
-
-            f = b.poll(timeout=1000)
-            assert not f.done()
-            await a.send_multipart([b"hi", b"there"])
-            evt = await f
-            assert evt == zmq.POLLIN
-            recvd = await b.recv_multipart()
-            assert recvd == [b"hi", b"there"]
-
-        self.loop.run_until_complete(test())
-
-    def test_poll_base_socket(self):
-        async def test():
-            ctx = zmq.Context()
-            url = "inproc://test"
-            a = ctx.socket(zmq.PUSH)
-            b = ctx.socket(zmq.PULL)
-            self.sockets.extend([a, b])
-            a.bind(url)
-            b.connect(url)
-
-            poller = zaio.Poller()
-            poller.register(b, zmq.POLLIN)
-
-            f = poller.poll(timeout=1000)
-            assert not f.done()
-            a.send_multipart([b"hi", b"there"])
-            evt = await f
-            assert evt == [(b, zmq.POLLIN)]
-            recvd = b.recv_multipart()
-            assert recvd == [b"hi", b"there"]
-
-        self.loop.run_until_complete(test())
-
-    def test_poll_on_closed_socket(self):
-        async def test():
-            a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-
-            f = b.poll(timeout=1)
-            b.close()
-
-            # The test might stall if we try to await f directly so instead just make a few
-            # passes through the event loop to schedule and execute all callbacks
-            for _ in range(5):
-                await asyncio.sleep(0)
-                if f.cancelled():
-                    break
-            assert f.cancelled()
-
-        self.loop.run_until_complete(test())
-
-    @pytest.mark.skipif(
-        sys.platform.startswith("win"),
-        reason="Windows does not support polling on files",
-    )
-    def test_poll_raw(self):
-        async def test():
-            p = zaio.Poller()
-            # make a pipe
-            r, w = os.pipe()
-            r = os.fdopen(r, "rb")
-            w = os.fdopen(w, "wb")
-
-            # POLLOUT
-            p.register(r, zmq.POLLIN)
-            p.register(w, zmq.POLLOUT)
-            evts = await p.poll(timeout=1)
-            evts = dict(evts)
-            assert r.fileno() not in evts
-            assert w.fileno() in evts
-            assert evts[w.fileno()] == zmq.POLLOUT
-
-            # POLLIN
-            p.unregister(w)
-            w.write(b"x")
-            w.flush()
-            evts = await p.poll(timeout=1000)
-            evts = dict(evts)
-            assert r.fileno() in evts
-            assert evts[r.fileno()] == zmq.POLLIN
-            assert r.read(1) == b"x"
-            r.close()
-            w.close()
-
-        loop = asyncio.new_event_loop()
-        loop.run_until_complete(test())
-
-    def test_multiple_loops(self):
-        a, b = self.create_bound_pair(zmq.PUSH, zmq.PULL)
-
-        async def test():
-            await a.send(b'buf')
-            msg = await b.recv()
-            assert msg == b'buf'
-
-        for i in range(3):
-            loop = asyncio.new_event_loop()
-            loop.run_until_complete(asyncio.wait_for(test(), timeout=10))
-            loop.close()
-
-    def test_shadow(self):
-        async def test():
-            ctx = zmq.Context()
-            s = ctx.socket(zmq.PULL)
-            async_s = zaio.Socket(s)
-            assert isinstance(async_s, self.socket_class)
-
-    def test_process_teardown(self):
-        proc = ProcessForTeardownTest()
-        proc.start()
-        try:
-            proc.join(10)  # starting new Python process may cost a lot
-            self.assertEqual(
-                proc.exitcode,
-                0,
-                "Python process died with code %d" % proc.exitcode
-                if proc.exitcode
-                else "process teardown hangs",
-            )
-        finally:
-            proc.terminate()
-
-
-class TestAsyncioAuthentication(TestThreadAuthentication):
-    """Test authentication running in a asyncio task"""
-
-    Context = zaio.Context
-
-    def shortDescription(self):
-        """Rewrite doc strings from TestThreadAuthentication from
-        'threaded' to 'asyncio'.
-        """
-        doc = self._testMethodDoc
-        if doc:
-            doc = doc.split("\n")[0].strip()
-            if doc.startswith("threaded auth"):
-                doc = doc.replace("threaded auth", "asyncio auth")
-        return doc
-
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        super().setUp()
-
-    def start_auth(self):
-        async def start():
-            self.auth.start()
-
-        self.loop.run_until_complete(start())
-
-    def tearDown(self):
-        super().tearDown()
-        self.loop.close()
-
-    def make_auth(self):
-        return AsyncioAuthenticator(self.context)
-
-    def can_connect(self, server, client):
-        """Check if client can connect to server using tcp transport"""
-
-        async def go():
-            result = False
-            iface = "tcp://127.0.0.1"
-            port = server.bind_to_random_port(iface)
-            client.connect("%s:%i" % (iface, port))
-            msg = [b"Hello World"]
-
-            # set timeouts
-            server.SNDTIMEO = client.RCVTIMEO = 1000
-            try:
-                await server.send_multipart(msg)
-            except zmq.Again:
-                return False
-            try:
-                rcvd_msg = await client.recv_multipart()
-            except zmq.Again:
-                return False
-            else:
-                assert rcvd_msg == msg
-                result = True
-            return result
-
-        return self.loop.run_until_complete(go())
-
-    def send(self, socket, *args, **kwargs):
-        async def _send():
-            return await socket.send(*args, **kwargs)
-
-        return self.loop.run_until_complete(_send())
-
-    def _select_recv(self, multipart, socket, **kwargs):
-        recv = socket.recv_multipart if multipart else socket.recv
-
-        async def coro():
-            if not await socket.poll(5000):
-                raise TimeoutError("Should have received a message")
-            return await recv(**kwargs)
-
-        return self.loop.run_until_complete(coro())
+def test_process_teardown(request):
+    proc = ProcessForTeardownTest()
+    proc.start()
+    request.addfinalizer(proc.terminate)
+    proc.join(10)  # starting new Python process may cost a lot
+    assert proc.exitcode is not None, "process teardown hangs"
+    assert proc.exitcode == 0, f"Python process died with code {proc.exitcode}"

--- a/zmq/tests/test_auth.py
+++ b/zmq/tests/test_auth.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import os
 import shutil
+import sys
 import warnings
 from contextlib import contextmanager
 
@@ -386,6 +387,10 @@ class TestThreadAuthentication(AuthTest):
         return ThreadAuthenticator(self.context)
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32' and sys.version_info < (3, 7),
+    reason="flaky event loop cleanup on windows+py36",
+)
 class TestAsyncioAuthentication(AuthTest):
     """Test authentication running in a thread"""
 
@@ -396,6 +401,10 @@ class TestAsyncioAuthentication(AuthTest):
 
 
 @pytest.mark.skipif(tornado is None, reason="requires tornado")
+@pytest.mark.skipif(
+    sys.platform == 'win32' and sys.version_info < (3, 7),
+    reason="flaky event loop cleanup on windows+py36",
+)
 class TestIOLoopAuthentication(AuthTest):
     """Test authentication running in a thread"""
 

--- a/zmq/tests/test_auth.py
+++ b/zmq/tests/test_auth.py
@@ -5,108 +5,123 @@ import asyncio
 import logging
 import os
 import shutil
-import tempfile
 import warnings
 
 import pytest
 
 import zmq
+import zmq.asyncio
 import zmq.auth
-from zmq.auth.thread import ThreadAuthenticator
-from zmq.tests import BaseZMQTestCase, SkipTest, skip_pypy
+from zmq.tests import SkipTest, skip_pypy
+
+try:
+    import tornado
+except ImportError:
+    tornado = None
 
 
-class BaseAuthTestCase(BaseZMQTestCase):
-    def setUp(self):
+@pytest.fixture
+def create_certs(tmpdir):
+    """Create CURVE certificates for a test"""
+
+    # Create temporary CURVE key pairs for this test run. We create all keys in a
+    # temp directory and then move them into the appropriate private or public
+    # directory.
+    base_dir = str(tmpdir.join("certs").mkdir())
+    keys_dir = os.path.join(base_dir, "certificates")
+    public_keys_dir = os.path.join(base_dir, 'public_keys')
+    secret_keys_dir = os.path.join(base_dir, 'private_keys')
+
+    os.mkdir(keys_dir)
+    os.mkdir(public_keys_dir)
+    os.mkdir(secret_keys_dir)
+
+    server_public_file, server_secret_file = zmq.auth.create_certificates(
+        keys_dir, "server"
+    )
+    client_public_file, client_secret_file = zmq.auth.create_certificates(
+        keys_dir, "client"
+    )
+    for key_file in os.listdir(keys_dir):
+        if key_file.endswith(".key"):
+            shutil.move(
+                os.path.join(keys_dir, key_file), os.path.join(public_keys_dir, '.')
+            )
+
+    for key_file in os.listdir(keys_dir):
+        if key_file.endswith(".key_secret"):
+            shutil.move(
+                os.path.join(keys_dir, key_file), os.path.join(secret_keys_dir, '.')
+            )
+
+    return (public_keys_dir, secret_keys_dir)
+
+
+def load_certs(secret_keys_dir):
+    """Return server and client certificate keys"""
+    server_secret_file = os.path.join(secret_keys_dir, "server.key_secret")
+    client_secret_file = os.path.join(secret_keys_dir, "client.key_secret")
+
+    server_public, server_secret = zmq.auth.load_certificate(server_secret_file)
+    client_public, client_secret = zmq.auth.load_certificate(client_secret_file)
+
+    return server_public, server_secret, client_public, client_secret
+
+
+@pytest.fixture
+def public_keys_dir(create_certs):
+    public_keys_dir, secret_keys_dir = create_certs
+    return public_keys_dir
+
+
+@pytest.fixture
+def secret_keys_dir(create_certs):
+    public_keys_dir, secret_keys_dir = create_certs
+    return secret_keys_dir
+
+
+@pytest.fixture
+def certs(secret_keys_dir):
+    return load_certs(secret_keys_dir)
+
+
+@pytest.fixture
+async def _async_setup(request):
+    """pytest doesn't support async setup/teardown"""
+    instance = request.instance
+    await instance.async_setup()
+
+
+@pytest.mark.usefixtures("_async_setup")
+class AuthTest:
+    auth = None
+
+    async def async_setup(self):
+        self.context = zmq.asyncio.Context()
         if zmq.zmq_version_info() < (4, 0):
             raise SkipTest("security is new in libzmq 4.0")
         try:
             zmq.curve_keypair()
         except zmq.ZMQError:
             raise SkipTest("security requires libzmq to have curve support")
-        super().setUp()
         # enable debug logging while we run tests
         logging.getLogger('zmq.auth').setLevel(logging.DEBUG)
         self.auth = self.make_auth()
-        self.base_dir, self.public_keys_dir, self.secret_keys_dir = self.create_certs()
-        self.start_auth()
+        await self.start_auth()
+
+    def teardown(self):
+        if self.auth:
+            self.auth.stop()
+            self.auth = None
+        self.context.destroy()
 
     def make_auth(self):
         raise NotImplementedError()
 
-    def send(self, socket, *args, **kwargs):
-        # allow override in async classes
-        return socket.send(*args, **kwargs)
-
-    def start_auth(self):
+    async def start_auth(self):
         self.auth.start()
 
-    def tearDown(self):
-        if self.auth:
-            self.auth.stop()
-            self.auth = None
-        self.remove_certs(self.base_dir)
-        super().tearDown()
-
-    def create_certs(self):
-        """Create CURVE certificates for a test"""
-
-        # Create temporary CURVE key pairs for this test run. We create all keys in a
-        # temp directory and then move them into the appropriate private or public
-        # directory.
-
-        base_dir = tempfile.mkdtemp()
-        keys_dir = os.path.join(base_dir, 'certificates')
-        public_keys_dir = os.path.join(base_dir, 'public_keys')
-        secret_keys_dir = os.path.join(base_dir, 'private_keys')
-
-        os.mkdir(keys_dir)
-        os.mkdir(public_keys_dir)
-        os.mkdir(secret_keys_dir)
-
-        server_public_file, server_secret_file = zmq.auth.create_certificates(
-            keys_dir, "server"
-        )
-        client_public_file, client_secret_file = zmq.auth.create_certificates(
-            keys_dir, "client"
-        )
-
-        for key_file in os.listdir(keys_dir):
-            if key_file.endswith(".key"):
-                shutil.move(
-                    os.path.join(keys_dir, key_file), os.path.join(public_keys_dir, '.')
-                )
-
-        for key_file in os.listdir(keys_dir):
-            if key_file.endswith(".key_secret"):
-                shutil.move(
-                    os.path.join(keys_dir, key_file), os.path.join(secret_keys_dir, '.')
-                )
-
-        return (base_dir, public_keys_dir, secret_keys_dir)
-
-    def remove_certs(self, base_dir):
-        """Remove certificates for a test"""
-        shutil.rmtree(base_dir)
-
-    def load_certs(self, secret_keys_dir):
-        """Return server and client certificate keys"""
-        server_secret_file = os.path.join(secret_keys_dir, "server.key_secret")
-        client_secret_file = os.path.join(secret_keys_dir, "client.key_secret")
-
-        server_public, server_secret = zmq.auth.load_certificate(server_secret_file)
-        client_public, client_secret = zmq.auth.load_certificate(client_secret_file)
-
-        return server_public, server_secret, client_public, client_secret
-
-
-class TestThreadAuthentication(BaseAuthTestCase):
-    """Test authentication running in a thread"""
-
-    def make_auth(self):
-        return ThreadAuthenticator(self.context)
-
-    def can_connect(self, server, client):
+    async def can_connect(self, server, client, timeout=1000):
         """Check if client can connect to server using tcp transport"""
         result = False
         iface = 'tcp://127.0.0.1'
@@ -115,20 +130,20 @@ class TestThreadAuthentication(BaseAuthTestCase):
         msg = [b"Hello World"]
         # run poll on server twice
         # to flush spurious events
-        server.poll(100, zmq.POLLOUT)
+        await server.poll(100, zmq.POLLOUT)
 
-        if server.poll(1000, zmq.POLLOUT):
+        if await server.poll(timeout, zmq.POLLOUT):
             try:
-                server.send_multipart(msg, zmq.NOBLOCK)
+                await server.send_multipart(msg, zmq.NOBLOCK)
             except zmq.Again:
                 warnings.warn("server set POLLOUT, but cannot send", RuntimeWarning)
                 return False
         else:
             return False
 
-        if client.poll(1000):
+        if await client.poll(timeout):
             try:
-                rcvd_msg = client.recv_multipart(zmq.NOBLOCK)
+                rcvd_msg = await client.recv_multipart(zmq.NOBLOCK)
             except zmq.Again:
                 warnings.warn("client set POLLIN, but cannot recv", RuntimeWarning)
             else:
@@ -136,153 +151,153 @@ class TestThreadAuthentication(BaseAuthTestCase):
                 result = True
         return result
 
-    def test_null(self):
+    async def test_null(self):
         """threaded auth - NULL"""
         # A default NULL connection should always succeed, and not
         # go through our authentication infrastructure at all.
         self.auth.stop()
         self.auth = None
-        # use a new context, so ZAP isn't inherited
-        self.context = self.Context()
 
-        server = self.socket(zmq.PUSH)
-        client = self.socket(zmq.PULL)
-        assert self.can_connect(server, client)
+        # use a new context, so ZAP isn't inherited
+        self.context.destroy()
+        self.context = zmq.asyncio.Context()
+
+        server = self.context.socket(zmq.PUSH)
+        client = self.context.socket(zmq.PULL)
+        assert await self.can_connect(server, client)
 
         # By setting a domain we switch on authentication for NULL sockets,
         # though no policies are configured yet. The client connection
         # should still be allowed.
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.zap_domain = b'global'
-        client = self.socket(zmq.PULL)
-        assert self.can_connect(server, client)
+        client = self.context.socket(zmq.PULL)
+        assert await self.can_connect(server, client)
 
-    def test_blacklist(self):
+    async def test_blacklist(self):
         """threaded auth - Blacklist"""
         # Blacklist 127.0.0.1, connection should fail
         self.auth.deny('127.0.0.1')
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         # By setting a domain we switch on authentication for NULL sockets,
         # though no policies are configured yet.
         server.zap_domain = b'global'
-        client = self.socket(zmq.PULL)
-        assert not self.can_connect(server, client)
+        client = self.context.socket(zmq.PULL)
+        assert not await self.can_connect(server, client, timeout=100)
 
-    def test_whitelist(self):
+    async def test_whitelist(self):
         """threaded auth - Whitelist"""
         # Whitelist 127.0.0.1, connection should pass"
         self.auth.allow('127.0.0.1')
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         # By setting a domain we switch on authentication for NULL sockets,
         # though no policies are configured yet.
         server.zap_domain = b'global'
-        client = self.socket(zmq.PULL)
-        assert self.can_connect(server, client)
+        client = self.context.socket(zmq.PULL)
+        assert await self.can_connect(server, client)
 
-    def test_plain(self):
+    async def test_plain(self):
         """threaded auth - PLAIN"""
 
         # Try PLAIN authentication - without configuring server, connection should fail
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.plain_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.plain_username = b'admin'
         client.plain_password = b'Password'
-        assert not self.can_connect(server, client)
+        assert not await self.can_connect(server, client, timeout=100)
 
         # Try PLAIN authentication - with server configured, connection should pass
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.plain_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.plain_username = b'admin'
         client.plain_password = b'Password'
         self.auth.configure_plain(domain='*', passwords={'admin': 'Password'})
-        assert self.can_connect(server, client)
+        assert await self.can_connect(server, client)
 
         # Try PLAIN authentication - with bogus credentials, connection should fail
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.plain_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.plain_username = b'admin'
         client.plain_password = b'Bogus'
-        assert not self.can_connect(server, client)
+        assert not await self.can_connect(server, client, timeout=100)
 
         # Remove authenticator and check that a normal connection works
         self.auth.stop()
         self.auth = None
 
-        server = self.socket(zmq.PUSH)
-        client = self.socket(zmq.PULL)
-        assert self.can_connect(server, client)
+        server = self.context.socket(zmq.PUSH)
+        client = self.context.socket(zmq.PULL)
+        assert await self.can_connect(server, client)
         client.close()
         server.close()
 
-    def test_curve(self):
+    async def test_curve(self, certs, public_keys_dir):
         """threaded auth - CURVE"""
         self.auth.allow('127.0.0.1')
-        certs = self.load_certs(self.secret_keys_dir)
         server_public, server_secret, client_public, client_secret = certs
 
         # Try CURVE authentication - without configuring server, connection should fail
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert not self.can_connect(server, client)
+        assert not await self.can_connect(server, client, timeout=100)
 
         # Try CURVE authentication - with server configured to CURVE_ALLOW_ANY, connection should pass
         self.auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY)
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert self.can_connect(server, client)
+        assert await self.can_connect(server, client)
 
         # Try CURVE authentication - with server configured, connection should pass
-        self.auth.configure_curve(domain='*', location=self.public_keys_dir)
-        server = self.socket(zmq.PULL)
+        self.auth.configure_curve(domain='*', location=public_keys_dir)
+        server = self.context.socket(zmq.PULL)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PUSH)
+        client = self.context.socket(zmq.PUSH)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert self.can_connect(client, server)
+        assert await self.can_connect(client, server)
 
         # Remove authenticator and check that a normal connection works
         self.auth.stop()
         self.auth = None
 
         # Try connecting using NULL and no authentication enabled, connection should pass
-        server = self.socket(zmq.PUSH)
-        client = self.socket(zmq.PULL)
-        assert self.can_connect(server, client)
+        server = self.context.socket(zmq.PUSH)
+        client = self.context.socket(zmq.PULL)
+        assert await self.can_connect(server, client)
 
-    def test_curve_callback(self):
+    async def test_curve_callback(self, certs):
         """threaded auth - CURVE with callback authentication"""
         self.auth.allow('127.0.0.1')
-        certs = self.load_certs(self.secret_keys_dir)
         server_public, server_secret, client_public, client_secret = certs
 
         # Try CURVE authentication - without configuring server, connection should fail
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert not self.can_connect(server, client)
+        assert not await self.can_connect(server, client, timeout=100)
 
         # Try CURVE authentication - with callback authentication configured, connection should pass
 
@@ -298,15 +313,15 @@ class TestThreadAuthentication(BaseAuthTestCase):
 
         provider = CredentialsProvider()
         self.auth.configure_curve_callback(credentials_provider=provider)
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert self.can_connect(server, client)
+        assert await self.can_connect(server, client, timeout=100)
 
         # Try CURVE authentication - with async callback authentication configured, connection should pass
 
@@ -323,15 +338,15 @@ class TestThreadAuthentication(BaseAuthTestCase):
 
         provider = AsyncCredentialsProvider()
         self.auth.configure_curve_callback(credentials_provider=provider)
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert self.can_connect(server, client)
+        assert await self.can_connect(server, client)
 
         # Try CURVE authentication - with callback authentication configured with wrong key, connection should not pass
 
@@ -347,15 +362,15 @@ class TestThreadAuthentication(BaseAuthTestCase):
 
         provider = WrongCredentialsProvider()
         self.auth.configure_curve_callback(credentials_provider=provider)
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert not self.can_connect(server, client)
+        assert not await self.can_connect(server, client, timeout=100)
 
         # Try CURVE authentication - with async callback authentication configured with wrong key, connection should not pass
 
@@ -372,37 +387,36 @@ class TestThreadAuthentication(BaseAuthTestCase):
 
         provider = WrongAsyncCredentialsProvider()
         self.auth.configure_curve_callback(credentials_provider=provider)
-        server = self.socket(zmq.PUSH)
+        server = self.context.socket(zmq.PUSH)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PULL)
+        client = self.context.socket(zmq.PULL)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert not self.can_connect(server, client)
+        assert not await self.can_connect(server, client)
 
     @skip_pypy
-    def test_curve_user_id(self):
+    async def test_curve_user_id(self, certs, public_keys_dir):
         """threaded auth - CURVE"""
         self.auth.allow('127.0.0.1')
-        certs = self.load_certs(self.secret_keys_dir)
         server_public, server_secret, client_public, client_secret = certs
 
-        self.auth.configure_curve(domain='*', location=self.public_keys_dir)
-        server = self.socket(zmq.PULL)
+        self.auth.configure_curve(domain='*', location=public_keys_dir)
+        server = self.context.socket(zmq.PULL)
         server.curve_publickey = server_public
         server.curve_secretkey = server_secret
         server.curve_server = True
-        client = self.socket(zmq.PUSH)
+        client = self.context.socket(zmq.PUSH)
         client.curve_publickey = client_public
         client.curve_secretkey = client_secret
         client.curve_serverkey = server_public
-        assert self.can_connect(client, server)
+        assert await self.can_connect(client, server)
 
         # test default user-id map
-        self.send(client, b'test')
-        msg = self.recv(server, copy=False)
+        await client.send(b'test')
+        msg = await server.recv(copy=False)
         assert msg.bytes == b'test'
         try:
             user_id = msg.get('User-Id')
@@ -414,14 +428,14 @@ class TestThreadAuthentication(BaseAuthTestCase):
         # test custom user-id map
         self.auth.curve_user_id = lambda client_key: 'custom'
 
-        client2 = self.socket(zmq.PUSH)
+        client2 = self.context.socket(zmq.PUSH)
         client2.curve_publickey = client_public
         client2.curve_secretkey = client_secret
         client2.curve_serverkey = server_public
-        assert self.can_connect(client2, server)
+        assert await self.can_connect(client2, server)
 
-        self.send(client2, b'test2')
-        msg = self.recv(server, copy=False)
+        await client2.send(b'test2')
+        msg = await server.recv(copy=False)
         assert msg.bytes == b'test2'
         try:
             user_id = msg.get('User-Id')
@@ -431,215 +445,30 @@ class TestThreadAuthentication(BaseAuthTestCase):
             assert user_id == 'custom'
 
 
-def with_ioloop(method, expect_success=True):
-    """decorator for running tests with an IOLoop"""
+class TestThreadAuthentication(AuthTest):
+    """Test authentication running in a thread"""
 
-    def test_method(self):
-        r = method(self)
+    def make_auth(self):
+        from zmq.auth.thread import ThreadAuthenticator
 
-        loop = self.io_loop
-        if expect_success:
-            self.pullstream.on_recv(self.on_message_succeed)
-        else:
-            self.pullstream.on_recv(self.on_message_fail)
-
-        loop.call_later(1, self.attempt_connection)
-        loop.call_later(1.2, self.send_msg)
-
-        if expect_success:
-            loop.call_later(2, self.on_test_timeout_fail)
-        else:
-            loop.call_later(2, self.on_test_timeout_succeed)
-
-        loop.start()
-        if self.fail_msg:
-            self.fail(self.fail_msg)
-
-        return r
-
-    return test_method
+        return ThreadAuthenticator(self.context)
 
 
-def should_auth(method):
-    return with_ioloop(method, True)
+class TestAsyncioAuthentication(AuthTest):
+    """Test authentication running in a thread"""
+
+    def make_auth(self):
+        from zmq.auth.asyncio import AsyncioAuthenticator
+
+        return AsyncioAuthenticator(self.context)
 
 
-def should_not_auth(method):
-    return with_ioloop(method, False)
-
-
-class TestIOLoopAuthentication(BaseAuthTestCase):
-    """Test authentication running in ioloop"""
-
-    def setUp(self):
-        try:
-            from tornado import ioloop
-        except ImportError:
-            pytest.skip("Requires tornado")
-        from zmq.eventloop import zmqstream
-
-        self.fail_msg = None
-        self.io_loop = ioloop.IOLoop(make_current=False)
-        super().setUp()
-        self.server = self.socket(zmq.PUSH)
-        self.client = self.socket(zmq.PULL)
-
-        async def make_streams():
-            self.pushstream = zmqstream.ZMQStream(self.server)
-            self.pullstream = zmqstream.ZMQStream(self.client)
-
-        self.io_loop.run_sync(make_streams)
+@pytest.mark.usefixtures("io_loop")
+@pytest.mark.skipif(tornado is None, reason="requires tornado")
+class TestIOLoopAuthentication(AuthTest):
+    """Test authentication running in a thread"""
 
     def make_auth(self):
         from zmq.auth.ioloop import IOLoopAuthenticator
 
-        async def make_auth():
-            return IOLoopAuthenticator(self.context)
-
-        return self.io_loop.run_sync(make_auth)
-
-    def tearDown(self):
-        if self.auth:
-            self.auth.stop()
-            self.auth = None
-        self.io_loop.close(all_fds=True)
-        super().tearDown()
-
-    def attempt_connection(self):
-        """Check if client can connect to server using tcp transport"""
-        iface = 'tcp://127.0.0.1'
-        port = self.server.bind_to_random_port(iface)
-        self.client.connect("%s:%i" % (iface, port))
-
-    def send_msg(self):
-        """Send a message from server to a client"""
-        msg = [b"Hello World"]
-        self.pushstream.send_multipart(msg)
-
-    def on_message_succeed(self, frames):
-        """A message was received, as expected."""
-        if frames != [b"Hello World"]:
-            self.fail_msg = "Unexpected message received"
-        self.io_loop.stop()
-
-    def on_message_fail(self, frames):
-        """A message was received, unexpectedly."""
-        self.fail_msg = 'Received messaged unexpectedly, security failed'
-        self.io_loop.stop()
-
-    def on_test_timeout_succeed(self):
-        """Test timer expired, indicates test success"""
-        self.io_loop.stop()
-
-    def on_test_timeout_fail(self):
-        """Test timer expired, indicates test failure"""
-        self.fail_msg = 'Test timed out'
-        self.io_loop.stop()
-
-    @should_auth
-    def test_none(self):
-        """ioloop auth - NONE"""
-        # A default NULL connection should always succeed, and not
-        # go through our authentication infrastructure at all.
-        # no auth should be running
-        self.auth.stop()
-        self.auth = None
-
-    @should_auth
-    def test_null(self):
-        """ioloop auth - NULL"""
-        # By setting a domain we switch on authentication for NULL sockets,
-        # though no policies are configured yet. The client connection
-        # should still be allowed.
-        self.server.zap_domain = b'global'
-
-    @should_not_auth
-    def test_blacklist(self):
-        """ioloop auth - Blacklist"""
-        # Blacklist 127.0.0.1, connection should fail
-        self.auth.deny('127.0.0.1')
-        self.server.zap_domain = b'global'
-
-    @should_auth
-    def test_whitelist(self):
-        """ioloop auth - Whitelist"""
-        # Whitelist 127.0.0.1, which overrides the blacklist, connection should pass"
-        self.auth.allow('127.0.0.1')
-
-        self.server.setsockopt(zmq.ZAP_DOMAIN, b'global')
-
-    @should_not_auth
-    def test_plain_unconfigured_server(self):
-        """ioloop auth - PLAIN, unconfigured server"""
-        self.client.plain_username = b'admin'
-        self.client.plain_password = b'Password'
-        # Try PLAIN authentication - without configuring server, connection should fail
-        self.server.plain_server = True
-
-    @should_auth
-    def test_plain_configured_server(self):
-        """ioloop auth - PLAIN, configured server"""
-        self.client.plain_username = b'admin'
-        self.client.plain_password = b'Password'
-        # Try PLAIN authentication - with server configured, connection should pass
-        self.server.plain_server = True
-        self.auth.configure_plain(domain='*', passwords={'admin': 'Password'})
-
-    @should_not_auth
-    def test_plain_bogus_credentials(self):
-        """ioloop auth - PLAIN, bogus credentials"""
-        self.client.plain_username = b'admin'
-        self.client.plain_password = b'Bogus'
-        self.server.plain_server = True
-
-        self.auth.configure_plain(domain='*', passwords={'admin': 'Password'})
-
-    @should_not_auth
-    def test_curve_unconfigured_server(self):
-        """ioloop auth - CURVE, unconfigured server"""
-        certs = self.load_certs(self.secret_keys_dir)
-        server_public, server_secret, client_public, client_secret = certs
-
-        self.auth.allow('127.0.0.1')
-
-        self.server.curve_publickey = server_public
-        self.server.curve_secretkey = server_secret
-        self.server.curve_server = True
-
-        self.client.curve_publickey = client_public
-        self.client.curve_secretkey = client_secret
-        self.client.curve_serverkey = server_public
-
-    @should_auth
-    def test_curve_allow_any(self):
-        """ioloop auth - CURVE, CURVE_ALLOW_ANY"""
-        certs = self.load_certs(self.secret_keys_dir)
-        server_public, server_secret, client_public, client_secret = certs
-
-        self.auth.allow('127.0.0.1')
-        self.auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY)
-
-        self.server.curve_publickey = server_public
-        self.server.curve_secretkey = server_secret
-        self.server.curve_server = True
-
-        self.client.curve_publickey = client_public
-        self.client.curve_secretkey = client_secret
-        self.client.curve_serverkey = server_public
-
-    @should_auth
-    def test_curve_configured_server(self):
-        """ioloop auth - CURVE, configured server"""
-        self.auth.allow('127.0.0.1')
-        certs = self.load_certs(self.secret_keys_dir)
-        server_public, server_secret, client_public, client_secret = certs
-
-        self.auth.configure_curve(domain='*', location=self.public_keys_dir)
-
-        self.server.curve_publickey = server_public
-        self.server.curve_secretkey = server_secret
-        self.server.curve_server = True
-
-        self.client.curve_publickey = client_public
-        self.client.curve_secretkey = client_secret
-        self.client.curve_serverkey = server_public
+        return IOLoopAuthenticator(self.context)

--- a/zmq/tests/test_ioloop.py
+++ b/zmq/tests/test_ioloop.py
@@ -2,136 +2,32 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-import asyncio
-import threading
-import warnings
-
 import pytest
 
-import zmq
-from zmq.tests import BaseZMQTestCase, have_gevent
-
 try:
-    from tornado.ioloop import IOLoop as BaseIOLoop
-
-    from zmq.eventloop import ioloop
+    import tornado.ioloop
 except ImportError:
     _tornado = False
 else:
     _tornado = True
 
-# tornado 5 with asyncio disables custom IOLoop implementations
-t5asyncio = False
-if _tornado:
-    import tornado
 
-    if tornado.version_info >= (5,) and asyncio:
-        t5asyncio = True
+def setup():
+    if not _tornado:
+        pytest.skip("requires tornado")
 
 
-class Delay(threading.Thread):
-    def __init__(self, f, delay=1):
-        self.f = f
-        self.delay = delay
-        self.aborted = False
-        self.cond = threading.Condition()
-        super().__init__()
+def test_ioloop():
+    # may have been imported before,
+    # can't capture the warning
+    from zmq.eventloop import ioloop
 
-    def run(self):
-        self.cond.acquire()
-        self.cond.wait(self.delay)
-        self.cond.release()
-        if not self.aborted:
-            self.f()
-
-    def abort(self):
-        self.aborted = True
-        self.cond.acquire()
-        self.cond.notify()
-        self.cond.release()
+    assert ioloop.IOLoop is tornado.ioloop.IOLoop
+    assert ioloop.ZMQIOLoop is ioloop.IOLoop
 
 
-class TestIOLoop(BaseZMQTestCase):
-    if _tornado:
-        IOLoop = BaseIOLoop
+def test_ioloop_install():
+    from zmq.eventloop import ioloop
 
-    def setUp(self):
-        if not _tornado:
-            pytest.skip("tornado required")
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
-    def test_simple(self):
-        """simple IOLoop creation test"""
-        loop = self.IOLoop(make_current=False)
-
-        async def start_callbacks():
-            dc = ioloop.PeriodicCallback(loop.stop, 200)
-            pc = ioloop.PeriodicCallback(lambda: None, 10)
-            pc.start()
-            dc.start()
-
-        loop.run_sync(start_callbacks)
-
-        t = Delay(loop.stop, 1)
-        t.start()
-        loop.start()
-        if t.is_alive():
-            t.abort()
-        else:
-            self.fail("IOLoop failed to exit")
-
-    def test_instance(self):
-        """IOLoop.instance returns the right object"""
-        with warnings.catch_warnings() as record:
-            loop = self.IOLoop.instance()
-            if not t5asyncio:
-                assert isinstance(loop, self.IOLoop)
-            base_loop = BaseIOLoop.instance()
-            assert base_loop is loop
-
-    def test_current(self):
-        """IOLoop.current returns the right object"""
-        with warnings.catch_warnings() as record:
-            loop = ioloop.IOLoop.current()
-            if not t5asyncio:
-                assert isinstance(loop, self.IOLoop)
-            base_loop = BaseIOLoop.current()
-            assert base_loop is loop
-
-    def test_close_all(self):
-        """Test close(all_fds=True)"""
-        loop = self.IOLoop(make_current=False)
-        req, rep = self.create_bound_pair(zmq.REQ, zmq.REP)
-        loop.add_handler(req, lambda msg: msg, ioloop.IOLoop.READ)
-        loop.add_handler(rep, lambda msg: msg, ioloop.IOLoop.READ)
-        assert req.closed == False
-        assert rep.closed == False
-        loop.close(all_fds=True)
-        assert req.closed == True
-        assert rep.closed == True
-
-
-if have_gevent and _tornado:
-    import zmq.green.eventloop.ioloop as green_ioloop
-
-    class TestIOLoopGreen(TestIOLoop):
-        IOLoop = green_ioloop.IOLoop
-
-        def xtest_instance(self):
-            """Green IOLoop.instance returns the right object"""
-            loop = self.IOLoop.instance()
-            if not t5asyncio:
-                assert isinstance(loop, self.IOLoop)
-            base_loop = BaseIOLoop.instance()
-            assert base_loop is loop
-
-        def xtest_current(self):
-            """Green IOLoop.current returns the right object"""
-            loop = self.IOLoop.current()
-            if not t5asyncio:
-                assert isinstance(loop, self.IOLoop)
-            base_loop = BaseIOLoop.current()
-            assert base_loop is loop
+    with pytest.warns(DeprecationWarning):
+        ioloop.install()

--- a/zmq/tests/test_monitor.py
+++ b/zmq/tests/test_monitor.py
@@ -1,171 +1,94 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
-import sys
-
 import zmq
-import zmq.asyncio as zaio
-from zmq.tests import BaseZMQTestCase, require_zmq_4
+import zmq.asyncio
+from zmq.tests import require_zmq_4
 from zmq.utils.monitor import recv_monitor_message
 
-
-async def recv_monitor_async(mon_socket):
-    """As a coroutine, to avoid deprected references to current loop"""
-    return await recv_monitor_message(mon_socket)
+pytestmark = require_zmq_4
+import pytest
 
 
-class TestSocketMonitor(BaseZMQTestCase):
-    @require_zmq_4
-    def test_monitor(self):
-        """Test monitoring interface for sockets."""
-        s_rep = self.context.socket(zmq.REP)
-        s_req = self.context.socket(zmq.REQ)
-        self.sockets.extend([s_rep, s_req])
-        s_req.bind("tcp://127.0.0.1:6666")
-        # try monitoring the REP socket
+@pytest.fixture(params=["zmq", "asyncio"])
+def Context(request, event_loop):
+    if request.param == "asyncio":
+        return zmq.asyncio.Context
+    else:
+        return zmq.Context
 
-        s_rep.monitor(
-            "inproc://monitor.rep",
-            zmq.EVENT_CONNECT_DELAYED | zmq.EVENT_CONNECTED | zmq.EVENT_MONITOR_STOPPED,
-        )
-        # create listening socket for monitor
-        s_event = self.context.socket(zmq.PAIR)
-        self.sockets.append(s_event)
-        s_event.connect("inproc://monitor.rep")
-        s_event.linger = 0
-        # test receive event for connect event
-        s_rep.connect("tcp://127.0.0.1:6666")
-        m = recv_monitor_message(s_event)
-        if m['event'] == zmq.EVENT_CONNECT_DELAYED:
-            assert m['endpoint'] == b"tcp://127.0.0.1:6666"
-            # test receive event for connected event
-            m = recv_monitor_message(s_event)
-        assert m['event'] == zmq.EVENT_CONNECTED
+
+async def test_monitor(context, socket):
+    """Test monitoring interface for sockets."""
+    s_rep = socket(zmq.REP)
+    s_req = socket(zmq.REQ)
+    s_req.bind("tcp://127.0.0.1:6666")
+    # try monitoring the REP socket
+    s_rep.monitor(
+        "inproc://monitor.rep",
+        zmq.EVENT_CONNECT_DELAYED | zmq.EVENT_CONNECTED | zmq.EVENT_MONITOR_STOPPED,
+    )
+    # create listening socket for monitor
+    s_event = socket(zmq.PAIR)
+    s_event.connect("inproc://monitor.rep")
+    s_event.linger = 0
+    # test receive event for connect event
+    s_rep.connect("tcp://127.0.0.1:6666")
+    m = recv_monitor_message(s_event)
+    if isinstance(context, zmq.asyncio.Context):
+        m = await m
+    if m['event'] == zmq.EVENT_CONNECT_DELAYED:
         assert m['endpoint'] == b"tcp://127.0.0.1:6666"
-
-        # test monitor can be disabled.
-        s_rep.disable_monitor()
+        # test receive event for connected event
         m = recv_monitor_message(s_event)
-        assert m['event'] == zmq.EVENT_MONITOR_STOPPED
+        if isinstance(context, zmq.asyncio.Context):
+            m = await m
+    assert m['event'] == zmq.EVENT_CONNECTED
+    assert m['endpoint'] == b"tcp://127.0.0.1:6666"
 
-    @require_zmq_4
-    def test_monitor_repeat(self):
-        s = self.socket(zmq.PULL)
-        m = s.get_monitor_socket()
-        self.sockets.append(m)
-        m2 = s.get_monitor_socket()
-        assert m is m2
-        s.disable_monitor()
-        evt = recv_monitor_message(m)
-        assert evt['event'] == zmq.EVENT_MONITOR_STOPPED
-        m.close()
-        s.close()
+    # test monitor can be disabled.
+    s_rep.disable_monitor()
+    m = recv_monitor_message(s_event)
+    if isinstance(context, zmq.asyncio.Context):
+        m = await m
+    assert m['event'] == zmq.EVENT_MONITOR_STOPPED
 
-    @require_zmq_4
-    def test_monitor_connected(self):
-        """Test connected monitoring socket."""
-        s_rep = self.context.socket(zmq.REP)
-        s_req = self.context.socket(zmq.REQ)
-        self.sockets.extend([s_rep, s_req])
-        s_req.bind("tcp://127.0.0.1:6667")
-        # try monitoring the REP socket
-        # create listening socket for monitor
-        s_event = s_rep.get_monitor_socket()
-        s_event.linger = 0
-        self.sockets.append(s_event)
-        # test receive event for connect event
-        s_rep.connect("tcp://127.0.0.1:6667")
+
+async def test_monitor_repeat(context, socket, sockets):
+    s = socket(zmq.PULL)
+    m = s.get_monitor_socket()
+    sockets.append(m)
+    m2 = s.get_monitor_socket()
+    assert m is m2
+    s.disable_monitor()
+    evt = recv_monitor_message(m)
+    if isinstance(context, zmq.asyncio.Context):
+        evt = await evt
+    assert evt['event'] == zmq.EVENT_MONITOR_STOPPED
+    m.close()
+    s.close()
+
+
+async def test_monitor_connected(context, socket, sockets):
+    """Test connected monitoring socket."""
+    s_rep = socket(zmq.REP)
+    s_req = socket(zmq.REQ)
+    s_req.bind("tcp://127.0.0.1:6667")
+    # try monitoring the REP socket
+    # create listening socket for monitor
+    s_event = s_rep.get_monitor_socket()
+    s_event.linger = 0
+    sockets.append(s_event)
+    # test receive event for connect event
+    s_rep.connect("tcp://127.0.0.1:6667")
+    m = recv_monitor_message(s_event)
+    if isinstance(context, zmq.asyncio.Context):
+        m = await m
+    if m['event'] == zmq.EVENT_CONNECT_DELAYED:
+        assert m['endpoint'] == b"tcp://127.0.0.1:6667"
+        # test receive event for connected event
         m = recv_monitor_message(s_event)
-        if m['event'] == zmq.EVENT_CONNECT_DELAYED:
-            assert m['endpoint'] == b"tcp://127.0.0.1:6667"
-            # test receive event for connected event
-            m = recv_monitor_message(s_event)
-        assert m['event'] == zmq.EVENT_CONNECTED
-        assert m['endpoint'] == b"tcp://127.0.0.1:6667"
-
-
-class TestSocketMonitorAsyncIO(BaseZMQTestCase):
-    Context = zaio.Context  # makes BaseZMQTestCase create asyncio self.context
-
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        super().setUp()
-        context = zaio.Context.instance()
-
-    def tearDown(self):
-        super().tearDown()
-        self.loop.close()
-        # verify cleanup of references to selectors
-        assert zaio._selectors == {}
-        if 'zmq._asyncio_selector' in sys.modules:
-            assert zmq._asyncio_selector._selector_loops == set()
-
-    @require_zmq_4
-    def test_monitor(self):
-        """Test monitoring interface for sockets."""
-        s_rep = self.context.socket(zmq.REP)
-        s_req = self.context.socket(zmq.REQ)
-        self.sockets.extend([s_rep, s_req])
-        s_req.bind("tcp://127.0.0.1:6666")
-        # try monitoring the REP socket
-
-        s_rep.monitor(
-            "inproc://monitor.rep",
-            zmq.EVENT_CONNECT_DELAYED | zmq.EVENT_CONNECTED | zmq.EVENT_MONITOR_STOPPED,
-        )
-        # create listening socket for monitor
-        s_event = self.context.socket(zmq.PAIR)
-        self.sockets.append(s_event)
-        s_event.connect("inproc://monitor.rep")
-        s_event.linger = 0
-        # test receive event for connect event
-        s_rep.connect("tcp://127.0.0.1:6666")
-        m = self.loop.run_until_complete(recv_monitor_async(s_event))
-        if m['event'] == zmq.EVENT_CONNECT_DELAYED:
-            assert m['endpoint'] == b"tcp://127.0.0.1:6666"
-            # test receive event for connected event
-            m = self.loop.run_until_complete(recv_monitor_async(s_event))
-        assert m['event'] == zmq.EVENT_CONNECTED
-        assert m['endpoint'] == b"tcp://127.0.0.1:6666"
-
-        # test monitor can be disabled.
-        s_rep.disable_monitor()
-        m = self.loop.run_until_complete(recv_monitor_async(s_event))
-        assert m['event'] == zmq.EVENT_MONITOR_STOPPED
-
-    @require_zmq_4
-    def test_monitor_repeat(self):
-        s = self.socket(zmq.PULL)
-        m = s.get_monitor_socket()
-        self.sockets.append(m)
-        m2 = s.get_monitor_socket()
-        assert m is m2
-        s.disable_monitor()
-
-        evt = self.loop.run_until_complete(recv_monitor_async(m))
-        assert evt['event'] == zmq.EVENT_MONITOR_STOPPED
-        m.close()
-        s.close()
-
-    @require_zmq_4
-    def test_monitor_connected(self):
-        """Test connected monitoring socket."""
-        s_rep = self.context.socket(zmq.REP)
-        s_req = self.context.socket(zmq.REQ)
-        self.sockets.extend([s_rep, s_req])
-        s_req.bind("tcp://127.0.0.1:6667")
-        # try monitoring the REP socket
-        # create listening socket for monitor
-        s_event = s_rep.get_monitor_socket()
-        s_event.linger = 0
-        self.sockets.append(s_event)
-        # test receive event for connect event
-        s_rep.connect("tcp://127.0.0.1:6667")
-        m = self.loop.run_until_complete(recv_monitor_async(s_event))
-        if m['event'] == zmq.EVENT_CONNECT_DELAYED:
-            assert m['endpoint'] == b"tcp://127.0.0.1:6667"
-            # test receive event for connected event
-            m = self.loop.run_until_complete(recv_monitor_async(s_event))
-        assert m['event'] == zmq.EVENT_CONNECTED
-        assert m['endpoint'] == b"tcp://127.0.0.1:6667"
+        if isinstance(context, zmq.asyncio.Context):
+            m = await m
+    assert m['event'] == zmq.EVENT_CONNECTED
+    assert m['endpoint'] == b"tcp://127.0.0.1:6667"


### PR DESCRIPTION
adds pytest-asyncio to test dependencies

adds most BaseZMQTestCase methods as fixtures in conftest

mostly migrates auth and async/ioloop tests, which were the most complicated to do with TestCase. These are much simpler now with pytest fixtures. Other tests can be migrated piecemeal.

avoids using TestCase, which don't have easy access to fixtures, async, etc.

deprecate using BaseZMQTestCase outside pyzmq