### PR TITLE
set rpath when installing libzmq to be bundled

### DIFF
--- a/tools/install_libzmq.sh
+++ b/tools/install_libzmq.sh
@@ -41,6 +41,8 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 PREFIX="${ZMQ_PREFIX:-/usr/local}"
+# add rpath so auditwheel patches it
+export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
 
 curl -L -O "https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}-RELEASE/libsodium-${LIBSODIUM_VERSION}.tar.gz"
 


### PR DESCRIPTION
auditwheel only fixes RPATH in bundled libs when it's defined (https://github.com/pypa/auditwheel/issues/451), so make sure it's defined.

seems like a bug in auditwheel, but this is easy enough for us to deal with.

closes #2013 