### PR TITLE
run constants generation in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,16 @@
 exclude: ^zmq/eventloop/minitornado/
 repos:
+  - repo: local
+    hooks:
+      - id: constants
+        name: constants
+        files: "^.*/constants.py"
+        description: Generate constants files
+        entry: python -m buildutils.constants
+        language: python
+        pass_filenames: false
+        additional_dependencies:
+          - black
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16  # Use the ref you want to point at
     hooks:
@@ -46,6 +57,8 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
+        # don't run black twice on constants.py
+        exclude: zmq/constants.py
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/buildutils/constants.py
+++ b/buildutils/constants.py
@@ -17,6 +17,7 @@ Currently generates the following files from templates:
 import enum
 import os
 import sys
+from subprocess import run
 
 from . import info
 
@@ -112,6 +113,8 @@ def generate_file(fname, ns_func, dest_dir="."):
     info("generating %s from template" % dest)
     with open(dest, 'w') as f:
         f.write(out)
+    if fname.endswith(".py"):
+        run([sys.executable, "-m", "black", dest])
 
 
 def render_constants():


### PR DESCRIPTION
ensures generated files are consistent

seems to be something tricky about the fact that `black` must be run, but pre-commit locks files