### PR TITLE
Update GPL license notices for remote-only FSF

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -94,9 +94,7 @@ License: LGPL-3+link
  Library General Public License for more details.
  .
  You should have received a copy of the GNU Library General Public
- License along with this library; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- 02110-1301 USA.
+ License along with this library; if not, see <https://www.gnu.org/licenses/>.
  .
  The full text of the GNU Lesser General Public License version 3
  is distributed in /usr/share/common-licenses/LGPL-3 on Debian systems.
@@ -127,8 +125,7 @@ License: LGPL-2.1
  Lesser General Public License for more details.
  .
  You should have received a copy of the GNU Lesser General Public
- License along with this library; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ License along with this library; if not, see <https://www.gnu.org/licenses/>.
  .
  The full text of the GNU Lesser General Public License version 2.1
  is distributed in /usr/share/common-licenses/LGPL-2.1 on Debian systems.

--- a/zmq/ssh/forward.py
+++ b/zmq/ssh/forward.py
@@ -14,8 +14,7 @@
 # details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02111-1301  USA.
+# along with Paramiko; if not, see <https://www.gnu.org/licenses/>.
 
 """
 Sample script showing how to do local port forwarding over paramiko.


### PR DESCRIPTION
The FSF no longer has a physical address. See:

- https://www.gnu.org/licenses/gpl-howto.html
- https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html#SEC4