### PR TITLE
Add missing `zmq.log.TopicLogger` log method overrides

### DIFF
--- a/zmq/log/handlers.py
+++ b/zmq/log/handlers.py
@@ -217,7 +217,7 @@ class TopicLogger(logging.Logger):
 
 # Generate the methods of TopicLogger, since they are just adding a
 # topic prefix to a message.
-for name in "debug warn warning error critical fatal".split():
+for name in "debug info warn warning error exception critical fatal".split():
     try:
         meth = getattr(logging.Logger, name)
     except AttributeError:


### PR DESCRIPTION
As promised in #2187, and related to #2188, here's the second fix for `zmq.log.TopicLogger`, which was missing (dynamic) overrides for the `Logger.info` and `logging.exception` log method.