### PR TITLE
add cython build dependency for implementations other than pypy, cpython

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,10 @@ For a full changelog, consult the [git log](https://github.com/zeromq/pyzmq/comm
 
 ## 26
 
+### 26.0.3
+
+- Add Cython as build dependency for non-pypy, non-cpython implementations (fixes install on pyston)
+
 ### 26.0.2
 
 - When bundling libsodium, download from libsodium's releases on GitHub instead of download.libsodium.org,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,8 @@
 [build-system]
 requires = [
   "cffi; implementation_name == 'pypy'",
-  "cython>=3.0.0; implementation_name == 'cpython'",
+  "cython>=3.0.0; implementation_name != 'pypy'",
   "packaging",
-  # "setuptools>=61",
-  # "setuptools_scm[toml]",
   "scikit-build-core",
 ]
 build-backend = "scikit_build_core.build"


### PR DESCRIPTION
rather than only specifying a build dependency on cpython and pypy, use pypy or _not_ pypy.

It' unclear if CFFI is more likely to work for other backends? Who knows! But this matches longstanding behavior where Cython is used "unless pypy", now the dependency matches the internal logic.

closes #1984 (confirmed with `docker run pyston/pyston pip install pyzmq` and `pip install .` with this branch)