### PR TITLE
Fill in the missing type annotations in `asyncio`, `auth`, `constants`, `decorators`, `error`

### DIFF
--- a/zmq/asyncio.py
+++ b/zmq/asyncio.py
@@ -103,7 +103,7 @@ class _AsyncIO:
     _WRITE = selectors.EVENT_WRITE
     _READ = selectors.EVENT_READ
 
-    def _default_loop(self):
+    def _default_loop(self) -> asyncio.AbstractEventLoop:
         try:
             return asyncio.get_running_loop()
         except RuntimeError:
@@ -187,7 +187,7 @@ class ZMQEventLoop(SelectorEventLoop):
     pyzmq sockets should work with any asyncio event loop as of pyzmq 17.
     """
 
-    def __init__(self, selector=None):
+    def __init__(self, selector: selectors.BaseSelector | None = None) -> None:
         _deprecated()
         return super().__init__(selector)
 
@@ -195,7 +195,7 @@ class ZMQEventLoop(SelectorEventLoop):
 _loop = None
 
 
-def _deprecated():
+def _deprecated() -> None:
     if _deprecated.called:  # type: ignore
         return
     _deprecated.called = True  # type: ignore
@@ -210,7 +210,7 @@ def _deprecated():
 _deprecated.called = False  # type: ignore
 
 
-def install():
+def install() -> None:
     """DEPRECATED: No longer needed in pyzmq 17"""
     _deprecated()
 

--- a/zmq/auth/base.py
+++ b/zmq/auth/base.py
@@ -221,7 +221,7 @@ class Authenticator:
         Currently this is a no-op because there is nothing to configure with GSSAPI.
         """
 
-    async def handle_zap_message(self, msg: list[bytes]):
+    async def handle_zap_message(self, msg: list[bytes]) -> None:
         """Perform ZAP authentication"""
         if len(msg) < 6:
             self.log.error("Invalid ZAP message, not enough frames: %r", msg)

--- a/zmq/constants.py
+++ b/zmq/constants.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import errno
 import sys
 from enum import Enum, IntEnum, IntFlag
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 _HAUSNUMERO = 156384712
 
@@ -139,7 +143,7 @@ class SocketOption(IntEnum):
 
     _opt_type: _OptType
 
-    def __new__(cls, value: int, opt_type: _OptType = _OptType.int):
+    def __new__(cls, value: int, opt_type: _OptType = _OptType.int) -> Self:
         """Attach option type as `._opt_type`"""
         obj = int.__new__(cls, value)
         obj._value_ = value

--- a/zmq/decorators.py
+++ b/zmq/decorators.py
@@ -26,17 +26,31 @@ __all__ = (
 )
 
 from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, cast
 
 import zmq
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+
+_CallableT = TypeVar('_CallableT', bound=Callable[..., object])
+
+
+class _DecoratorCallable(Protocol):
+    def __call__(self, func: _CallableT) -> _CallableT: ...
+
+
+_DecoratorTarget = Callable[..., "AbstractContextManager[Any]"]
 
 
 class _Decorator:
     '''The mini decorator factory'''
 
-    def __init__(self, target=None):
+    def __init__(self, target: _DecoratorTarget | None = None) -> None:
         self._target = target
 
-    def __call__(self, *dec_args, **dec_kwargs):
+    def __call__(self, *dec_args: Any, **dec_kwargs: Any) -> _DecoratorCallable:
         """
         The main logic of decorator
 
@@ -58,10 +72,11 @@ class _Decorator:
             *dec_args, **dec_kwargs
         )
 
-        def decorator(func):
+        def decorator(func: _CallableT) -> _CallableT:
             @wraps(func)
             def wrapper(*args, **kwargs):
                 target = self.get_target(*args, **kwargs)
+                assert target is not None
 
                 with target(*dec_args, **dec_kwargs) as obj:
                     # insert our object into args
@@ -77,18 +92,20 @@ class _Decorator:
 
                     return func(*args, **kwargs)
 
-            return wrapper
+            return cast("_CallableT", wrapper)
 
         return decorator
 
-    def get_target(self, *args, **kwargs):
+    def get_target(self, *args: Any, **kwargs: Any) -> _DecoratorTarget | None:
         """Return the target function
 
         Allows modifying args/kwargs to be passed.
         """
         return self._target
 
-    def process_decorator_args(self, *args, **kwargs):
+    def process_decorator_args(
+        self, *args: Any, **kwargs: Any
+    ) -> tuple[str | None, tuple[Any, ...], dict[str, Any]]:
         """Process args passed to the decorator.
 
         args not consumed by the decorator will be passed to the target factory
@@ -108,7 +125,7 @@ class _Decorator:
 class _ContextDecorator(_Decorator):
     """Decorator subclass for Contexts"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(zmq.Context)
 
 
@@ -118,18 +135,20 @@ class _SocketDecorator(_Decorator):
     Gets the context from other args.
     """
 
-    def process_decorator_args(self, *args, **kwargs):
+    def process_decorator_args(
+        self, *args: Any, **kwargs: Any
+    ) -> tuple[str | None, tuple[Any, ...], dict[str, Any]]:
         """Also grab context_name out of kwargs"""
         kw_name, args, kwargs = super().process_decorator_args(*args, **kwargs)
         self.context_name = kwargs.pop('context_name', 'context')
         return kw_name, args, kwargs
 
-    def get_target(self, *args, **kwargs):
+    def get_target(self, *args: Any, **kwargs: Any) -> _DecoratorTarget:
         """Get context, based on call-time args"""
         context = self._get_context(*args, **kwargs)
         return context.socket
 
-    def _get_context(self, *args, **kwargs):
+    def _get_context(self, *args: Any, **kwargs: Any) -> zmq.Context:
         """
         Find the ``zmq.Context`` from ``args`` and ``kwargs`` at call time.
 
@@ -156,7 +175,7 @@ class _SocketDecorator(_Decorator):
         return zmq.Context.instance()
 
 
-def context(*args, **kwargs):
+def context(*args: Any, **kwargs: Any) -> _DecoratorCallable:
     """Decorator for adding a Context to a function.
 
     Usage::
@@ -172,7 +191,7 @@ def context(*args, **kwargs):
     return _ContextDecorator()(*args, **kwargs)
 
 
-def socket(*args, **kwargs):
+def socket(*args: Any, **kwargs: Any) -> _DecoratorCallable:
     """Decorator for adding a socket to a function.
 
     Usage::

--- a/zmq/error.py
+++ b/zmq/error.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from errno import EINTR
+from typing import Literal
 
 
 class DraftFDWarning(RuntimeWarning):
@@ -13,7 +14,7 @@ class DraftFDWarning(RuntimeWarning):
     .. versionadded:: 27
     """
 
-    def __init__(self, msg=""):
+    def __init__(self, msg: str = "") -> None:
         if not msg:
             msg = (
                 "pyzmq's back-fill socket.FD support on thread-safe sockets is experimental, and may be removed."
@@ -105,7 +106,11 @@ class ContextTerminated(ZMQError):
     .. versionadded:: 13.0
     """
 
-    def __init__(self, errno="ignored", msg="ignored"):
+    def __init__(
+        self,
+        errno: int | Literal["ignored"] = "ignored",
+        msg: str = "ignored",
+    ) -> None:
         from zmq import ETERM
 
         super().__init__(ETERM)
@@ -117,7 +122,11 @@ class Again(ZMQError):
     .. versionadded:: 13.0
     """
 
-    def __init__(self, errno="ignored", msg="ignored"):
+    def __init__(
+        self,
+        errno: int | Literal["ignored"] = "ignored",
+        msg: str = "ignored",
+    ) -> None:
         from zmq import EAGAIN
 
         super().__init__(EAGAIN)
@@ -135,15 +144,19 @@ class InterruptedSystemCall(ZMQError, InterruptedError):
     errno = EINTR
     strerror: str
 
-    def __init__(self, errno="ignored", msg="ignored"):
+    def __init__(
+        self,
+        errno: int | Literal["ignored"] = "ignored",
+        msg: str = "ignored",
+    ) -> None:
         super().__init__(EINTR)
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = super().__str__()
         return s + ": This call should have been retried. Please report this to pyzmq."
 
 
-def _check_rc(rc, errno=None, error_without_errno=True):
+def _check_rc(rc, errno: int | None = None, error_without_errno: bool = True) -> None:
     """internal utility for checking zmq return condition
 
     and raising the appropriate Exception class
@@ -177,9 +190,11 @@ class ZMQVersionError(NotImplementedError):
     .. versionadded:: 14.2
     """
 
-    min_version = None
+    msg: str
+    min_version: str
+    version: str
 
-    def __init__(self, min_version: str, msg: str = "Feature"):
+    def __init__(self, min_version: str, msg: str = "Feature") -> None:
         global _zmq_version
         if _zmq_version is None:
             from zmq import zmq_version
@@ -199,7 +214,7 @@ class ZMQVersionError(NotImplementedError):
 def _check_version(
     min_version_info: tuple[int] | tuple[int, int] | tuple[int, int, int],
     msg: str = "Feature",
-):
+) -> None:
     """Check for libzmq
 
     raises ZMQVersionError if current zmq version is not at least min_version


### PR DESCRIPTION
Similar to #2182, this increases the type coverage of `zmq` by filling missing type annotations of public symbols in a subset if the `zmq` modules. With this, type coverage increases from 73.69% to 75.88% (+2.19%) (according to [typestats](https://github.com/jorenham/typestats)).

No runtime changes; this only affects (i.e. improves) static typing.

---

Thanks for submitting a PR!

LLM/AI contributions are not accepted.

Please make sure:

- [x] I wrote this (no AI-generated code or text is included in this PR or its description)
- [x] any code changes are tested, if possible
