### PR TITLE
build 3.12 wheels with Cython 0.29

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    continue-on-error: ${{ matrix.zmq == 'head' }}
 
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.14"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,6 +9,7 @@ on:
       - "**"
   pull_request:
     paths:
+      - pyproject.toml
       - setup.py
       - buildutils/**
       - .github/workflows/wheels.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # only need to track non-version-controlled files to add
-include bundled/zeromq/COPYING
+include bundled/zeromq/COPYING*
 graft bundled/zeromq/include
 graft bundled/zeromq/src
 graft bundled/zeromq/external/wepoll

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = [
     "packaging",
     "cffi; implementation_name == 'pypy'",
     "cython>=0.29; implementation_name == 'cpython'",
-    "cython>=3.0.0b3; implementation_name == 'cpython' and python_version >= '3.12'",
+    "cython>=0.29.35; implementation_name == 'cpython' and python_version >= '3.12'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tools/test_sdist.py
+++ b/tools/test_sdist.py
@@ -47,6 +47,7 @@ def test_git_files(sdist_files, git_files):
     [
         # bundled zeromq
         "bundled/zeromq/COPYING",
+        "bundled/zeromq/COPYING.LESSER",
         "bundled/zeromq/include/zmq.h",
         "bundled/zeromq/src/zmq.cpp",
         "bundled/zeromq/external/wepoll/license.txt",


### PR DESCRIPTION
now that there have been releases with fixes, this should work without requiring Cython 3 prerelease