### PR TITLE
statically link msvcp on Windows wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ _deps
 _src
 licenses
 .virtual_documents
+/libsodium-*
+/zeromq-*
+*.tar.gz

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,10 @@ For a full changelog, consult the [git log](https://github.com/zeromq/pyzmq/comm
 
 ## 26
 
+### 26.1.1
+
+Windows wheels now statically link msvcp instead of bundling msvcp.dll, which could cause compatibility problems.
+
 ### 26.1.0
 
 26.1.0 is the first release with wheels for CPython 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ repair-wheel-command = """\
 # see https://github.com/zeromq/pyzmq/issues/2012
 # and https://github.com/matplotlib/matplotlib/pull/28687
 "cmake.define.CMAKE_MSVC_RUNTIME_LIBRARY" = "MultiThreaded"
+"cmake.define.CMAKE_SHARED_LINKER_FLAGS_INIT" = "ucrt.lib;vcruntime.lib;/nodefaultlib:libucrt.lib;/nodefaultlib:libvcruntime.lib"
 
 [tool.cibuildwheel.windows.environment]
 ZMQ_PREFIX = "bundled"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ repair-wheel-command = """\
 # see https://github.com/zeromq/pyzmq/issues/2012
 # and https://github.com/matplotlib/matplotlib/pull/28687
 "cmake.define.CMAKE_MSVC_RUNTIME_LIBRARY" = "MultiThreaded"
-"cmake.define.CMAKE_SHARED_LINKER_FLAGS_INIT" = "ucrt.lib;vcruntime.lib;/nodefaultlib:libucrt.lib;/nodefaultlib:libvcruntime.lib"
+"cmake.define.CMAKE_SHARED_LINKER_FLAGS" = "ucrt.lib;vcruntime.lib;/nodefaultlib:libucrt.lib;/nodefaultlib:libvcruntime.lib"
 
 [tool.cibuildwheel.windows.environment]
 ZMQ_PREFIX = "bundled"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,12 @@ repair-wheel-command = """\
         {wheel} \
 """
 
+[tool.cibuildwheel.windows.config-settings]
+# statically link MSVCP
+# see https://github.com/zeromq/pyzmq/issues/2012
+# and https://github.com/matplotlib/matplotlib/pull/28687
+"cmake.define.CMAKE_MSVC_RUNTIME_LIBRARY" = "MultiThreaded"
+
 [tool.cibuildwheel.windows.environment]
 ZMQ_PREFIX = "bundled"
 

--- a/tools/test_wheel.py
+++ b/tools/test_wheel.py
@@ -50,8 +50,8 @@ def test_bundle_msvcp():
     print(dlls)
     # Is concrt140 needed? delvewheel doesn't detect it anymore
     # check for vcruntime?
-    should_bundle = ["msvcp140*.dll"]
-    shouldnt_bundle = []
+    should_bundle = []
+    shouldnt_bundle = ["msvcp140*.dll"]
 
     for pattern in shouldnt_bundle:
         matched = [dll for dll in dlls if fnmatch(dll, pattern)]


### PR DESCRIPTION
should avoid conflicts

hopefully closes #2012 (need to check delvewheel output)

never know, this might help with #1981 