### PR TITLE
test with Cython 3.0b3 on Python 3.12b1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: ubuntu-latest
-            python: "3.12.0-beta.1"
           - os: macos-13
             python: 3.6
 
@@ -73,6 +71,9 @@ jobs:
           - os: ubuntu-22.04
             python: 3.8
             zmq: head
+
+          - os: ubuntu-22.04
+            python: "3.12.0-beta.1"
 
           - os: windows-2022
             python: 3.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,17 +120,6 @@ jobs:
           pip install --upgrade pip wheel
           pip install -r test-requirements.txt
 
-      - name: install pre-release Cython
-        if: startsWith(matrix.python, '3.12')
-        run: |
-          pip install --pre cython
-
-      - name: install cython
-        if: "! (startsWith(matrix.python, 'pypy') || startsWith(matrix.python, '3.12'))"
-        run: |
-          pip install ${{ matrix.cython || 'cython' }}
-          python setup.py cython
-
       - name: remove tornado
         if: matrix.tornado == 'none'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
-  PYZMQ_CYTHON_COVERAGE: "1"
   # only affects Windows, but easiest to set here for now
   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
@@ -97,11 +96,15 @@ jobs:
           architecture: ${{ matrix.arch || 'x64' }}
 
       - name: setup coverage
-        if: startsWith(matrix.python, 'pypy')
+        if: startsWith(matrix.python, 'pypy') || startsWith(matrix.python, '3.12')
         run: |
-          grep -v plugins .coveragerc > .coveragerc-pypy
-          mv .coveragerc-pypy .coveragerc
+          grep -v plugins .coveragerc > .coveragerc-save
+          mv .coveragerc-save .coveragerc
 
+      - name: enable Cython coverage
+        if: "! (startsWith(matrix.python, 'pypy') || startsWith(matrix.python, '3.12'))"
+        run: |
+          echo "PYZMQ_CYTHON_COVERAGE=1" >> "$GITHUB_ENV"
       # preserve pip cache to speed up installation
       - name: Cache pip
         uses: actions/cache@v3
@@ -116,6 +119,11 @@ jobs:
         run: |
           pip install --upgrade pip wheel
           pip install -r test-requirements.txt
+
+      - name: install pre-release Cython
+        if: startsWith(matrix.python, '3.12')
+        run: |
+          pip install --pre cython
 
       - name: install cython
         if: "! (startsWith(matrix.python, 'pypy') || startsWith(matrix.python, '3.12'))"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,16 @@ jobs:
           grep -v plugins .coveragerc > .coveragerc-pypy
           mv .coveragerc-pypy .coveragerc
 
+      # preserve pip cache to speed up installation
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ runner.python }}-${{ hashFiles('*requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: install dependencies
         run: |
           pip install --upgrade pip wheel
@@ -125,16 +135,6 @@ jobs:
       - name: show environment
         run: |
           pip freeze
-
-      # preserve pip cache to speed up installation
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ runner.python }}-${{ hashFiles('*requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - name: install mac dependencies
         if: startsWith(matrix.os, 'mac') && matrix.zmq != 'bundled'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.14"
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - os: macos-13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - "docs/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: "1"
   PYZMQ_CYTHON_COVERAGE: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          - os: ubuntu-latest
+            python: "3.12.0-beta.1"
           - os: macos-13
             python: 3.6
 
@@ -116,7 +118,7 @@ jobs:
           pip install -r test-requirements.txt
 
       - name: install cython
-        if: "! startsWith(matrix.python, 'pypy')"
+        if: "! (startsWith(matrix.python, 'pypy') || startsWith(matrix.python, '3.12'))"
         run: |
           pip install ${{ matrix.cython || 'cython' }}
           python setup.py cython

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,10 @@ on:
       - tools/install_libzmq.sh
       - zmq/utils/*.h
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TWINE_NONINTERACTIVE: "1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
     "wheel",
     "packaging",
     "cffi; implementation_name == 'pypy'",
+    "cython>=0.29; implementation_name == 'cpython'",
     "cython>=3.0.0b3; implementation_name == 'cpython' and python_version >= '3.12'",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
     "wheel",
     "packaging",
     "cffi; implementation_name == 'pypy'",
+    "cython>=3.0.0b3; implementation_name == 'cpython' and python_version >= '3.12'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -422,7 +422,7 @@ class Configure(build_ext):
         if use_static_zmq in ('TRUE', '1'):
             settings['define_macros'].append(('ZMQ_STATIC', '1'))
 
-        if os.environ.get("PYZMQ_CYTHON_COVERAGE"):
+        if os.environ.get("PYZMQ_CYTHON_COVERAGE", "") not in {"", "0"}:
             settings['define_macros'].append(('CYTHON_TRACE', '1'))
 
         # include internal directories
@@ -1280,7 +1280,7 @@ if cython:
     # set binding so that compiled methods can be inspected
     # set language-level to 3str, requires Cython 0.29
     cython_directives = {"binding": True, "language_level": "3str"}
-    if os.environ.get("PYZMQ_CYTHON_COVERAGE"):
+    if os.environ.get("PYZMQ_CYTHON_COVERAGE", "") not in {"", "0"}:
         cython_directives["linetrace"] = True
     extensions = cythonize(extensions, compiler_directives=cython_directives)
 

--- a/setup.py
+++ b/setup.py
@@ -1362,11 +1362,5 @@ setup_args = dict(
         "cffi; implementation_name == 'pypy'",
     ],
 )
-if not os.path.exists(os.path.join("zmq", "backend", "cython", "socket.c")):
-    # this generally means pip install from git
-    # which requires Cython
-    setup_args.setdefault("setup_requires", []).append(
-        f"cython>={min_cython_version}; implementation_name == 'cpython'",
-    )
 
 setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -1188,6 +1188,9 @@ submodules = {
 min_cython_version = "0.29"
 cython_language_level = "3str"
 
+if sys.version_info >= (3, 12):
+    min_cython_version = "3.0.0b3"
+
 try:
     import Cython
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,8 @@ black; platform_python_implementation != "PyPy"
 codecov
 # coverage 5 has issues with Cython: https://github.com/cython/cython/issues/3515
 coverage<5
+cython; platform_python_implementation != "PyPy" # required for Cython tests
+cython>=3.0.0b3; platform_python_implementation != "PyPy" and python_version >= "3.12" # required for Cython tests
 flake8
 gevent; platform_python_implementation != "PyPy" and sys_platform != "win32" and sys_platform != "darwin" and python_version < "3.11"
 mypy; platform_python_implementation != "PyPy"
@@ -12,6 +14,6 @@ pytest-asyncio>=0.16; python_version < "3.7"
 pytest-asyncio>=0.17; python_version >= "3.7"
 # pytest-cov 2.11 requires coverage 5, which still doesn't work with Cython
 pytest-cov==2.10.*
-
 pytest-rerunfailures
+setuptools; platform_python_implementation != "PyPy" # required for Cython tests after distutils deprecation
 tornado

--- a/zmq/tests/test_cython.py
+++ b/zmq/tests/test_cython.py
@@ -20,6 +20,7 @@ cython_ext = os.path.join(HERE, "cython_ext.pyx")
     sys.platform.startswith('win'), reason="Don't try runtime Cython on Windows"
 )
 @pytest.mark.parametrize('language_level', [3, 2])
+@pytest.mark.importorskip("pyximport")
 def test_cython(language_level, request, tmpdir):
     import pyximport
 


### PR DESCRIPTION
Adds Cython as a build dependency for _future_ releases, so that .c files get regenerated

Currently Cython 0.29 doesn't support 3.12, but maybe 3.0 does?

