### PR TITLE
MNT: remove Python2 only code

### DIFF
--- a/zmq/backend/cython/_zmq.py
+++ b/zmq/backend/cython/_zmq.py
@@ -371,26 +371,6 @@ class Frame:
         buffer.itemsize = 1
         buffer.internal = NULL
 
-    def __getsegcount__(self, lenp: pointer(Py_ssize_t)) -> C.int:
-        # required for getreadbuffer
-        if lenp != NULL:
-            lenp[0] = zmq_msg_size(address(self.zmq_msg))
-        return 1
-
-    def __getreadbuffer__(self, idx: Py_ssize_t, p: pointer(p_void)) -> Py_ssize_t:
-        # old-style (buffer) interface
-        data_c: p_char = NULL
-        data_len_c: Py_ssize_t
-        if idx != 0:
-            raise SystemError("accessing non-existent buffer segment")
-        # read-only, because we don't want to allow
-        # editing of the message in-place
-        data_c = cast(p_char, zmq_msg_data(address(self.zmq_msg)))
-        data_len_c = zmq_msg_size(address(self.zmq_msg))
-        if p != NULL:
-            p[0] = cast(p_void, data_c)
-        return data_len_c
-
     def __len__(self) -> size_t:
         """Return the length of the message in bytes."""
         sz: size_t = zmq_msg_size(address(self.zmq_msg))


### PR DESCRIPTION
These special methods were for Cython to support a version of the buffer protocol that was superceeded by PEP 3118 in Python 2.6 and removed from CPython in 3.0.

In Cython 3.1 will be remove support for these methods and fail at build time.

closes #1915

xref https://github.com/cython/cython/pull/5869/f