### PR TITLE
cibuildwheel 3, upgrade base images

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,12 +99,12 @@ jobs:
               build: "*manylinux*"
 
           # additional manylinux variants, not specified in pyproject.toml:
-          # build with newer 2_28 for cpython >= 3.10, pypy 3.9
-          - name: manylinux-x86_64-2_28
-            cibw:
-              arch: x86_64
-              build: "cp31*-manylinux* pp39-manylinux*"
-              manylinux_x86_64_image: manylinux_2_28
+          # this is where we would add e.g. older manylinux_2014 builds
+          # - name: manylinux-x86_64-2014
+          #   cibw:
+          #     arch: x86_64
+          #     build: "cp31*-manylinux* pp39-manylinux*"
+          #     manylinux_x86_64_image: manylinux_2_28
 
           - name: musllinux
             cibw:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,12 +161,12 @@ NO_CYTHON_COMPILE = "true"
 
 [tool.cibuildwheel.linux]
 before-all = "bash tools/install_libzmq.sh"
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
-musllinux-aarch64-image = "musllinux_1_1"
-musllinux-i686-image = "musllinux_1_1"
-musllinux-x86_64-image = "musllinux_1_1"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-i686-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+musllinux-aarch64-image = "musllinux_1_2"
+musllinux-i686-image = "musllinux_1_2"
+musllinux-x86_64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.linux.environment]
 ZMQ_PREFIX = "/usr/local"
@@ -218,6 +218,3 @@ config-settings."wheel.py-api" = "cp312"
 before-build = "pip install abi3audit"
 inherit.repair-wheel-command = "append"
 repair-wheel-command = "abi3audit --strict --report {wheel}"
-
-# note: manylinux_2_28 builds are added
-# in .github/workflows/wheels.yml

--- a/tools/wheel-requirements.txt
+++ b/tools/wheel-requirements.txt
@@ -1,3 +1,3 @@
 abi3audit
-cibuildwheel==2.23.*
+cibuildwheel==3.0.*
 delvewheel==1.10.*; sys_platform == 'win32'


### PR DESCRIPTION
bump to manylinux_2_28, musllinux_1_2

drops some ancient end-of-life glibc wheels