### PR TITLE
bundle libzmq 4.3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,45 +33,45 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: macos-13
-            python: 3.7
-
-          - os: macos-13
-            python: 3.11
-            zmq: bundled
-
-          - os: macos-13
-            python: pypy-3.9
-            zmq: bundled
-
-          - os: ubuntu-20.04
-            python: 3.7
-            zmq: bundled
-            tornado: none
-
-          - os: ubuntu-22.04
-            python: pypy-3.9
-            zmq: bundled
-
-          - os: ubuntu-22.04
-            python: pypy-3.7
-
-          - os: ubuntu-22.04
-            python: 3.9
-            tornado: head
-
-          - os: ubuntu-22.04
-            python: "3.10"
-
-          - os: ubuntu-22.04
-            python: "3.11"
-
-          - os: ubuntu-22.04
-            python: "3.8"
-            zmq: head
-
-          - os: ubuntu-22.04
-            python: "3.12"
+#           - os: macos-13
+#             python: 3.7
+#
+#           - os: macos-13
+#             python: 3.11
+#             zmq: bundled
+#
+#           - os: macos-13
+#             python: pypy-3.9
+#             zmq: bundled
+#
+#           - os: ubuntu-20.04
+#             python: 3.7
+#             zmq: bundled
+#             tornado: none
+#
+#           - os: ubuntu-22.04
+#             python: pypy-3.9
+#             zmq: bundled
+#
+#           - os: ubuntu-22.04
+#             python: pypy-3.7
+#
+#           - os: ubuntu-22.04
+#             python: 3.9
+#             tornado: head
+#
+#           - os: ubuntu-22.04
+#             python: "3.10"
+#
+#           - os: ubuntu-22.04
+#             python: "3.11"
+#
+#           - os: ubuntu-22.04
+#             python: "3.8"
+#             zmq: head
+#
+#           - os: ubuntu-22.04
+#             python: "3.12"
 
           - os: windows-2022
             python: "3.7"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -95,43 +95,43 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-11
-            name: mac-cpython
-            cibw:
-              build: "cp*"
-
-          - os: macos-11
-            name: mac-pypy
-            cibw:
-              build: "pp*"
-
-          - os: macos-11
-            name: mac-arm
-            cibw:
-              arch: universal2
-              build: "cp*"
-
-          - name: manylinux-x86_64
-            cibw:
-              arch: x86_64
-              build: "*manylinux*"
-
-          - name: manylinux-i686
-            cibw:
-              arch: i686
-              build: "*manylinux*"
-
-          # additional manylinux variants, not specified in pyproject.toml:
-          # build with newer 2_28 for cpython >= 3.10, pypy 3.9
-          - name: manylinux-x86_64-2_28
-            cibw:
-              arch: x86_64
-              build: "cp31*-manylinux* pp39-manylinux*"
-              manylinux_x86_64_image: manylinux_2_28
-
-          - name: musllinux
-            cibw:
-              build: "*musllinux*"
+#           - os: macos-11
+#             name: mac-cpython
+#             cibw:
+#               build: "cp*"
+#
+#           - os: macos-11
+#             name: mac-pypy
+#             cibw:
+#               build: "pp*"
+#
+#           - os: macos-11
+#             name: mac-arm
+#             cibw:
+#               arch: universal2
+#               build: "cp*"
+#
+#           - name: manylinux-x86_64
+#             cibw:
+#               arch: x86_64
+#               build: "*manylinux*"
+#
+#           - name: manylinux-i686
+#             cibw:
+#               arch: i686
+#               build: "*manylinux*"
+#
+#           # additional manylinux variants, not specified in pyproject.toml:
+#           # build with newer 2_28 for cpython >= 3.10, pypy 3.9
+#           - name: manylinux-x86_64-2_28
+#             cibw:
+#               arch: x86_64
+#               build: "cp31*-manylinux* pp39-manylinux*"
+#               manylinux_x86_64_image: manylinux_2_28
+#
+#           - name: musllinux
+#             cibw:
+#               build: "*musllinux*"
 
           - name: win32
             os: windows-2019

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -28,22 +28,22 @@ pjoin = os.path.join
 # Constants
 # -----------------------------------------------------------------------------
 
-bundled_version = (4, 3, 4)
+bundled_version = (4, 3, 5)
 vs = '%i.%i.%i' % bundled_version
 x, y, z = bundled_version
 libzmq = "zeromq-%s.zip" % vs
 download_url = f"https://github.com/zeromq/libzmq/releases/download/v{vs}"
 
 libzmq_url = f"{download_url}/{libzmq}"
-libzmq_checksum = (
-    "sha256:622bf650f7dab6de098c84d491052ad5a6d3e57550cd09cc259e0ab24ec83ec3"
-)
+libzmq_checksum = "sha1:a8a8b800cbb3e13db0246473362d4d1f17813879"
 
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.dirname(HERE)
 
 
+# libzmq has stopped building binaries with 4.3.5
+# so this is all dead code:
 # msvc 142 builds have a problem:
 # on _some_ (unclear which!) systems due to the implementation of runtime detection of AF_UNIX
 # in 4.3.4

--- a/buildutils/include_darwin/platform.hpp
+++ b/buildutils/include_darwin/platform.hpp
@@ -33,7 +33,7 @@
 /* Define to 1 if you have the <errno.h> header file. */
 #define HAVE_ERRNO_H 1
 
-/* Define to 1 if you have the `fork' function. */
+/* fork is available */
 #define HAVE_FORK 1
 
 /* Define to 1 if you have the `freeifaddrs' function. */
@@ -93,9 +93,6 @@
 /* Define to 1 if you have the <limits.h> header file. */
 #define HAVE_LIMITS_H 1
 
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
-
 /* Define to 1 if you have the `memset' function. */
 #define HAVE_MEMSET 1
 
@@ -118,13 +115,16 @@
 #define HAVE_SOCKET 1
 
 /* Define to 1 if stdbool.h conforms to C99. */
-/* #undef HAVE_STDBOOL_H */
+#define HAVE_STDBOOL_H 1
 
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -181,7 +181,7 @@
 #define PACKAGE_NAME "zeromq"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "zeromq 4.3.4"
+#define PACKAGE_STRING "zeromq 4.3.5"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "zeromq"
@@ -190,19 +190,22 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
+#define PACKAGE_VERSION "4.3.5"
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #define STDC_HEADERS 1
 
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. This
+   macro is obsolete. */
 #define TIME_WITH_SYS_TIME 1
 
 /* Version number of package */
-#define VERSION "4.3.4"
+#define VERSION "4.3.5"
 
 /* Enable militant API assertions */
 /* #undef ZMQ_ACT_MILITANT */
@@ -227,7 +230,7 @@
 #define ZMQ_HAVE_ATOMIC_INTRINSICS 1
 
 /* Using curve encryption */
-#define ZMQ_HAVE_CURVE 1
+/* #undef ZMQ_HAVE_CURVE */
 
 /* Have Cygwin */
 /* #undef ZMQ_HAVE_CYGWIN */
@@ -291,6 +294,9 @@
 
 /* Whether O_CLOEXEC is defined and functioning. */
 #define ZMQ_HAVE_O_CLOEXEC 1
+
+/* Build with zmq_ppoll */
+#define ZMQ_HAVE_PPOLL 1
 
 /* Whether pthread_setname_np() has 1 argument */
 #define ZMQ_HAVE_PTHREAD_SETNAME_1 1
@@ -382,6 +388,13 @@
 /* Use 'select' I/O thread polling system */
 /* #undef ZMQ_IOTHREAD_POLLER_USE_SELECT */
 
+/* Automatically close libsodium randombytes. Not threadsafe without
+   getrandom() */
+/* #undef ZMQ_LIBSODIUM_RANDOMBYTES_CLOSE */
+
+/* kevent udata type is intptr_t */
+/* #undef ZMQ_NETBSD_KEVENT_UDATA_INTPTR_T */
+
 /* Use 'poll' zmq_poll(er)_* API polling system */
 #define ZMQ_POLL_BASED_ON_POLL 1
 
@@ -417,9 +430,6 @@
 
 /* Use radix tree implementation to manage subscriptions */
 /* #undef ZMQ_USE_RADIX_TREE */
-
-/* Using tweetnacl for curve encryption */
-#define ZMQ_USE_TWEETNACL 1
 
 /* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
    <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,17 +129,17 @@ ZMQ_PREFIX = "/usr/local"
 MACOSX_DEPLOYMENT_TARGET = "10.9"
 
 [tool.cibuildwheel.windows]
-before-all = [
-  "python setup.py fetch_libzmq --dll",
-  "xcopy /i libzmq-dll C:\\libzmq-dll",
-]
+# before-all = [
+#   "python setup.py fetch_libzmq --dll",
+#   "xcopy /i libzmq-dll C:\\libzmq-dll",
+# ]
 repair-wheel-command = """
     delvewheel repair \
         -v \
-        --add-path=C:/libzmq-dll \
         --wheel-dir={dest_dir} \
         {wheel}
 """
+        # --add-path=C:/libzmq-dll \
 
 [tool.cibuildwheel.windows.environment]
 ZMQ_PREFIX = "libzmq-dll"

--- a/tools/install_libzmq.sh
+++ b/tools/install_libzmq.sh
@@ -39,7 +39,7 @@ curl -L -O "https://download.libsodium.org/libsodium/releases/libsodium-${LIBSOD
 curl -L -O "https://github.com/zeromq/libzmq/releases/download/v${LIBZMQ_VERSION}/zeromq-${LIBZMQ_VERSION}.tar.gz"
 
 tar -xzf libsodium-${LIBSODIUM_VERSION}.tar.gz
-cd libsodium-${LIBSODIUM_VERSION}
+cd libsodium-*/
 ./configure --prefix="$PREFIX"
 make -j4
 make install

--- a/tools/install_libzmq.sh
+++ b/tools/install_libzmq.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # script to install libzmq/libsodium for use in wheels
 set -ex
-LIBSODIUM_VERSION="1.0.18"
+LIBSODIUM_VERSION="1.0.19"
 
 LIBZMQ_VERSION="$(python3 -m buildutils.bundle)"
 
@@ -50,30 +50,10 @@ which ldconfig && ldconfig || true
 
 tar -xzf zeromq-${LIBZMQ_VERSION}.tar.gz
 cd zeromq-${LIBZMQ_VERSION}
-# patch CURVE crash bug https://github.com/zeromq/libzmq/issues/4241
-# FIXME: switch to `--disable-libsodium_randombytes_close`
-# when we bump bundle libzmq to 4.3.5
-
-patch -p1 <<EOF
-diff --git a/src/random.cpp b/src/random.cpp
-index 17c3537df3..12dead87ba 100644
---- a/src/random.cpp
-+++ b/src/random.cpp
-@@ -151,8 +151,6 @@ static void manage_random (bool init_)
-     if (init_) {
-         int rc = sodium_init ();
-         zmq_assert (rc != -1);
--    } else {
--        randombytes_close ();
-     }
- #else
-     LIBZMQ_UNUSED (init_);
-EOF
-
 # avoid error on warning
 export CXXFLAGS="-Wno-error ${CXXFLAGS:-}"
 
-./configure --prefix="$PREFIX" --with-libsodium
+./configure --prefix="$PREFIX" --with-libsodium --disable-libsodium_randombytes_close
 make -j4
 make install
 

--- a/tools/test_sdist.py
+++ b/tools/test_sdist.py
@@ -46,8 +46,7 @@ def test_git_files(sdist_files, git_files):
     "path",
     [
         # bundled zeromq
-        "bundled/zeromq/COPYING",
-        "bundled/zeromq/COPYING.LESSER",
+        "bundled/zeromq/LICENSE",
         "bundled/zeromq/include/zmq.h",
         "bundled/zeromq/src/zmq.cpp",
         "bundled/zeromq/external/wepoll/license.txt",


### PR DESCRIPTION
libzmq no longer supports binaries for Windows, and has removed support for tweetnacl.

This may mean that Windows wheels will lose CURVE, or we have to get binaries elsehwere, or run our own builds of libzmq to bundle, which I suspect would be _highly_ likely to get the wrong DLL dependency bundling.

Maybe related to #1902 since windows arm builds ought to work, I think?