### PR TITLE
Update _JSONType to allow floats

### DIFF
--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -40,7 +40,9 @@ except AttributeError:
 
 _SocketType = TypeVar("_SocketType", bound="Socket")
 
-_JSONType: TypeAlias = "int | float | str | bool | list[_JSONType] | dict[str, _JSONType]"
+_JSONType: TypeAlias = (
+    "int | float | str | bool | list[_JSONType] | dict[str, _JSONType]"
+)
 
 
 class _SocketContext(Generic[_SocketType]):

--- a/zmq/sugar/socket.py
+++ b/zmq/sugar/socket.py
@@ -40,7 +40,7 @@ except AttributeError:
 
 _SocketType = TypeVar("_SocketType", bound="Socket")
 
-_JSONType: TypeAlias = "int | str | bool | list[_JSONType] | dict[str, _JSONType]"
+_JSONType: TypeAlias = "int | float | str | bool | list[_JSONType] | dict[str, _JSONType]"
 
 
 class _SocketContext(Generic[_SocketType]):


### PR DESCRIPTION
In #2078, a unified type was created to hold a common alias for types. During this change, float was removed from the list of allowed types, causing an error for type checkers. 

This change restores floats as an allowed type. They are currently processed as expected, however throw an exception in type checkers.

Thanks for submitting a PR!

LLM/AI contributions are not accepted.

Please make sure:

- [x] I wrote this (no AI-generated code or text is included in this PR or its description)
- [x] any code changes are tested, if possible
