### PR TITLE
Fix TestFrame.test_buffer_numpy on numpy 2.5

### DIFF
--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -341,7 +341,7 @@ class TestFrame(BaseZMQTestCase):
                 B = numpy.frombuffer(msg, A.dtype).reshape(A.shape)
                 assert_array_equal(A, B)
 
-            A = numpy.empty(shape, dtype=[('a', int), ('b', float), ('c', 'a32')])
+            A = numpy.empty(shape, dtype=[('a', int), ('b', float), ('c', 'S32')])
             A['a'] = 1024
             A['b'] = 1e9
             A['c'] = 'hello there'


### PR DESCRIPTION
https://numpy.org/doc/stable/release/2.5.0-notes.html#expired-deprecations: Data type alias `a` was removed in favor of `S`. (deprecated since 2.0)

See also https://github.com/numpy/numpy/pull/30613.

This fixes a test failure with numpy 2.5:

```
_________________________ TestFrame.test_buffer_numpy __________________________
self = <tests.test_message.TestFrame testMethod=test_buffer_numpy>
    def test_buffer_numpy(self):
        """test non-copying numpy array messages"""
        try:
            import numpy
            from numpy.testing import assert_array_equal
        except ImportError:
            raise SkipTest("requires numpy")
        rand = numpy.random.randint
        shapes = [rand(2, 5) for i in range(5)]
        a, b = self.create_bound_pair(zmq.PAIR, zmq.PAIR)
        dtypes = [int, float, '>i4', 'B']
        for i in range(1, len(shapes) + 1):
            shape = shapes[:i]
            for dt in dtypes:
                A = numpy.empty(shape, dtype=dt)
                a.send(A, copy=False)
                msg = b.recv(copy=False)
    
                B = numpy.frombuffer(msg, A.dtype).reshape(A.shape)
                assert_array_equal(A, B)
    
>           A = numpy.empty(shape, dtype=[('a', int), ('b', float), ('c', 'a32')])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           TypeError: data type 'a32' not understood
tests/test_message.py:370: TypeError
```

----

Thanks for submitting a PR!

LLM/AI contributions are not accepted.

Please make sure:

- [x] I wrote this (no AI-generated code or text is included in this PR or its description)
- [x] any code changes are tested, if possible
