### PR TITLE
fix builds with cmake < 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ if (ZMQ_PREFIX STREQUAL "bundled")
     PREFIX ${BUNDLE_DIR}
   )
   FetchContent_MakeAvailable(bundled_libsodium)
-  file(COPY_FILE "${bundled_libsodium_SOURCE_DIR}/LICENSE" "${LICENSE_DIR}/LICENSE.libsodium.txt")
+  configure_file("${bundled_libsodium_SOURCE_DIR}/LICENSE" "${LICENSE_DIR}/LICENSE.libsodium.txt" COPYONLY)
   # run libsodium build explicitly here, so it's available to libzmq next
   set(bundled_libsodium_include "${bundled_libsodium_SOURCE_DIR}/src/libsodium/include")
 
@@ -237,7 +237,7 @@ if (ZMQ_PREFIX STREQUAL "bundled")
       endif()
       file(GLOB_RECURSE BUILT_LIB "${bundled_libsodium_SOURCE_DIR}/**/libsodium.lib")
       message(STATUS "copy ${BUILT_LIB} ${libsodium_lib}")
-      file(COPY_FILE ${BUILT_LIB} ${libsodium_lib})
+      configure_file(${BUILT_LIB} ${libsodium_lib} COPYONLY)
     else()
       list(APPEND libsodium_configure
         ./configure
@@ -321,7 +321,7 @@ if (ZMQ_PREFIX STREQUAL "bundled")
     PREFIX ${BUNDLE_DIR}
   )
   FetchContent_MakeAvailable(bundled_libzmq)
-  file(COPY_FILE "${bundled_libzmq_SOURCE_DIR}/LICENSE" "${LICENSE_DIR}/LICENSE.zeromq.txt")
+  configure_file("${bundled_libzmq_SOURCE_DIR}/LICENSE" "${LICENSE_DIR}/LICENSE.zeromq.txt" COPYONLY)
 
   # target for libzmq static
   if (TARGET libzmq-static)

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,12 @@ For a full changelog, consult the [git log](https://github.com/zeromq/pyzmq/comm
 
 ## 26
 
+### 26.0.1
+
+- Fix install from source with cmake \< 3.21
+
+### 26.0.0
+
 pyzmq 26 is a small release, but with some big changes _hopefully_ nobody will notice,
 except for some users (especially on Windows) where pyzmq releases did not work.
 


### PR DESCRIPTION
`file(COPY_FILE` is new in 3.21, but we claim to support 3.14

use `configure_file(...COPYONLY)` instead, which does the same thing.