### PR TITLE
tests: using await for on_send(), on_recv() with ZMQStream

### DIFF
--- a/zmq/tests/test_zmqstream.py
+++ b/zmq/tests/test_zmqstream.py
@@ -32,28 +32,28 @@ async def push_pull(socket):
 
 
 @pytest.fixture
-def push(push_pull):
-    push, pull = push_pull
+async def push(push_pull):
+    push, pull = await push_pull
     return push
 
 
 @pytest.fixture
-def pull(push_pull):
-    push, pull = push_pull
+async def pull(push_pull):
+    push, pull = await push_pull
     return pull
 
 
 async def test_callable_check(pull):
     """Ensure callable check works."""
 
-    pull.on_send(lambda *args: None)
-    pull.on_recv(lambda *args: None)
+    await pull.on_send(lambda *args: None)
+    await pull.on_recv(lambda *args: None)
     with pytest.raises(AssertionError):
-        pull.on_recv(1)
+        await pull.on_recv(1)
     with pytest.raises(AssertionError):
-        pull.on_send(1)
+        await pull.on_send(1)
     with pytest.raises(AssertionError):
-        pull.on_recv(zmq)
+        await pull.on_recv(zmq)
 
 
 async def test_on_recv_basic(push, pull):


### PR DESCRIPTION
Update: This patch may be an artifact of an incomplete test installation. `pytest_asyncio` was not installed under the initial testing environment.  This may have resulted in the test failure I'd seen.

Maybe it's possible to await some things related to a tornado IO loop, this patch might not in fact be the right approach though
