### PR TITLE
allow building cffi on cpython

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,7 @@ jobs:
         if: matrix.backend
         run: |
           echo "PYZMQ_BACKEND=${{ matrix.backend }}" >> "$GITHUB_ENV"
+          pip install cffi
 
       - name: install libzmq-dev
         if: matrix.zmq == 'head'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,10 @@ jobs:
 
           - os: ubuntu-24.04
             python: "3.13"
+            backend: cffi
+
+          - os: ubuntu-24.04
+            python: "3.13"
 
           - os: ubuntu-24.04
             python: "3.13"
@@ -192,6 +196,11 @@ jobs:
         if: matrix.zmq
         run: |
           echo "ZMQ_PREFIX=${{ matrix.zmq }}" >> "$GITHUB_ENV"
+
+      - name: set $PYZMQ_BACKEND
+        if: matrix.backend
+        run: |
+          echo "PYZMQ_BACKEND=${{ matrix.backend }}" >> "$GITHUB_ENV"
 
       - name: install libzmq-dev
         if: matrix.zmq == 'head'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(PYZMQ_LIBSODIUM_URL "" CACHE STRING "full URL to download bundled libsodium"
 set(PYZMQ_LIBSODIUM_CONFIGURE_ARGS "" CACHE STRING "semicolon-separated list of arguments to pass to ./configure for bundled libsodium")
 set(PYZMQ_LIBSODIUM_MSBUILD_ARGS "" CACHE STRING "semicolon-separated list of arguments to pass to msbuild for bundled libsodium")
 set(PYZMQ_LIBSODIUM_VS_VERSION "" CACHE STRING "Visual studio solution version for bundled libsodium (default: detect from MSVC_VERSION)")
+set(PYZMQ_BACKEND "" CACHE STRING "pyzmq backend to build ('cffi' or 'cython'). Default: cffi on PyPy, else Cython.")
 
 if (NOT CMAKE_BUILD_TYPE)
   # default to Release
@@ -57,6 +58,7 @@ foreach(_optname
   PYZMQ_LIBSODIUM_CONFIGURE_ARGS
   PYZMQ_LIBSODIUM_MSBUILD_ARGS
   PYZMQ_LIBSODIUM_VS_VERSION
+  PYZMQ_BACKEND
 )
   if (DEFINED ENV{${_optname}})
     if (_optname MATCHES ".*_ARGS")
@@ -367,8 +369,19 @@ set(EXT_SRC_DIR "${CMAKE_CURRENT_BINARY_DIR}/_src")
 set(ZMQ_BUILDUTILS "${CMAKE_CURRENT_SOURCE_DIR}/buildutils")
 file(MAKE_DIRECTORY "${EXT_SRC_DIR}")
 
-if(Python_INTERPRETER_ID STREQUAL "PyPy")
+if (NOT PYZMQ_BACKEND)
+  if(Python_INTERPRETER_ID STREQUAL "PyPy")
+    set(PYZMQ_BACKEND "cffi")
+  else()
+    set(PYZMQ_BACKEND "cython")
+  endif()
+endif()
+
+if(PYZMQ_BACKEND STREQUAL "cffi")
   message(STATUS "Building CFFI backend")
+  if(NOT Python_INTERPRETER_ID STREQUAL "PyPy")
+    message(WARNING "Building CFFI backend on ${Python_INTERPRETER_ID}, not PyPy. This is not supported and may not work.")
+  endif()
   set(ZMQ_EXT_NAME "_cffi")
 
   set(ZMQ_BACKEND_DEST "zmq/backend/cffi")
@@ -381,8 +394,11 @@ if(Python_INTERPRETER_ID STREQUAL "PyPy")
             "${ZMQ_BUILDUTILS}/build_cffi.py"
             "${ZMQ_C}"
   )
-else()
+elseif(PYZMQ_BACKEND STREQUAL "cython")
   message(STATUS "Building Cython backend")
+  if(NOT Python_INTERPRETER_ID STREQUAL "Python")
+    message(WARNING "Building Cython backend on ${Python_INTERPRETER_ID}, not CPython. This is not supported and may not work.")
+  endif()
   find_program(CYTHON "cython")
 
   set(ZMQ_BACKEND_DEST "zmq/backend/cython")
@@ -400,6 +416,8 @@ else()
             --module-name "zmq.backend.cython._zmq"
             ${ZMQ_PYX}
   )
+else()
+  message(FATAL_ERROR "Unsupported PYZMQ_BACKEND=${PYZMQ_BACKEND}. Must be 'cffi' or 'cython'.")
 endif()
 
 file(MAKE_DIRECTORY ${ZMQ_BACKEND_DEST})

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,10 @@ For a full changelog, consult the [git log](https://github.com/zeromq/pyzmq/comm
 
 ## 26
 
+### 26.3
+
+pyzmq 26.3 drops support for Python 3.7 and adds wheels for PyPy 3.11
+
 ### 26.2.1
 
 26.2.1 is a tiny bugfix release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "cffi; implementation_name == 'pypy'",
   "cython>=3.0.0; implementation_name != 'pypy'",
   "packaging",
-  "scikit-build-core",
+  "scikit-build-core>=0.10",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -55,8 +55,12 @@ wheel.license-files = ["licenses/LICENSE*"]
 # 3.15 is required by scikit-build-core
 cmake.version = ">=3.15"
 # only build/install the pyzmq component
-cmake.targets = ["pyzmq"]
+build.targets = ["pyzmq"]
 install.components = ["pyzmq"]
+
+[[tool.scikit-build.overrides]]
+if.env.PYZMQ_BACKEND = "cffi"
+build.requires = ["cffi"]
 
 [tool.ruff]
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -16,7 +16,7 @@ else:
 import time
 
 import zmq
-from zmq_test_utils import PYPY, BaseZMQTestCase, SkipTest, skip_pypy
+from zmq_test_utils import PYPY, BaseZMQTestCase, SkipTest, skip_cpython_cffi, skip_pypy
 
 # some useful constants:
 
@@ -230,6 +230,7 @@ class TestFrame(BaseZMQTestCase):
         assert outb is m.buffer
         assert m.buffer is m.buffer
 
+    @skip_cpython_cffi
     def test_memoryview_shape(self):
         """memoryview shape info"""
         data = "§§¶•ªº˜µ¬˚…∆˙åß∂©œ∑´†≈ç√".encode()
@@ -278,6 +279,7 @@ class TestFrame(BaseZMQTestCase):
         assert s2 == s
         assert m.bytes == s
 
+    @skip_cpython_cffi
     def test_noncopying_recv(self):
         """check for clobbering message buffers"""
         null = b'\0' * 64
@@ -300,6 +302,7 @@ class TestFrame(BaseZMQTestCase):
                 assert m2.bytes == ff
                 assert type(m2.bytes) is bytes
 
+    @skip_cpython_cffi
     def test_noncopying_memoryview(self):
         """test non-copying memmoryview messages"""
         null = b'\0' * 64

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -630,7 +630,7 @@ class TestSocket(BaseZMQTestCase):
         # sample the front and back of the received message
         # without checking the whole content
         byte = ord(c)
-        view = memoryview(rcvd)
+        view = memoryview(rcvd.buffer)
         assert len(view) == N
         assert view[0] == byte
         assert view[-1] == byte

--- a/tests/zmq_test_utils.py
+++ b/tests/zmq_test_utils.py
@@ -27,7 +27,8 @@ except ImportError:
     have_gevent = False
 
 
-PYPY = platform.python_implementation() == 'PyPy'
+CFFI = zmq.backend.Socket.__module__.startswith("zmq.backend.cffi.")
+PYPY = platform.python_implementation() == 'PyPy' or CFFI
 
 # -----------------------------------------------------------------------------
 # skip decorators (directly from unittest)
@@ -38,7 +39,11 @@ def _id(x):
     return x
 
 
-skip_pypy = mark.skipif(PYPY, reason="Doesn't work on PyPy")
+skip_pypy = mark.skipif(PYPY, reason="Doesn't work on CFFI backend")
+skip_cpython_cffi = mark.skipif(
+    platform.python_implementation() == 'CPython' and CFFI,
+    reason="CFFI on CPython is unsupported",
+)
 require_zmq_4 = mark.skipif(zmq.zmq_version_info() < (4,), reason="requires zmq >= 4")
 
 # -----------------------------------------------------------------------------

--- a/zmq/backend/cffi/__init__.py
+++ b/zmq/backend/cffi/__init__.py
@@ -3,6 +3,9 @@
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
+# for clearer error message on missing cffi
+import cffi  # noqa
+
 from zmq.backend.cffi import _poll, context, devices, error, message, socket, utils
 
 from ._cffi import ffi

--- a/zmq/sugar/frame.py
+++ b/zmq/sugar/frame.py
@@ -74,7 +74,7 @@ class Frame(FrameBase, AttributeSetter):
         nbytes = len(self)
         msg_suffix = ""
         if nbytes > 16:
-            msg_bytes = bytes(memoryview(self)[:12])
+            msg_bytes = bytes(memoryview(self.buffer)[:12])
             if nbytes >= 1e9:
                 unit = "GB"
                 n = nbytes // 1e9


### PR DESCRIPTION
with `PYZMQ_BACKEND=cffi`, the same longstanding env for selecting the backend at runtime:

```bash
PYZMQ_BACKEND=cffi pip wheel .
pip install *.whl cffi
```

Not everything works, notably `memoryview(Frame)` doesn't work because CPython doesn't support PyPy's `__buffer__()`. `cffi` build-time dependency injection works (thanks @mgorny for the tip!), but there doesn't appear to be one for runtime, so you have to install cffi, but that seems fine.

not really supported, but it should work. Does this work for you @mgorny?

closes #2076