### PR TITLE
trusted-publisher only runs on linux

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,9 +26,6 @@ env:
 
 jobs:
   sdist:
-    permissions:
-      id-token: write
-    # environment: release
     runs-on: ubuntu-22.04
 
     steps:
@@ -58,14 +55,7 @@ jobs:
         run:
           pytest -v tools/test_sdist.py
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: startsWith(github.ref, 'refs/tags/')
-
   wheel:
-    permissions:
-      id-token: write
-    # environment: release
     runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
     name: wheel-${{ matrix.name }}
 
@@ -174,8 +164,19 @@ jobs:
           path: "wheelhouse/*"
           if-no-files-found: error
 
+  upload-pypi:
+    permissions:
+      id-token: write
+    environment: release
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - sdist
+      - wheel
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
       - name: Publish wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          packages-dir: wheelhouse/


### PR DESCRIPTION
use upload/download artifact to upload in a dedicated job