### PR TITLE
fix bind/connect in devmode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,8 @@ jobs:
 
           - os: ubuntu-24.04
             python: "3.13"
+            env: |
+              PYTHONDEVMODE=1
 
           - os: ubuntu-24.04
             python: "3.13"
@@ -133,6 +135,11 @@ jobs:
           freethreaded: ${{ matrix.free_threading == 'free_threading' }}
           check-latest: ${{ matrix.python == '3.14' }}
           cache: pip
+
+      - name: set environment variables
+        if: ${{ matrix.env }}
+        run: |
+          echo "${{ matrix.env }}" >> "$GITHUB_ENV"
 
       - name: setup free threading
         if: ${{ matrix.free_threading }}

--- a/zmq/backend/cython/_zmq.py
+++ b/zmq/backend/cython/_zmq.py
@@ -666,11 +666,16 @@ class Context:
 
 @cfunc
 @inline
-def _c_addr(addr) -> p_char:
+def _c_addr(addr) -> bytes:
+    """cast an address input to bytes
+
+    Expects a str, but accepts bytes
+    and raises informative TypeError otherwise.
+    """
     if isinstance(addr, str):
-        addr = addr.encode('utf-8')
+        addr = addr.encode("utf-8")
     try:
-        c_addr: p_char = addr
+        c_addr: bytes = addr
     except TypeError:
         raise TypeError(f"Expected addr to be str, got addr={addr!r}")
     return c_addr
@@ -974,7 +979,8 @@ class Socket:
             tcp, udp, pgm, epgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
         """
-        c_addr: p_char = _c_addr(addr)
+        _addr_bytes: bytes = _c_addr(addr)
+        c_addr: p_char = _addr_bytes
         _check_closed(self)
         rc: C.int = zmq_bind(self.handle, c_addr)
         if rc != 0:
@@ -1015,7 +1021,8 @@ class Socket:
             encoded to utf-8 first.
         """
         rc: C.int
-        c_addr: p_char = _c_addr(addr)
+        _addr_bytes: bytes = _c_addr(addr)
+        c_addr: p_char = _addr_bytes
         _check_closed(self)
 
         while True:
@@ -1043,7 +1050,8 @@ class Socket:
             tcp, udp, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
         """
-        c_addr: p_char = _c_addr(addr)
+        _addr_bytes: bytes = _c_addr(addr)
+        c_addr: p_char = _addr_bytes
         _check_closed(self)
         rc: C.int = zmq_unbind(self.handle, c_addr)
         if rc != 0:
@@ -1064,7 +1072,8 @@ class Socket:
             tcp, udp, pgm, inproc and ipc. If the address is unicode, it is
             encoded to utf-8 first.
         """
-        c_addr: p_char = _c_addr(addr)
+        _addr_bytes: bytes = _c_addr(addr)
+        c_addr: p_char = _addr_bytes
         _check_closed(self)
 
         rc: C.int = zmq_disconnect(self.handle, c_addr)
@@ -1094,7 +1103,8 @@ class Socket:
         """
         c_addr: p_char = NULL
         if addr is not None:
-            c_addr = _c_addr(addr)
+            _addr_bytes: bytes = _c_addr(addr)
+            c_addr: p_char = _addr_bytes
         _check_closed(self)
 
         _check_rc(zmq_socket_monitor(self.handle, c_addr, events))


### PR DESCRIPTION
when bind was called with a string (i.e. usually), we encode to bytes before constructing the `char *` to pass to libzmq. For code re-use purposes, this was consolidated in an inline function. But the problem with creating the bytes object with `str.encode()` in the inline function is that it gets deallocated when the inline function returns. This has been safe because the actual memory doesn't get freed until the true function returns. However, devmode enables `PYTHONMALLOC=debug`, which explicitly [overwrites memory](https://docs.python.org/3/c-api/memory.html#debug-hooks-on-the-python-memory-allocators) with `PYMEM_DEADBYTE ` at dereference time (i.e. exit of the _inline_ function), leading (rightly!) to EINVAL because the actual addr we are passing is `"\xDD\xDD\xDD\xDD"`, not the user input.

The fix is to return a Python bytes object from the inline function and hold its reference in the same scope as the pointer to its memory.

I'm not 100% sure why there wasn't an error or warning from Cython and/or C for this, but 🤷 .

closes #2093 