### PR TITLE
deprecate mostly unused `setup.py test` entrypoint

### DIFF
--- a/packaging/redhat/python-pyzmq.spec
+++ b/packaging/redhat/python-pyzmq.spec
@@ -179,7 +179,7 @@ chmod -x examples/pubsub/topics_sub.py
     # Make sure we import from the install directory
     #rm zmq/__*.py
     PYTHONPATH=%{buildroot}%{python3_sitearch} \
-        %{__python3} setup.py test
+        %{__python3} pytest
 %endif
 
 
@@ -235,7 +235,7 @@ rm -rf zmq/tests/test_auth.py
 %else
 %python_exec setup.py build_ext --inplace
 %endif
-%python_exec setup.py test
+%python_exec pytest
 %endif
 
 %files %{python_files}

--- a/setup.py
+++ b/setup.py
@@ -851,9 +851,7 @@ class FetchCommand(Command):
 class TestCommand(Command):
     """Custom setuptools command to run the test suite."""
 
-    description = (
-        "Test PyZMQ (must have been built inplace: `setup.py build_ext --inplace`)"
-    )
+    description = "DEPRECATED, use pytest"
 
     user_options = []
 
@@ -864,7 +862,9 @@ class TestCommand(Command):
         pass
 
     def run(self):
-        """Run the test suite with py.test"""
+        """Run the test suite with pytest"""
+        warn("Running pyzmq's tests with `setup.py test` is deprecated. Use `pytest`.")
+        time.sleep(10)
         # crude check for inplace build:
         try:
             import zmq


### PR DESCRIPTION
closes #1806 

we don't use any of setuptools' deprecated functionality, so I don't think #1806 would ever have been an issue.