### PR TITLE
feat: add riscv64 manylinux wheels to build matrix

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -114,6 +114,11 @@ jobs:
           #     build: "cp31*-manylinux* pp39-manylinux*"
           #     manylinux_x86_64_image: manylinux_2_28
 
+          - name: manylinux-riscv64
+            cibw:
+              arch: riscv64
+              build: "*manylinux*"
+
           - name: musllinux
             cibw:
               arch: auto,auto32

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -117,7 +117,9 @@ jobs:
           - name: manylinux-riscv64
             cibw:
               arch: riscv64
-              build: "*manylinux*"
+              # this build is emulated, limit to the stable-abi build on 3.12 (works on 3.13+)
+              # because it costs way more per wheel
+              build: "cp312*manylinux*"
 
           - name: musllinux
             cibw:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -180,6 +180,12 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Set up QEMU
+        if: matrix.name == 'manylinux-riscv64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
       - name: install dependencies
         run: |
           pip install --upgrade setuptools pip wheel


### PR DESCRIPTION
## Summary

Add `linux_riscv64` manylinux wheels to the release build matrix.

### Changes

- Add `manylinux-riscv64` entry to the wheel job matrix
- Add QEMU setup step for riscv64 emulation on x86_64 runners

### Evidence

- Tested wheel: [pyzmq-26.3.0-cp313-cp313-linux_riscv64.whl](https://github.com/gounthar/riscv64-python-wheels/releases/tag/v2026.03.07-cp313)
- Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz, 16 GB RAM)
- Imports and passes basic smoke test on riscv64

### Context

- `manylinux_2_28_riscv64` is available in pypa/manylinux
- cibuildwheel 3.x supports riscv64 via QEMU
- Several packages already ship riscv64 wheels: aiohttp, yarl, multidict, propcache
- RISC-V hardware is shipping (SiFive, SpacemiT, Sophgo SG2044)

closes #2163