### PR TITLE
chore: minor correction in required CMake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ requires = [
 ]
 build-backend = "scikit_build_core.build"
 
-# build-backend = "setuptools.build_meta"
-
 # Project metadata
 # ref: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 [project]
@@ -54,8 +52,8 @@ Tracker = "https://github.com/zeromq/pyzmq/issues"
 [tool.scikit-build]
 wheel.packages = ["zmq"]
 wheel.license-files = ["licenses/LICENSE*"]
-# 3.14 for FetchContent_MakeAvailable
-cmake.version = ">=3.14"
+# 3.15 is required by scikit-build-core
+cmake.version = ">=3.15"
 # only build/install the pyzmq component
 cmake.targets = ["pyzmq"]
 install.components = ["pyzmq"]


### PR DESCRIPTION
The minimum require version of CMake for scikit-build-core is 3.15, so setting it below 3.15 isn't helpful.

It could be removed altogether, as the default it to require what scikit-build-core requires, but leaving it here might make it easier to update on your end if you decide to raise it someday (3.26 is really nice!)