### PR TITLE
explicit sys.path in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ search = '__version__: str = "{current_version}"'
 [tool.cibuildwheel]
 build-verbosity = "1"
 free-threaded-support = true
-test-requires = ["pytest", "importlib_metadata"]
+test-requires = ["pytest>=6", "importlib_metadata"]
 test-command = "pytest -vsx {package}/tools/test_wheel.py"
 
 [tool.cibuildwheel.linux]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,11 @@
 [pytest]
-addopts = --durations 10
+addopts = --durations 10 --import-mode=importlib
 markers =
     large: these tests use a lot of memory
     new_console: these tests create a new console
     wheel: these tests are for installs from a wheel, not dev-installs
+# import-mode=importlib doesn't put testpaths on sys.path
+pythonpath = tests
 testpaths =
     tests
 # automatically run coroutine tests with asyncio


### PR DESCRIPTION
not all import modes add test dir to sys.path

closes #2020 