### PR TITLE
Update wheels.yml to prevent release if failed builds. 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -234,5 +234,11 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+      - name: Verify all wheel builds are successful
+        run: |
+          if [ -z "$(ls dist/*.whl)" ]; then
+            echo "No wheels available, aborting release."
+            exit 1
+          fi
       - name: Publish wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Add check for all wheels building successfully before uploading to PyPI. Not sure if this step should happen immediately after wheel building step or where I have put it?