### PR TITLE
include bundled library licenses in wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ cmake_install.cmake
 _deps
 /Makefile
 _src
+licenses

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,9 @@ if (ZMQ_PREFIX STREQUAL "bundled")
   include_directories(${BUNDLE_DIR}/include)
   list(PREPEND CMAKE_PREFIX_PATH ${BUNDLE_DIR})
 
+  set(LICENSE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/licenses")
+  file(MAKE_DIRECTORY "${LICENSE_DIR}")
+
   # libsodium
 
   if (MSVC)
@@ -187,6 +190,7 @@ if (ZMQ_PREFIX STREQUAL "bundled")
     PREFIX ${BUNDLE_DIR}
   )
   FetchContent_MakeAvailable(bundled_libsodium)
+  file(COPY_FILE "${bundled_libsodium_SOURCE_DIR}/LICENSE" "${LICENSE_DIR}/LICENSE.libsodium.txt")
   # run libsodium build explicitly here, so it's available to libzmq next
   set(bundled_libsodium_include "${bundled_libsodium_SOURCE_DIR}/src/libsodium/include")
 
@@ -317,6 +321,7 @@ if (ZMQ_PREFIX STREQUAL "bundled")
     PREFIX ${BUNDLE_DIR}
   )
   FetchContent_MakeAvailable(bundled_libzmq)
+  file(COPY_FILE "${bundled_libzmq_SOURCE_DIR}/LICENSE" "${LICENSE_DIR}/LICENSE.zeromq.txt")
 
   # target for libzmq static
   if (TARGET libzmq-static)

--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -5,9 +5,41 @@ no longer any info other than version numbers
 """
 
 import sys
+from pathlib import Path
+from urllib.request import urlretrieve
+
+buildutils = Path(__file__).parent
+repo_root = buildutils.parent.resolve()
+licenses = repo_root / "licenses"
 
 bundled_libsodium_version = "1.0.19"
 bundled_version = "4.3.5"
+
+
+def report_version(library="libzmq"):
+    """Report the bundled version of the dependency"""
+    if library == 'libsodium':
+        v = bundled_libsodium_version
+    else:
+        v = bundled_version
+    sys.stdout.write(v)
+
+
+def fetch_licenses():
+    """Download license files for bundled dependencies"""
+    licenses.mkdir(exist_ok=True)
+    libsodium_license_url = f"https://raw.githubusercontent.com/jedisct1/libsodium/{bundled_libsodium_version}/LICENSE"
+    libzmq_license_url = (
+        f"https://raw.githubusercontent.com/zeromq/libzmq/v{bundled_version}/LICENSE"
+    )
+    libzmq_license_file = licenses / "LICENSE.zeromq.txt"
+    libsodium_license_file = licenses / "LICENSE.libsodium.txt"
+    for dest, url in [
+        (libzmq_license_file, libzmq_license_url),
+        (libsodium_license_file, libsodium_license_url),
+    ]:
+        print(f"Downloading {url} -> {dest}")
+        urlretrieve(url, dest)
 
 
 def main():
@@ -15,11 +47,17 @@ def main():
 
     for easier consumption by non-python
     """
-    if sys.argv[1:2] == ['libsodium']:
-        v = bundled_libsodium_version
+    if len(sys.argv) > 1:
+        cmd = sys.argv[1]
     else:
-        v = bundled_version
-    sys.stdout.write(v)
+        cmd = "libzmq"
+
+    if cmd in {"libzmq", "libsodium"}:
+        report_version(cmd)
+    elif cmd == "licenses":
+        fetch_licenses()
+    else:
+        sys.exit(f"Unrecognized command: {cmd!r}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,20 +53,9 @@ Documentation = "https://pyzmq.readthedocs.org"
 Source = "https://github.com/zeromq/pyzmq"
 Tracker = "https://github.com/zeromq/pyzmq/issues"
 
-[tool.meson-python.args]
-# avoid installing static libzmq
-install = ['--tags=runtime,python-runtime']
-
-[tool.setuptools]
-zip-safe = false
-license-files = ["LICENSE.md", "bundled/zeromq/COPYING", "bundled/zeromq/COPYING.LESSER"]
-packages = ["zmq"]
-
-[tool.setuptools.dynamic]
-readme = { file = "README.md" }
-
 [tool.scikit-build]
 wheel.packages = ["zmq"]
+wheel.license-files = ["licenses/LICENSE*"]
 # 3.14 for FetchContent_MakeAvailable
 cmake.version = ">=3.14"
 # only build/install the pyzmq component
@@ -120,7 +109,7 @@ search = '__version__: str = "{current_version}"'
 
 [tool.cibuildwheel]
 build-verbosity = "1"
-test-requires = ["pytest"]
+test-requires = ["pytest", "importlib_metadata"]
 test-command = "pytest -vsx {package}/tools/test_wheel.py"
 
 [tool.cibuildwheel.linux]
@@ -145,6 +134,7 @@ ZMQ_PREFIX = "/tmp/zmq"
 MACOSX_DEPLOYMENT_TARGET = "10.9"
 
 [tool.cibuildwheel.windows]
+before-all = "python buildutils/bundle.py licenses"
 repair-wheel-command = """\
     delvewheel repair \
         -v \

--- a/tools/install_libzmq.sh
+++ b/tools/install_libzmq.sh
@@ -3,6 +3,9 @@
 set -ex
 LIBSODIUM_VERSION=$(python buildutils/bundle.py libsodium)
 LIBZMQ_VERSION=$(python buildutils/bundle.py)
+PYZMQ_DIR="$PWD"
+LICENSE_DIR="$PYZMQ_DIR/licenses"
+test -d "$LICENSE_DIR" || mkdir "$LICENSE_DIR"
 
 if [[ "$(uname)" == "Darwin" ]]; then
     # need LT_MULTI_MODULE or libtool will strip out
@@ -45,6 +48,7 @@ curl -L -O "https://github.com/zeromq/libzmq/releases/download/v${LIBZMQ_VERSION
 
 tar -xzf libsodium-${LIBSODIUM_VERSION}.tar.gz
 cd libsodium-*/
+cp LICENSE "${LICENSE_DIR}/LICENSE.libsodium.txt"
 ./configure --prefix="$PREFIX"
 make -j4
 make install
@@ -58,6 +62,7 @@ export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 
 tar -xzf zeromq-${LIBZMQ_VERSION}.tar.gz
 cd zeromq-${LIBZMQ_VERSION}
+cp LICENSE "${LICENSE_DIR}/LICENSE.zeromq.txt"
 # avoid error on warning
 export CXXFLAGS="-Wno-error ${CXXFLAGS:-}"
 

--- a/tools/test_wheel.py
+++ b/tools/test_wheel.py
@@ -10,6 +10,11 @@ from fnmatch import fnmatch
 
 import pytest
 
+try:
+    from importlib.metadata import distribution
+except ImportError:
+    from importlib_metadata import distribution
+
 
 @pytest.mark.parametrize("feature", ["curve", "ipc"])
 def test_has(feature):
@@ -55,3 +60,22 @@ def test_bundle_msvcp():
     for pattern in should_bundle:
         matched = [dll for dll in dlls if fnmatch(dll, pattern)]
         assert matched
+
+
+@pytest.mark.parametrize(
+    "license_name",
+    [
+        "LICENSE.md",
+        "LICENSE.zeromq.txt",
+        "LICENSE.libsodium.txt",
+    ],
+)
+def test_license_files(license_name):
+    pyzmq = distribution("pyzmq")
+    license_files = [f for f in pyzmq.files if "licenses" in str(f)]
+    license_file_names = [f.name for f in license_files]
+    assert license_name in license_file_names
+    for license_file in license_files:
+        if license_file.name == license_name:
+            break
+    assert license_file.locate().exists()


### PR DESCRIPTION
ideally, the cmake-downloaded license files could be matched by globs, but the globs are evaluated before that happens.