### PR TITLE
Fill in the missing type annotations in `zmq.utils.*`

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ cython; platform_python_implementation != "PyPy" # required for Cython tests
 cython>=3.0.0b3; platform_python_implementation != "PyPy" and python_version >= "3.12" # required for Cython tests
 flake8
 gevent; platform_python_implementation != "PyPy" and sys_platform != "win32" and sys_platform != "darwin" and python_version < "3.11"
-mypy; platform_python_implementation != "PyPy"
+mypy<2; platform_python_implementation != "PyPy"
 pymongo
 pytest
 pytest-asyncio>=0.17

--- a/zmq/utils/garbage.py
+++ b/zmq/utils/garbage.py
@@ -5,29 +5,39 @@ used in zero-copy sends.
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import annotations
+
 import atexit
 import struct
 import warnings
-from collections import namedtuple
 from os import getpid
 from threading import Event, Lock, Thread
+from typing import Final, NamedTuple
 
 import zmq
 
-gcref = namedtuple('gcref', ['obj', 'event'])
+
+class gcref(NamedTuple):
+    obj: object
+    event: Event | None
 
 
 class GarbageCollectorThread(Thread):
     """Thread in which garbage collection actually happens."""
 
-    def __init__(self, gc):
+    gc: GarbageCollector
+    daemon: bool
+    pid: int
+    ready: Event
+
+    def __init__(self, gc: GarbageCollector) -> None:
         super().__init__()
         self.gc = gc
         self.daemon = True
         self.pid = getpid()
         self.ready = Event()
 
-    def run(self):
+    def run(self) -> None:
         # detect fork at beginning of the thread
         if getpid is None or getpid() != self.pid:
             self.ready.set()
@@ -70,16 +80,20 @@ class GarbageCollector:
     and any tracker events that should be signaled fire.
     """
 
-    refs = None
-    _context = None
-    _lock = None
+    # refs = None
+    _context: zmq.Context | None = None
+    # _lock = None
     url = "inproc://pyzmq.gc.01"
 
-    def __init__(self, context=None):
+    refs: dict[int, gcref]
+    _lock: Lock
+    _push: zmq.Socket | None
+
+    def __init__(self, context: zmq.Context | None = None) -> None:
         super().__init__()
         self.refs = {}
-        self.pid = None
-        self.thread = None
+        self.pid: int | None = None
+        self.thread: GarbageCollectorThread | None = None
         self._context = context
         self._lock = Lock()
         self._stay_down = False
@@ -88,7 +102,7 @@ class GarbageCollector:
         atexit.register(self._atexit)
 
     @property
-    def context(self):
+    def context(self) -> zmq.Context:
         if self._context is None:
             if Thread.__module__.startswith('gevent'):
                 # gevent has monkey-patched Thread, use green Context
@@ -100,7 +114,7 @@ class GarbageCollector:
         return self._context
 
     @context.setter
-    def context(self, ctx):
+    def context(self, ctx: zmq.Context | None) -> None:
         if self.is_alive():
             if self.refs:
                 warnings.warn(
@@ -109,7 +123,7 @@ class GarbageCollector:
             self.stop()
         self._context = ctx
 
-    def _atexit(self):
+    def _atexit(self) -> None:
         """atexit callback
 
         sets _stay_down flag so that gc doesn't try to start up again in other atexit handlers
@@ -117,13 +131,13 @@ class GarbageCollector:
         self._stay_down = True
         self.stop()
 
-    def stop(self):
+    def stop(self) -> None:
         """stop the garbage-collection thread"""
         if not self.is_alive():
             return
         self._stop()
 
-    def _clear(self):
+    def _clear(self) -> None:
         """Clear state
 
         called after stop or when setting up a new subprocess
@@ -134,19 +148,19 @@ class GarbageCollector:
         self.refs.clear()
         self.context = None
 
-    def _stop(self):
+    def _stop(self) -> None:
         push = self.context.socket(zmq.PUSH)
         push.connect(self.url)
         push.send(b'DIE')
         push.close()
         if self._push:
             self._push.close()
-        self.thread.join()
+        self.thread.join()  # type:ignore[union-attr]
         self.context.term()
         self._clear()
 
     @property
-    def _push_socket(self):
+    def _push_socket(self) -> zmq.Socket:
         """The PUSH socket for use in the zmq message destructor callback."""
         if getattr(self, "_stay_down", False):
             raise RuntimeError("zmq gc socket requested during shutdown")
@@ -155,7 +169,7 @@ class GarbageCollector:
             self._push.connect(self.url)
         return self._push
 
-    def start(self):
+    def start(self) -> None:
         """Start a new garbage collection thread.
 
         Creates a new zmq Context used for garbage collection.
@@ -171,7 +185,7 @@ class GarbageCollector:
         self.thread.start()
         self.thread.ready.wait()
 
-    def is_alive(self):
+    def is_alive(self) -> bool:
         """Is the garbage collection thread currently running?
 
         Includes checks for process shutdown or fork.
@@ -185,7 +199,7 @@ class GarbageCollector:
             return False
         return True
 
-    def store(self, obj, event=None):
+    def store(self, obj: object, event: Event | None = None) -> int:
         """store an object and (optionally) event for zero-copy"""
         if not self.is_alive():
             if self._stay_down:
@@ -201,7 +215,7 @@ class GarbageCollector:
         self.refs[theid] = tup
         return theid
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not self.is_alive():
             return
         try:
@@ -210,4 +224,4 @@ class GarbageCollector:
             raise (e)
 
 
-gc = GarbageCollector()
+gc: Final[GarbageCollector] = GarbageCollector()

--- a/zmq/utils/jsonapi.py
+++ b/zmq/utils/jsonapi.py
@@ -17,7 +17,7 @@ from typing import Any
 jsonmod = json
 
 
-def dumps(o: Any, **kwargs) -> bytes:
+def dumps(o: object, **kwargs: Any) -> bytes:
     """Serialize object to JSON bytes (utf-8).
 
     Keyword arguments are passed along to :py:func:`json.dumps`.
@@ -25,7 +25,7 @@ def dumps(o: Any, **kwargs) -> bytes:
     return json.dumps(o, **kwargs).encode("utf8")
 
 
-def loads(s: bytes | str, **kwargs) -> dict | list | str | int | float:
+def loads(s: bytes | str, **kwargs: Any) -> dict[str, Any] | list[Any] | str | float:
     """Load object from JSON bytes (utf-8).
 
     Keyword arguments are passed along to :py:func:`json.loads`.

--- a/zmq/utils/monitor.py
+++ b/zmq/utils/monitor.py
@@ -70,15 +70,11 @@ def recv_monitor_message(
     socket: zmq.asyncio.Socket,
     flags: int = 0,
 ) -> Awaitable[_MonitorMessage]: ...
-
-
 @overload
 def recv_monitor_message(
     socket: zmq.Socket[bytes],
     flags: int = 0,
 ) -> _MonitorMessage: ...
-
-
 def recv_monitor_message(
     socket: zmq.Socket,
     flags: int = 0,

--- a/zmq/utils/strtypes.py
+++ b/zmq/utils/strtypes.py
@@ -8,6 +8,8 @@ Authors
 # Copyright (C) PyZMQ Developers
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import annotations
+
 import warnings
 
 bytes = bytes

--- a/zmq/utils/strtypes.py
+++ b/zmq/utils/strtypes.py
@@ -15,8 +15,8 @@ unicode = str
 basestring = (str,)
 
 
-def cast_bytes(s, encoding='utf8', errors='strict'):
-    """cast unicode or bytes to bytes"""
+def cast_bytes(s: str | bytes, encoding: str = 'utf8', errors: str = 'strict') -> bytes:
+    """cast str or bytes to bytes"""
     warnings.warn(
         "zmq.utils.strtypes is deprecated in pyzmq 23.",
         DeprecationWarning,
@@ -30,8 +30,8 @@ def cast_bytes(s, encoding='utf8', errors='strict'):
         raise TypeError(f"Expected unicode or bytes, got {s!r}")
 
 
-def cast_unicode(s, encoding='utf8', errors='strict'):
-    """cast bytes or unicode to unicode"""
+def cast_unicode(s: str | bytes, encoding: str = 'utf8', errors: str = 'strict') -> str:
+    """cast bytes or str to str"""
     warnings.warn(
         "zmq.utils.strtypes is deprecated in pyzmq 23.",
         DeprecationWarning,

--- a/zmq/utils/win32.py
+++ b/zmq/utils/win32.py
@@ -109,7 +109,7 @@ class allow_interrupt:
 
         self.handle = handle
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         """Install the custom CTRL-C handler."""
         if os.name != "nt":
             return
@@ -119,7 +119,7 @@ class allow_interrupt:
             # `FormatMessage()` into a nice exception object :-)
             raise OSError()
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         """Remove the custom CTRL-C handler."""
         if os.name != "nt":
             return

--- a/zmq/utils/z85.py
+++ b/zmq/utils/z85.py
@@ -12,16 +12,19 @@ See ZMQ RFC 32 for details.
 from __future__ import annotations
 
 import struct
+from typing import Final, Union
+
+_RawBytes = Union[bytes, bytearray, memoryview]
 
 # Z85CHARS is the base 85 symbol table
-Z85CHARS = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#"
+Z85CHARS: Final = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#"
 # Z85MAP maps integers in [0,84] to the appropriate character in Z85CHARS
-Z85MAP = {c: idx for idx, c in enumerate(Z85CHARS)}
+Z85MAP: Final[dict[int, int]] = {c: idx for idx, c in enumerate(Z85CHARS)}
 
 _85s = [85**i for i in range(5)][::-1]
 
 
-def encode(rawbytes):
+def encode(rawbytes: _RawBytes) -> bytes:
     """encode raw bytes into Z85"""
     # Accepts only byte arrays bounded to 4 bytes
     if len(rawbytes) % 4:
@@ -37,7 +40,7 @@ def encode(rawbytes):
     return bytes(encoded)
 
 
-def decode(z85bytes):
+def decode(z85bytes: str | _RawBytes) -> bytes:
     """decode Z85 bytes to raw bytes, accepts ASCII string"""
     if isinstance(z85bytes, str):
         try:


### PR DESCRIPTION
This fills in the missing type annotations of the public symbols in `zmq.utils.*`, increaing the global [type coverage](https://jorenham.github.io/typestats/dashboard/report/#pyzmq) of `zmq` by 3.78% (as reported by `uvx typestats check pyzmq`)

Admittedly this isn't the most interesting of static typing improvements. But my goal is to submit other PRs as well to increase `zmq`'s type coverage even more :)

---

- [x] I wrote this (no AI-generated code or text is included in this PR or its description)
- [x] any code changes are tested, if possible
