### PR TITLE
Fix `Socket.send` return type docstrings

### DIFF
--- a/zmq/backend/cython/_zmq.py
+++ b/zmq/backend/cython/_zmq.py
@@ -1174,11 +1174,11 @@ class Socket:
 
         Returns
         -------
-        None : if `copy` or not track
-            None if message was sent, raises an exception otherwise.
-        MessageTracker : if track and not copy
+        MessageTracker : if `data` is a :class:`Frame` or `copy=False`
             a MessageTracker object, whose `done` property will
             be False until the send is completed.
+        None : otherwise
+            None if message was sent, raises an exception otherwise.
 
         Raises
         ------

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -655,11 +655,11 @@ class Socket(SocketBase, AttributeSetter, Generic[SocketReturnType]):
 
         Returns
         -------
-        None : if `copy` or not track
-            None if message was sent, raises an exception otherwise.
-        MessageTracker : if track and not copy
+        MessageTracker : if `data` is a :class:`Frame` or `copy=False`
             a MessageTracker object, whose `done` property will
             be False until the send is completed.
+        None : otherwise
+            None if message was sent, raises an exception otherwise.
 
         Raises
         ------
@@ -726,10 +726,11 @@ class Socket(SocketBase, AttributeSetter, Generic[SocketReturnType]):
 
         Returns
         -------
-        None : if copy or not track
-        MessageTracker : if track and not copy
+        MessageTracker : if any part is a :class:`Frame` or `copy=False`
             a MessageTracker object, whose `done` property will
-            be False until the last send is completed.
+            be False until the send is completed.
+        None : otherwise
+            None if message was sent, raises an exception otherwise.
         """
         # typecheck parts before sending:
         for i, msg in enumerate(msg_parts):


### PR DESCRIPTION
While working on #2184 I noticed that the docstrings for the return type of the `send`  methods of the `Socket`s wasn't quite right. So to avoid #2184 from getting even bigger than it already is, I figured that this documentation fix could be addressed separately.

---

No AI, btw