### PR TITLE
verify contents of sdists (and fix some missing files)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip install --upgrade pip build
+          pip install --upgrade pip build pytest
           pip install -r tools/wheel-requirements.txt
 
       - name: build sdist
@@ -59,6 +59,10 @@ jobs:
           name: sdist
           path: "dist/*.tar.gz"
           if-no-files-found: error
+
+      - name: verify sdist files
+        run:
+          pytest -v tools/test_sdist.py
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,47 +1,7 @@
-include LICENSE.BSD
-include LICENSE.LESSER
-include CONTRIBUTING.md
-include MANIFEST.in
-include README.md
-include AUTHORS.md
-include setup.cfg.template
-include setup.cfg.android
-include setup.py
-include setupegg.py
-include zmqversion.py
-include tox.ini
-include .travis.yml
-
-graft docs
-graft tools
-prune docs/build
-prune docs/gh-pages
-
+# only need to track non-version-controlled files to add
 include bundled/zeromq/COPYING
 graft bundled/zeromq/include
 graft bundled/zeromq/src
-graft bundled/zeromq/tweetnacl
 graft bundled/zeromq/external/wepoll
 exclude bundled/zeromq/src/Makefile*
 exclude bundled/zeromq/src/platform.hpp
-
-graft buildutils
-graft examples
-graft zmq
-graft perf
-
-exclude setup.cfg
-exclude zmq/libzmq*
-# exclude docs/_static
-# exclude docs/_templates
-
-global-exclude __pycache__/*
-global-exclude .deps/*
-global-exclude *.so
-global-exclude *.pyd
-global-exclude *.pyc
-global-exclude .git*
-global-exclude .DS_Store
-global-exclude .mailmap
-global-exclude Makefile.am
-global-exclude Makefile.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ skip = [
 [build-system]
 requires = [
     "setuptools",
+    "setuptools_scm[toml]",
     "wheel",
     "packaging",
     "cffi; implementation_name == 'pypy'",

--- a/tools/test_sdist.py
+++ b/tools/test_sdist.py
@@ -1,0 +1,72 @@
+"""
+Verify the contents of our sdists
+"""
+
+import tarfile
+from fnmatch import fnmatch
+from pathlib import Path
+from subprocess import run
+
+import pytest
+
+repo = Path(__file__).parent.parent.resolve()
+
+
+@pytest.fixture
+def sdist():
+    path = list(repo.glob("dist/*.tar.gz"))[0]
+    return tarfile.open(path)
+
+
+@pytest.fixture
+def sdist_files(sdist):
+    paths = set()
+    for name in sdist.getnames():
+        # 'pyzmq-25.1.0.dev0/zmq/utils/config.json'
+        root, _, relative = name.partition("/")
+        paths.add(relative)
+    return paths
+
+
+@pytest.fixture
+def git_files():
+    p = run(["git", "ls-files"], cwd=repo, capture_output=True, text=True)
+    paths = set()
+    for line in p.stdout.splitlines():
+        paths.add(line)
+    return paths
+
+
+def test_git_files(sdist_files, git_files):
+    missing_git_files = git_files.difference(sdist_files)
+    assert missing_git_files == set()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # bundled zeromq
+        "bundled/zeromq/COPYING",
+        "bundled/zeromq/include/zmq.h",
+        "bundled/zeromq/src/zmq.cpp",
+        "bundled/zeromq/external/wepoll/license.txt",
+        "bundled/zeromq/external/wepoll/wepoll.h",
+        # Cython-generated files
+        "zmq/backend/cython/socket.c",
+    ],
+)
+def test_included(sdist_files, path):
+    assert path in sdist_files
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "bundled/zeromq/src/platform.hpp",
+        "**/*.so",
+        "**/__pycache__",
+    ],
+)
+def test_excluded(sdist_files, path):
+    matches = [f for f in sdist_files if fnmatch(f, path)]
+    assert not matches


### PR DESCRIPTION
use setuptools-scm to ensure we always get all VCS files. Removes most of MANIFEST.in, no longer required for anything in the repo. Keep the bundled/zeromq bit and add a `test_sdist.py` script to verify sdist contents.

closes #1857 