### PR TITLE
Enable Android testing in CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -165,6 +165,14 @@ jobs:
         run: |
           echo 'MACOSX_DEPLOYMENT_TARGET=10.15' >> "$GITHUB_ENV"
 
+      # https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
+      - name: enable KVM for Android emulator
+        if: matrix.name == 'android'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: install dependencies
         run: |
           pip install --upgrade setuptools pip wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,10 +157,6 @@ test-sources = ["tools/test_wheel.py"]
 test-command = "python -m pytest -vsx tools/test_wheel.py"
 build-frontend = "build"
 
-# android test env doesn't work on GitHub CI
-# "x86_64 emulation currently requires hardware acceleration!"
-test-skip = "*-android*"
-
 [tool.cibuildwheel.environment]
 NO_CYTHON_COMPILE = "true"
 


### PR DESCRIPTION
GitHub Actions does support the Android emulator on Linux x86_64, but it requires some additional commands to enable the KVM interface. For more details, see the [cibuildwheel documentation](https://cibuildwheel.pypa.io/en/stable/platforms/#android).

Currently all the tests are passing except one that checks for the presence of LICENSE.zeromq.txt. I guess this is probably something to do with the way libzmq was built. If any of the maintainers know how to fix this, feel free to push to this PR.