### PR TITLE
drop python<=3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
   { name = "Min Ragan-Kelley" },
 ]
 license = { file = "LICENSE.md" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -122,12 +122,8 @@ async def test_recv_json_cancelled(push_pull):
     obj = dict(a=5)
     await a.send_json(obj)
     # CancelledError change in 3.8 https://bugs.python.org/issue32528
-    if sys.version_info < (3, 8):
-        with pytest.raises(CancelledError):
-            recvd = await f
-    else:
-        with pytest.raises(asyncio.exceptions.CancelledError):
-            recvd = await f
+    with pytest.raises(asyncio.exceptions.CancelledError):
+        recvd = await f
     assert f.done()
     # give it a chance to incorrectly consume the event
     events = await b.poll(timeout=5)

--- a/zmq/_typing.py
+++ b/zmq/_typing.py
@@ -3,22 +3,7 @@ from __future__ import annotations
 import sys
 from typing import Any, Dict
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, TypedDict
-else:
-    # avoid runtime dependency on typing_extensions on py37
-    try:
-        from typing_extensions import Literal, TypedDict  # type: ignore
-    except ImportError:
-
-        class _Literal:
-            def __getitem__(self, key):
-                return Any
-
-        Literal = _Literal()  # type: ignore
-
-        class TypedDict(Dict):  # type: ignore
-            pass
+from typing import Literal, TypedDict
 
 
 if sys.version_info >= (3, 10):

--- a/zmq/_typing.py
+++ b/zmq/_typing.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Dict
-
-from typing import Literal, TypedDict
-
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.