### PR TITLE
CIBW_ARCHS env is unnecessary on a native arm worker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
     resource_class: arm.medium
 
     environment:
-      CIBW_ARCHS: "aarch64"
       CIBW_SKIP: "<< parameters.skip >>"
       CIBW_BUILD: "<< parameters.build >>"
 


### PR DESCRIPTION
...I think...