### PR TITLE
Drop support for 3.13t due to cibuildwheel dropping support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,10 +99,6 @@ jobs:
               PYTHONDEVMODE=1
 
           - os: ubuntu-24.04
-            python: "3.13"
-            free_threading: free_threading
-
-          - os: ubuntu-24.04
             python: "3.14"
 
           - os: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ search = '__version__: str = "{current_version}"'
 
 [tool.cibuildwheel]
 build-verbosity = "1"
-enable = ["cpython-freethreading", "pypy", "pypy-eol"]
+enable = ["pypy", "pypy-eol"]
 test-requires = ["pytest>=6", "importlib_metadata"]
 test-sources = ["tools/test_wheel.py"]
 test-command = "python -m pytest -vsx tools/test_wheel.py"


### PR DESCRIPTION
See https://cibuildwheel.pypa.io/en/stable/changelog/#v341, the next release of cibuildwheel will drop 3.13t support. I also dropped 3.13t from the testing matrix to lighten CI load - let me know if you'd prefer I leave it.

- [x] I wrote this (no AI-generated code or text is included in this PR or its description)
- [x] any code changes are tested, if possible
