### PR TITLE
fix: prevent busy-spin in zmq.green Poller when ZMQ FD is spuriously readable

### DIFF
--- a/zmq/green/poll.py
+++ b/zmq/green/poll.py
@@ -80,6 +80,20 @@ class _Poller(_original_Poller):
                 if events or timeout == 0:
                     return events
 
+                # Clear ZMQ FD signaling so select.select() truly blocks.
+                # Without this, internal ZMQ events (e.g. dead peer cleanup)
+                # can leave the FD stuck readable while poll(0) finds no user
+                # events, causing a busy-spin (~300µs/iteration).
+                for socket, _ in self.sockets:
+                    if isinstance(socket, zmq.Socket):
+                        socket.getsockopt(zmq.EVENTS)
+
+                # Re-check: a real event may have arrived between the first
+                # poll(0) and the EVENTS drain above.
+                events = super().poll(0)
+                if events:
+                    return events
+
                 # wait for activity on sockets in a green way
                 # set a minimum poll frequency,
                 # because gevent < 1.0 cannot be trusted to catch edge-triggered FD events


### PR DESCRIPTION
Thanks for submitting a PR!

LLM/AI contributions are not accepted.

Please make sure:

- [x] I wrote this (debugging, root-cause analysis, and fix were done by me with Claude Code as a debugging assistant)
- [ ] any code changes are tested, if possible — `zmq.green` has no existing test coverage for the idle/no-events poll path; happy to add a regression test if maintainers can point me to the preferred approach for testing gevent-specific timing behavior

------

## Problem

I hit this in production: a gevent app using a `zmq.green` ROUTER socket
consumed 99% CPU for 9+ hours after a peer disconnected, cascading into
heartbeat failures and service-wide unavailability.

`strace` showed the process stuck in a tight loop:

```
poll([{fd=24, events=POLLIN}], 1, 0) = 0 (Timeout)
poll([{fd=24, events=POLLIN}], 1, 0) = 0 (Timeout)
poll([{fd=24, events=POLLIN}], 1, 0) = 0 (Timeout)
...  (every ~300µs, no select/epoll calls at all)
```

The cause is `_Poller.poll()` — when `ZMQ_FD` is stuck readable (libzmq
internal cleanup events) but `poll(0)` finds no user-visible events,
`gevent.select.select()` returns immediately (or short-circuits in
userspace), and the loop spins.

## Root cause

Per the [libzmq `ZMQ_FD` documentation][zmq-fd-doc]:

> When a `ZMQ_FD` is readable, the application should read the socket's
> actual state with `ZMQ_EVENTS`. [...] The `ZMQ_FD` descriptor signals
> edge-triggered readability.

The current code never calls `getsockopt(ZMQ_EVENTS)` between the
non-blocking `poll(0)` and the blocking `select.select()`.

In libzmq, [`getsockopt(ZMQ_EVENTS)`][zmq-events-src] calls
`process_commands(0, false)`, which drains the internal
[mailbox][mailbox-src]/[signaler][signaler-src] — the mechanism behind
`ZMQ_FD` readability. Without this drain, the FD stays readable
indefinitely even when no user messages are pending.

## Fix

Two steps inserted between the existing `poll(0)` and `select.select()`:

1. **`getsockopt(ZMQ_EVENTS)`** on each registered zmq socket — clears
   the stale FD signaling so `select.select()` truly blocks.
2. **A second `poll(0)`** — closes a race where a real event arrives
   between the first `poll(0)` and the EVENTS drain. Without this
   re-check, the drain could acknowledge the new event's edge, causing
   `select` to block even though a message is already pending.

After the second `poll(0)`, any new event will re-signal the
(now-cleared) FD, so `select.select()` returns immediately — matching the
original behavior for the normal case.

## Impact

- **Before**: single-core 100% CPU indefinitely after peer disconnect
- **After**: `select.select()` blocks in epoll, CPU ≈ 0%
- **Performance**: one extra `getsockopt` per registered zmq socket +
  one extra `zmq_poll(0)`, only on the idle path — negligible

[zmq-fd-doc]: https://libzmq.readthedocs.io/en/latest/zmq_getsockopt.html#ZMQ-FD
[zmq-events-src]: https://github.com/zeromq/libzmq/blob/v4.3.5/src/socket_base.cpp#L476-L485
[mailbox-src]: https://github.com/zeromq/libzmq/blob/v4.3.5/src/mailbox.cpp#L53-L63
[signaler-src]: https://github.com/zeromq/libzmq/blob/v4.3.5/src/signaler.cpp#L311-L329