### PR TITLE
fix PYZMQ_NO_BUNDLE option name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(ZMQ_DRAFT_API "whether to build the libzmq draft API" OFF)
 option(PYZMQ_LIBZMQ_RPATH "Add $ZMQ_PREFIX/lib to $RPATH (true by default). Set to false if libzmq will be bundled or relocated and RPATH is handled separately" ON)
 
 # anything new should start with PYZMQ_
-option(PYZMQ_LIBZMQ_NO_BUNDLE "Prohibit building bundled libzmq. Useful for repackaging, to allow default search for libzmq and requiring it to succeed." OFF)
+option(PYZMQ_NO_BUNDLE "Prohibit building bundled libzmq. Useful for repackaging, to allow default search for libzmq and requiring it to succeed." OFF)
 set(PYZMQ_LIBZMQ_VERSION "4.3.5" CACHE STRING "libzmq version when bundling")
 set(PYZMQ_LIBSODIUM_VERSION "1.0.20" CACHE STRING "libsodium version when bundling")
 set(PYZMQ_LIBZMQ_URL "" CACHE STRING "full URL to download bundled libzmq")


### PR DESCRIPTION
Fix the CMake `option()` name from `PYZMQ_LIBZMQ_NO_BUNDLE` to `PYZMQ_NO_BUNDLE`.  The latter is actually used below as the environment variable and as the actual condition, as well as in the documentation. Given that there are projects already using it, just fix the name passed to `option()` to match.