### PR TITLE
fix MessageTracker.done reference

### DIFF
--- a/zmq/backend/cython/_zmq.py
+++ b/zmq/backend/cython/_zmq.py
@@ -1101,8 +1101,8 @@ class Socket:
         None : if `copy` or not track
             None if message was sent, raises an exception otherwise.
         MessageTracker : if track and not copy
-            a MessageTracker object, whose `pending` property will
-            be True until the send is completed.
+            a MessageTracker object, whose `done` property will
+            be False until the send is completed.
 
         Raises
         ------

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -650,8 +650,8 @@ class Socket(SocketBase, AttributeSetter, Generic[ST]):
         None : if `copy` or not track
             None if message was sent, raises an exception otherwise.
         MessageTracker : if track and not copy
-            a MessageTracker object, whose `pending` property will
-            be True until the send is completed.
+            a MessageTracker object, whose `done` property will
+            be False until the send is completed.
 
         Raises
         ------
@@ -720,8 +720,8 @@ class Socket(SocketBase, AttributeSetter, Generic[ST]):
         -------
         None : if copy or not track
         MessageTracker : if track and not copy
-            a MessageTracker object, whose `pending` property will
-            be True until the last send is completed.
+            a MessageTracker object, whose `done` property will
+            be False until the last send is completed.
         """
         # typecheck parts before sending:
         for i, msg in enumerate(msg_parts):


### PR DESCRIPTION
it was referred to as `pending` which is the inverse of `done`, but no such property is defined

closes #1223