### PR TITLE
Replace setsockopt() by setsockopt_string()

### DIFF
--- a/docs/source/notes/unicode.md
+++ b/docs/source/notes/unicode.md
@@ -173,14 +173,6 @@ Overview of the relevant methods:
 ```
 
 ```{eval-rst}
-.. py:function::    socket.setsockopt(self, opt, optval)
-
-        only accepts ``bytes``  for `optval` (or ``int``, depending on `opt`)
-
-        ``TypeError`` if ``unicode`` or anything else
-```
-
-```{eval-rst}
 .. py:function::    socket.getsockopt(self, opt)
 
         returns ``bytes`` (or ``int``), never ``unicode``

--- a/examples/monitoring/zmq_monitor_class.py
+++ b/examples/monitoring/zmq_monitor_class.py
@@ -12,7 +12,7 @@ from zmq_monitor_class import event_monitor
 
 context = zmq.Context()
 socket = context.socket(zmq.SUB)
-socket.setsockopt(zmq.SUBSCRIBE, b"")
+socket.setsockopt_string(zmq.SUBSCRIBE, u"")
 
 event_monitor(socket)
 # event_monitor_async(socket, zmq.asyncio.asyncio.get_event_loop() )

--- a/zmq/devices/basedevice.py
+++ b/zmq/devices/basedevice.py
@@ -47,7 +47,7 @@ class Device:
         passthrough for ``{in|out}_socket.connect(iface)``, to be called in the
         thread
     setsockopt_{in_out}(opt,value)
-        passthrough for ``{in|out}_socket.setsockopt(opt, value)``, to be called in
+        passthrough for ``{in|out}_socket.setsockopt_string(opt, value)``, to be called in
         the thread
 
     Attributes
@@ -211,9 +211,9 @@ class Device:
 
         # set sockopts (must be done first, in case of zmq.IDENTITY)
         for opt, value in self._in_sockopts:
-            ins.setsockopt(opt, value)
+            ins.setsockopt_string(opt, value)
         for opt, value in self._out_sockopts:
-            outs.setsockopt(opt, value)
+            outs.setsockopt_string(opt, value)
 
         for iface in self._in_binds:
             ins.bind(iface)


### PR DESCRIPTION
Fix below error:
  TypeError: unicode not allowed, use setsockopt_string

And remove remaining references to socket.setsockopt() and replace by socket.setsockopt_string().