### PR TITLE
disable IPC in Windows wheels (again)

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,16 @@ For a full changelog, consult the [git log](https://github.com/zeromq/pyzmq/comm
 
 ## 26
 
+### 26.2
+
+Re-disable IPC in Windows wheels.
+
+Installing pyzmq from source on Windows should build with IPC enabled.
+
+IPC support via epoll on Windows was disabled in pyzmq 24 due to crashes,
+this was reintroduced somewhat unintentionally via the new build system in 26.0,
+but unfortunately the crashes remain, so IPC is disabled again in 26.2.
+
 ### 26.1.1
 
 Windows wheels now statically link msvcp instead of bundling msvcp.dll, which could cause compatibility problems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,14 +178,16 @@ repair-wheel-command = """\
 """
 
 [tool.cibuildwheel.windows.config-settings]
+"cmake.define.ZMQ_PREFIX" = "bundled"
 # statically link MSVCP
 # see https://github.com/zeromq/pyzmq/issues/2012
 # and https://github.com/matplotlib/matplotlib/pull/28687
 "cmake.define.CMAKE_MSVC_RUNTIME_LIBRARY" = "MultiThreaded"
 "cmake.define.CMAKE_SHARED_LINKER_FLAGS" = "ucrt.lib;vcruntime.lib;/nodefaultlib:libucrt.lib;/nodefaultlib:libvcruntime.lib"
-
-[tool.cibuildwheel.windows.environment]
-ZMQ_PREFIX = "bundled"
+# disable IPC/epoll on Windows
+# due to https://github.com/zeromq/pyzmq/issues/1981
+"cmake.define.ZMQ_HAVE_IPC" = "OFF"
+"cmake.define.POLLER" = "select"
 
 # mac-arm target is 10.15
 [[tool.cibuildwheel.overrides]]

--- a/tools/test_wheel.py
+++ b/tools/test_wheel.py
@@ -20,7 +20,12 @@ except ImportError:
 def test_has(feature):
     import zmq
 
-    assert zmq.has(feature)
+    if feature == 'ipc' and sys.platform.startswith('win32'):
+        # IPC support is broken in enough cases on Windows
+        # that we can't ship wheels with it (for now)
+        assert not zmq.has(feature)
+    else:
+        assert zmq.has(feature)
 
 
 def test_simple_socket():


### PR DESCRIPTION
I suspect this may be the same crash that caused us to disable it in #1758. It was reintroduced in pyzmq 26 due to the new build system and libzmq 4.3.5 appears to not have fixed the error.

It is my hope that this will fix #1981, which I suspect was caused by re-enabling IPC. Maybe someday the upstream bug in libzmq can be understood and fixed.

**update:** I've confirmed this fixes at least one Windows system with no other practical workaround, which is enough for me.

closes #1999 
closes #1981 
closes #1505 
