### PR TITLE
stop type checking for python 3.7

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 allow_redefinition = True
 #warn_unused_configs = True
 #incremental = False


### PR DESCRIPTION
mypy 1.9 fails if you try to support 3.7