### PR TITLE
start publishing manylinux wheels for both glibc 2.17 and 2.28, starting with cpython 3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,6 +78,7 @@ jobs:
       CIBW_SKIP: "${{ matrix.cibw.skip || '' }}"
       CIBW_ARCHS_LINUX: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_ARCHS_MACOS: "${{ matrix.cibw.arch || 'auto' }}"
+      CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_x86_64_image || '' }}"
 
     strategy:
       fail-fast: false
@@ -110,6 +111,15 @@ jobs:
             cibw:
               arch: i686
               build: "*manylinux*"
+
+          # additional manylinux variants, not specified in pyproject.toml:
+          # build with newer 2_28 for cpython >= 3.10, pypy 3.9
+          - name: manylinux-x86_64-2_28
+            os: ubuntu-20.04
+            cibw:
+              arch: x86_64
+              build: "cp31*-manylinux* pp39-manylinux*"
+              manylinux_x86_64_image: manylinux_2_28
 
           - os: ubuntu-20.04
             name: musllinux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ test-command = "pytest -vsx {package}/tools/test_wheel.py"
 [tool.cibuildwheel.linux]
 before-all = "bash tools/install_libzmq.sh"
 
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 musllinux-aarch64-image = "musllinux_1_1"
 musllinux-i686-image = "musllinux_1_1"
@@ -109,22 +111,14 @@ select = "cp3{6,7}-*"
 manylinux-x86_64-image = "manylinux1"
 manylinux-i686-image = "manylinux1"
 
-# manylinux2010 for cp38-9, pp37-8
+# manylinux2010 for (less) old cp38-9, pp37-8
 [[tool.cibuildwheel.overrides]]
 select = "cp3{8,9}-* pp3{7,8}-*"
 manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
 
-# manylinux2014 for cp310, pp39
-[[tool.cibuildwheel.overrides]]
-select = "cp310-* pp39-*"
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-
-# manylinux_2_28 for cp311
-[[tool.cibuildwheel.overrides]]
-select = "cp311-*"
-manylinux-x86_64-image = "manylinux_2_28"
+# note: manylinux_2_28 builds are added
+# in .github/workflows/wheels.yml
 
 [[tool.cibuildwheel.overrides]]
 select = "pp*win*"


### PR DESCRIPTION
rather than only having one choice specified for each Python build in pyproject.toml (2.17 for 3.10, 2.28 for 3.11), build everything starting at 3.10 with manylinux2014. Then _also_ build everything starting with 3.10 with manylinux_2_28.

cibuildwheel doesn't support multiple values for the image inputs, so 2014 is the default and 2_28 is added via a gha matrix entry.

These future-glibc builds are published only for x86_64.

The change only adds builds (all x86_64):

- 2014 for cp311
- 2_28 for cp310, pp39

The rest should be unchanged.

closes #1821 