### PR TITLE
Fix `zmq.log.TopicLogger` log method signatures

### DIFF
--- a/zmq/log/handlers.py
+++ b/zmq/log/handlers.py
@@ -226,7 +226,7 @@ for name in "debug warn warning error critical fatal".split():
     setattr(
         TopicLogger,
         name,
-        lambda self, level, topic, msg, *args, **kwargs: meth(
-            self, level, topic + TOPIC_DELIM + msg, *args, **kwargs
+        lambda self, topic, msg, *args, **kwargs: meth(
+            self, topic + TOPIC_DELIM + msg, *args, **kwargs
         ),
     )


### PR DESCRIPTION
As promised in #2187, this fixes a bug in the level-specific log methods of `TopicLogger`. The `logging.Logger` that are dynamically overridden here do not have a `level` parameter; only `logging.Logger` has this.