### PR TITLE
FIX: do not re-declare variables

### DIFF
--- a/zmq/backend/cython/_zmq.py
+++ b/zmq/backend/cython/_zmq.py
@@ -354,7 +354,7 @@ class Frame:
         if _gc is None:
             from zmq.utils.garbage import gc as _gc
 
-        hint: pointer(_zhint) = cast(pointer(_zhint), malloc(sizeof(_zhint)))
+        hint = cast(pointer(_zhint), malloc(sizeof(_zhint)))
         hint.id = _gc.store(data, self.tracker_event)
         if not _gc._push_mutex:
             hint.mutex = mutex_allocate()
@@ -1109,7 +1109,7 @@ class Socket:
         c_addr: p_char = NULL
         if addr is not None:
             _addr_bytes: bytes = _c_addr(addr)
-            c_addr: p_char = _addr_bytes
+            c_addr = _addr_bytes
         _check_closed(self)
 
         _check_rc(zmq_socket_monitor(self.handle, c_addr, events))


### PR DESCRIPTION
This will error out in future versions of cython via

1f6db306c4134a8cd8cba4225a2b19c56acbf705 /
https://github.com/cython/cython/pull/7253 /
Fixes https://github.com/cython/cython/issues/7246


Please make sure:

- [x] I wrote this (no AI-generated code or text is included in this PR or its description)
- [x] any code changes are tested, if possible (it compiles now)
