### PR TITLE
make socket.bind('tcp://127.0.0.1:0') work as a context manager

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -34,6 +34,8 @@ See [build docs](building-pyzmq) for more info.
 __New__:
 
 - Experimental support for wheels on windows-arm64
+- `Socket.bind('tcp://ip:0')` can be used as a context manager to bind to a random port.
+  The resulting URL can be retrieved as `socket.last_endpoint`.
 
 __Enhancements__:
 

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -270,6 +270,13 @@ class Socket(SocketBase, AttributeSetter, Generic[ST]):
 
         .. versionadded:: 20.0
         """
+        try:
+            # retrieve last_endpoint
+            # to support binding on random ports via
+            # `socket.bind('tcp://127.0.0.1:0')`
+            addr = cast(bytes, self.get(zmq.LAST_ENDPOINT)).decode("utf8")
+        except (AttributeError, ZMQError, UnicodeDecodeError):
+            pass
         return _SocketContext(self, 'bind', addr)
 
     def bind(self: T, addr: str) -> _SocketContext[T]:
@@ -285,6 +292,11 @@ class Socket(SocketBase, AttributeSetter, Generic[ST]):
 
         .. versionadded:: 20.0
             Can be used as a context manager.
+
+        .. versionadded:: 26.0
+            binding to port 0 can be used as a context manager
+            for binding to a random port.
+            The URL can be retrieved as `socket.last_endpoint`.
 
         Parameters
         ----------

--- a/zmq/tests/test_socket.py
+++ b/zmq/tests/test_socket.py
@@ -90,6 +90,15 @@ class TestSocket(BaseZMQTestCase):
                 with pytest.raises(zmq.Again):
                     b.recv(flags=zmq.DONTWAIT)
 
+    def test_bind_random_context(self):
+        with self.context.socket(zmq.PUSH) as push:
+            with push.bind("tcp://127.0.0.1:0"):
+                url = push.last_endpoint
+                with self.context.socket(zmq.PULL) as pull:
+                    pull.connect(url)
+                    push.send(b"msg")
+                    self.recv(pull)
+
     _repr_cls = "zmq.Socket"
 
     def test_repr(self):


### PR DESCRIPTION
so it can be used to bind to random ports

closes #1468